### PR TITLE
feat: force push禁止 + merge戦略に変更

### DIFF
--- a/.claude/hooks/dangerous-command-guard.sh
+++ b/.claude/hooks/dangerous-command-guard.sh
@@ -21,11 +21,10 @@ check_dangerous() {
   # rm コマンド
   echo "$cmd" | grep -qE "^rm " && return 0
 
-  # git 破壊的コマンド（--force-with-lease は安全なので除外）
+  # git 破壊的コマンド
   echo "$cmd" | grep -qE "git reset --hard" && return 0
-  echo "$cmd" | grep -qE "git push --force[^-]" && return 0
-  echo "$cmd" | grep -qE "git push --force$" && return 0
-  echo "$cmd" | grep -qE "git push -f " && return 0
+  echo "$cmd" | grep -qE "git push.*--force" && return 0
+  echo "$cmd" | grep -qE "git push.*-f[ $]" && return 0
   echo "$cmd" | grep -qE "git checkout -- " && return 0
   echo "$cmd" | grep -qE "git clean" && return 0
   echo "$cmd" | grep -qE "git branch -D" && return 0

--- a/scripts/rebase-on-main.sh
+++ b/scripts/rebase-on-main.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# rebase-on-main.sh
-# 現在のブランチをorigin/mainにリベースし、pnpm-lock.yamlコンフリクトを自動解決する
+# merge-from-main.sh (旧 rebase-on-main.sh)
+# 現在のブランチにorigin/mainをマージし、pnpm-lock.yamlコンフリクトを自動解決する
+# rebaseではなくmergeを使用するため、force pushが不要
 #
 # 使い方:
 #   scripts/rebase-on-main.sh                    # カレントディレクトリで実行
@@ -20,7 +21,7 @@ git -C "$WORKTREE_PATH" fetch origin main --quiet 2>/dev/null
 
 BRANCH=$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null)
 if [ "$BRANCH" = "main" ]; then
-    echo "⚠️  mainブランチではリベース不要です。git pull を使ってください。"
+    echo "⚠️  mainブランチではmerge不要です。git pull を使ってください。"
     exit 0
 fi
 
@@ -30,49 +31,33 @@ if [ "$BEHIND" = "0" ]; then
     exit 0
 fi
 
-echo "🔄 $BRANCH を origin/main にリベース中（${BEHIND}コミット遅れ）..."
+echo "🔄 $BRANCH に origin/main をマージ中（${BEHIND}コミット遅れ）..."
 
-# リベース実行、コンフリクト発生時にループで自動解決
-git -C "$WORKTREE_PATH" rebase origin/main 2>&1 || true
+# マージ実行
+if git -C "$WORKTREE_PATH" merge origin/main --no-edit 2>&1; then
+    echo "✅ マージ完了: $BRANCH は origin/main の最新です。"
+    exit 0
+fi
 
-# リベース中のコンフリクト自動解決ループ
-MAX_RETRIES=10
-RETRY=0
+# コンフリクト発生時の自動解決
+CONFLICTS=$(git -C "$WORKTREE_PATH" diff --name-only --diff-filter=U 2>/dev/null)
 
-while [ -d "$WORKTREE_PATH/.git/rebase-merge" ] || [ -d "$WORKTREE_PATH/.git/rebase-apply" ] || \
-      ([ -f "$WORKTREE_PATH/.git" ] && {
-          GIT_DIR=$(cat "$WORKTREE_PATH/.git" | sed 's/^gitdir: //');
-          [ -d "$GIT_DIR/rebase-merge" ] || [ -d "$GIT_DIR/rebase-apply" ];
-      }); do
+if echo "$CONFLICTS" | grep -q "pnpm-lock.yaml"; then
+    echo "  🔧 pnpm-lock.yaml コンフリクトを自動解決中..."
+    git -C "$WORKTREE_PATH" checkout --theirs pnpm-lock.yaml
+    (cd "$WORKTREE_PATH" && pnpm install --no-frozen-lockfile 2>/dev/null) || true
+    git -C "$WORKTREE_PATH" add pnpm-lock.yaml
+fi
 
-    RETRY=$((RETRY + 1))
-    if [ "$RETRY" -gt "$MAX_RETRIES" ]; then
-        echo "❌ リベース自動解決の上限に達しました。手動で解決してください。"
-        echo "   git -C $WORKTREE_PATH rebase --abort  # 中止する場合"
-        exit 1
-    fi
+# pnpm-lock.yaml以外のコンフリクトがあるか確認
+REMAINING=$(git -C "$WORKTREE_PATH" diff --name-only --diff-filter=U 2>/dev/null | grep -v "pnpm-lock.yaml" || true)
+if [ -n "$REMAINING" ]; then
+    echo "❌ 手動解決が必要なコンフリクトがあります:"
+    echo "$REMAINING"
+    echo "   解決後: git -C $WORKTREE_PATH add . && git -C $WORKTREE_PATH merge --continue"
+    exit 1
+fi
 
-    # pnpm-lock.yaml のコンフリクトを検出・自動解決
-    CONFLICTS=$(git -C "$WORKTREE_PATH" diff --name-only --diff-filter=U 2>/dev/null)
-
-    if echo "$CONFLICTS" | grep -q "pnpm-lock.yaml"; then
-        echo "  🔧 pnpm-lock.yaml コンフリクトを自動解決中..."
-        git -C "$WORKTREE_PATH" checkout --theirs pnpm-lock.yaml
-        (cd "$WORKTREE_PATH" && pnpm install --no-frozen-lockfile 2>/dev/null) || true
-        git -C "$WORKTREE_PATH" add pnpm-lock.yaml
-    fi
-
-    # pnpm-lock.yaml以外のコンフリクトがあるか確認
-    REMAINING=$(git -C "$WORKTREE_PATH" diff --name-only --diff-filter=U 2>/dev/null | grep -v "pnpm-lock.yaml" || true)
-    if [ -n "$REMAINING" ]; then
-        echo "❌ 手動解決が必要なコンフリクトがあります:"
-        echo "$REMAINING"
-        echo "   解決後: git -C $WORKTREE_PATH rebase --continue"
-        exit 1
-    fi
-
-    # リベース続行
-    GIT_EDITOR=true git -C "$WORKTREE_PATH" rebase --continue 2>&1 || true
-done
-
-echo "✅ リベース完了: $BRANCH は origin/main の最新です。"
+# マージコミット完了
+git -C "$WORKTREE_PATH" commit --no-edit 2>/dev/null || true
+echo "✅ マージ完了: $BRANCH は origin/main の最新です。"


### PR DESCRIPTION
## Summary
- 全force push（--force, --force-with-lease, -f）をhookでブロック
- rebase-on-main.sh をmerge戦略に変更（force push不要）

## Test plan
- [x] `--force-with-lease` → exit 2 (ブロック)
- [x] `--force` → exit 2 (ブロック)
- [x] 通常push → exit 0 (通過)

Closes #201

🤖 Generated with [Claude Code](https://claude.ai/code)