### PR TITLE
feat: GitHub Actions CIパイプライン #112

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test


### PR DESCRIPTION
## Summary
- PR / push時に自動でlint, typecheck, testを実行するGitHub Actions CIパイプラインを追加
- 3ジョブ（lint, typecheck, test）が並列実行される構成
- pnpm/action-setup@v4でpackageManagerフィールドからpnpmバージョンを自動検出

## Test plan
- [ ] PRマージ前にCIが正常に起動することを確認
- [ ] lint, typecheck, testの各ジョブが正常に完了することを確認

Closes #112

Co-Authored-By: Claude <noreply@anthropic.com>