### PR TITLE
feat: Nix開発環境 (flake.nix) セットアップ #49

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,12 @@ coverage/
 # OMC (oh-my-claudecode state)
 .omc/
 
+# Nix
+result
+result-*
+
+# direnv
+.direnv/
+
 # Other tools
 .grepai/

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "TechClip development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nodejs_22
+            pnpm
+            nodePackages.wrangler
+            turbo
+            biome
+            gh
+            git
+          ];
+
+          shellHook = ''
+            echo "TechClip dev environment ready"
+            echo "Node: $(node --version)"
+            echo "pnpm: $(pnpm --version)"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- Nix Flakes による再現可能な開発環境を構築 (`nix develop` で必要ツールが揃う)
- `flake.nix`: Node.js 22, pnpm, wrangler, turbo, biome, gh, git を提供
- `.envrc`: direnv 統合 (`use flake`) でディレクトリ移動時に自動で環境をロード
- `.gitignore`: Nix ビルド成果物 (`result`, `result-*`) と direnv キャッシュ (`.direnv/`) を追加

Closes #49

## Test plan
- [ ] `nix develop` で devShell に入れることを確認
- [ ] `node --version`, `pnpm --version` が正しく表示されることを確認
- [ ] `direnv allow` 後、ディレクトリ移動で自動ロードされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)