### PR TITLE
feat: notificationsテーブルスキーマ #32

### DIFF
--- a/apps/api/src/db/schema/notifications.test.ts
+++ b/apps/api/src/db/schema/notifications.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { notifications } from "./notifications";
+
+describe("notifications schema", () => {
+  it("必須フィールドが定義されていること", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.id).toBeDefined();
+    expect(columns.userId).toBeDefined();
+    expect(columns.type).toBeDefined();
+    expect(columns.title).toBeDefined();
+    expect(columns.body).toBeDefined();
+  });
+
+  it("オプションフィールドが定義されていること", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.isRead).toBeDefined();
+    expect(columns.data).toBeDefined();
+    expect(columns.createdAt).toBeDefined();
+  });
+
+  it("isReadのデフォルト値がfalseであること", () => {
+    const columns = getTableColumns(notifications);
+    expect(columns.isRead.default).toBe(false);
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    const columns = getTableColumns(notifications);
+    const columnNames = Object.keys(columns);
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("userId");
+    expect(columnNames).toContain("type");
+    expect(columnNames).toContain("title");
+    expect(columnNames).toContain("body");
+    expect(columnNames).toContain("isRead");
+    expect(columnNames).toContain("data");
+    expect(columnNames).toContain("createdAt");
+  });
+});

--- a/apps/api/src/db/schema/notifications.ts
+++ b/apps/api/src/db/schema/notifications.ts
@@ -1,0 +1,33 @@
+import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+
+/**
+ * notificationsテーブル
+ * プッシュ通知・アプリ内通知を管理する
+ */
+export const notifications = sqliteTable(
+  "notifications",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: text("type").notNull(),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    isRead: integer("is_read", { mode: "boolean" }).default(false),
+    data: text("data"),
+    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => [
+    index("idx_notifications_user").on(table.userId),
+    index("idx_notifications_user_unread").on(table.userId, table.isRead),
+  ],
+);
+
+/** notificationsテーブルのSELECT型 */
+export type Notification = typeof notifications.$inferSelect;
+
+/** notificationsテーブルのINSERT型 */
+export type NewNotification = typeof notifications.$inferInsert;


### PR DESCRIPTION
## Summary
- プッシュ通知・アプリ内通知用の `notifications` テーブルスキーマを追加
- userId(FK→users CASCADE), type, title, body, isRead, data, createdAt カラムを定義
- `idx_notifications_user` / `idx_notifications_user_unread` インデックスを追加
- TDDで実装（テスト4件 全パス）

Closes #32

## Test plan
- [x] RED: テストファイル作成 → モジュール未存在で失敗確認
- [x] GREEN: スキーマ実装 → 全テストパス確認
- [x] 既存テスト(users, articles)が壊れていないことを確認（14テスト全パス）

🤖 Generated with [Claude Code](https://claude.ai/code)