### PR TITLE
feat: mainブランチへの直接コミット防止フック

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,19 @@
 #!/bin/bash
-# pre-commit: ステージングされたファイルからシークレット・環境変数を検知
+# pre-commit: mainブランチ保護 + シークレット検知
+
+# mainブランチへの直接コミットをブロック
+BRANCH=$(git branch --show-current 2>/dev/null)
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  echo ""
+  echo "🚫 mainブランチへの直接コミットは禁止されています"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Worktreeを作成してください:"
+  echo "  git worktree add .worktrees/issue-N -b issue/N/short-desc"
+  echo ""
+  exit 1
+fi
+
+# ステージングされたファイルからシークレット・環境変数を検知
 
 STAGED_DIFF=$(git diff --cached --diff-filter=ACMR 2>/dev/null)
 


### PR DESCRIPTION
## Summary
- pre-commitフックにmainブランチ保護を追加
- mainまたはmasterブランチでの直接コミットをブロック
- Worktree作成を促すエラーメッセージを表示

Closes #117

## Test plan
- [ ] mainブランチで `git commit` を実行し、ブロックされることを確認
- [ ] worktreeブランチで `git commit` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)