### PR TITLE
feat: Better Auth用 sessions/accounts/verifications スキーマ #28

### DIFF
--- a/apps/api/src/db/schema/accounts.test.ts
+++ b/apps/api/src/db/schema/accounts.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { accounts } from "./accounts";
+
+describe("accounts schema", () => {
+  it("Better Auth必須フィールドが定義されていること", () => {
+    const columns = getTableColumns(accounts);
+    expect(columns.id).toBeDefined();
+    expect(columns.userId).toBeDefined();
+    expect(columns.accountId).toBeDefined();
+    expect(columns.providerId).toBeDefined();
+  });
+
+  it("トークン関連フィールドが定義されていること", () => {
+    const columns = getTableColumns(accounts);
+    expect(columns.accessToken).toBeDefined();
+    expect(columns.refreshToken).toBeDefined();
+    expect(columns.accessTokenExpiresAt).toBeDefined();
+    expect(columns.refreshTokenExpiresAt).toBeDefined();
+  });
+
+  it("認証詳細フィールドが定義されていること", () => {
+    const columns = getTableColumns(accounts);
+    expect(columns.scope).toBeDefined();
+    expect(columns.idToken).toBeDefined();
+    expect(columns.password).toBeDefined();
+  });
+
+  it("タイムスタンプフィールドが定義されていること", () => {
+    const columns = getTableColumns(accounts);
+    expect(columns.createdAt).toBeDefined();
+    expect(columns.updatedAt).toBeDefined();
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    const columns = getTableColumns(accounts);
+    const columnNames = Object.keys(columns);
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("userId");
+    expect(columnNames).toContain("accountId");
+    expect(columnNames).toContain("providerId");
+  });
+});

--- a/apps/api/src/db/schema/accounts.ts
+++ b/apps/api/src/db/schema/accounts.ts
@@ -1,0 +1,31 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+
+/**
+ * accountsテーブル
+ * Better Auth が要求するアカウント（認証プロバイダ）管理テーブル
+ */
+export const accounts = sqliteTable("accounts", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  accountId: text("account_id").notNull(),
+  providerId: text("provider_id").notNull(),
+  accessToken: text("access_token"),
+  refreshToken: text("refresh_token"),
+  accessTokenExpiresAt: text("access_token_expires_at"),
+  refreshTokenExpiresAt: text("refresh_token_expires_at"),
+  scope: text("scope"),
+  idToken: text("id_token"),
+  password: text("password"),
+  createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+});
+
+/** accounts テーブルの SELECT 結果の型 */
+export type Account = typeof accounts.$inferSelect;
+
+/** accounts テーブルへの INSERT データの型 */
+export type NewAccount = typeof accounts.$inferInsert;

--- a/apps/api/src/db/schema/sessions.test.ts
+++ b/apps/api/src/db/schema/sessions.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { sessions } from "./sessions";
+
+describe("sessions schema", () => {
+  it("Better Auth必須フィールドが定義されていること", () => {
+    const columns = getTableColumns(sessions);
+    expect(columns.id).toBeDefined();
+    expect(columns.userId).toBeDefined();
+    expect(columns.token).toBeDefined();
+    expect(columns.expiresAt).toBeDefined();
+  });
+
+  it("オプションフィールドが定義されていること", () => {
+    const columns = getTableColumns(sessions);
+    expect(columns.ipAddress).toBeDefined();
+    expect(columns.userAgent).toBeDefined();
+  });
+
+  it("タイムスタンプフィールドが定義されていること", () => {
+    const columns = getTableColumns(sessions);
+    expect(columns.createdAt).toBeDefined();
+    expect(columns.updatedAt).toBeDefined();
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    const columns = getTableColumns(sessions);
+    const columnNames = Object.keys(columns);
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("userId");
+    expect(columnNames).toContain("token");
+    expect(columnNames).toContain("expiresAt");
+  });
+});

--- a/apps/api/src/db/schema/sessions.ts
+++ b/apps/api/src/db/schema/sessions.ts
@@ -1,0 +1,26 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+
+/**
+ * sessionsテーブル
+ * Better Auth が要求するセッション管理テーブル
+ */
+export const sessions = sqliteTable("sessions", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  token: text("token").notNull().unique(),
+  expiresAt: text("expires_at").notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+});
+
+/** sessions テーブルの SELECT 結果の型 */
+export type Session = typeof sessions.$inferSelect;
+
+/** sessions テーブルへの INSERT データの型 */
+export type NewSession = typeof sessions.$inferInsert;

--- a/apps/api/src/db/schema/verifications.test.ts
+++ b/apps/api/src/db/schema/verifications.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { verifications } from "./verifications";
+
+describe("verifications schema", () => {
+  it("Better Auth必須フィールドが定義されていること", () => {
+    const columns = getTableColumns(verifications);
+    expect(columns.id).toBeDefined();
+    expect(columns.identifier).toBeDefined();
+    expect(columns.value).toBeDefined();
+    expect(columns.expiresAt).toBeDefined();
+  });
+
+  it("タイムスタンプフィールドが定義されていること", () => {
+    const columns = getTableColumns(verifications);
+    expect(columns.createdAt).toBeDefined();
+    expect(columns.updatedAt).toBeDefined();
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    const columns = getTableColumns(verifications);
+    const columnNames = Object.keys(columns);
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("identifier");
+    expect(columnNames).toContain("value");
+    expect(columnNames).toContain("expiresAt");
+  });
+});

--- a/apps/api/src/db/schema/verifications.ts
+++ b/apps/api/src/db/schema/verifications.ts
@@ -1,0 +1,21 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+
+/**
+ * verificationsテーブル
+ * Better Auth が要求するメール認証・パスワードリセット等の検証トークン管理テーブル
+ */
+export const verifications = sqliteTable("verifications", {
+  id: text("id").primaryKey(),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: text("expires_at").notNull(),
+  createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+});
+
+/** verifications テーブルの SELECT 結果の型 */
+export type Verification = typeof verifications.$inferSelect;
+
+/** verifications テーブルへの INSERT データの型 */
+export type NewVerification = typeof verifications.$inferInsert;


### PR DESCRIPTION
## Summary
- Better Auth が要求する3テーブル（sessions, accounts, verifications）のDrizzle ORMスキーマを定義
- 各テーブルにusers FK（CASCADE）、createdAt/updatedAt タイムスタンプを含む
- TDDで実装: テスト先行 → スキーマ実装 → 全22テストパス確認済み

Closes #28

## Test plan
- [x] sessions schema: 4テスト（必須フィールド、オプションフィールド、タイムスタンプ、型エクスポート）
- [x] accounts schema: 5テスト（必須フィールド、トークン関連、認証詳細、タイムスタンプ、型エクスポート）
- [x] verifications schema: 3テスト（必須フィールド、タイムスタンプ、型エクスポート）
- [x] 既存テスト（users, articles）への影響なし: 全テストパス

Co-Authored-By: Claude <noreply@anthropic.com>