### PR TITLE
feat: tags/article_tags スキーマ追加 #31

### DIFF
--- a/apps/api/src/db/schema/tags.test.ts
+++ b/apps/api/src/db/schema/tags.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { tags, articleTags } from "./tags";
+
+describe("tags schema", () => {
+  it("必須フィールドが定義されていること", () => {
+    const columns = getTableColumns(tags);
+    expect(columns.id).toBeDefined();
+    expect(columns.userId).toBeDefined();
+    expect(columns.name).toBeDefined();
+  });
+
+  it("タイムスタンプフィールドが定義されていること", () => {
+    const columns = getTableColumns(tags);
+    expect(columns.createdAt).toBeDefined();
+  });
+
+  it("nameカラムがnotNullであること", () => {
+    const columns = getTableColumns(tags);
+    expect(columns.name.notNull).toBe(true);
+  });
+
+  it("userIdカラムがnotNullであること", () => {
+    const columns = getTableColumns(tags);
+    expect(columns.userId.notNull).toBe(true);
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    const tag: typeof tags.$inferSelect = {} as never;
+    expect(tag).toBeDefined();
+  });
+});
+
+describe("articleTags schema", () => {
+  it("必須フィールドが定義されていること", () => {
+    const columns = getTableColumns(articleTags);
+    expect(columns.articleId).toBeDefined();
+    expect(columns.tagId).toBeDefined();
+  });
+
+  it("articleIdカラムがnotNullであること", () => {
+    const columns = getTableColumns(articleTags);
+    expect(columns.articleId.notNull).toBe(true);
+  });
+
+  it("tagIdカラムがnotNullであること", () => {
+    const columns = getTableColumns(articleTags);
+    expect(columns.tagId.notNull).toBe(true);
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    const articleTag: typeof articleTags.$inferSelect = {} as never;
+    expect(articleTag).toBeDefined();
+  });
+});

--- a/apps/api/src/db/schema/tags.ts
+++ b/apps/api/src/db/schema/tags.ts
@@ -1,0 +1,62 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  primaryKey,
+  unique,
+  index,
+} from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { users } from "./users";
+import { articles } from "./articles";
+
+/**
+ * tagsテーブル
+ * ユーザーごとのタグを管理する
+ */
+export const tags = sqliteTable(
+  "tags",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [
+    unique("unq_tags_user_name").on(table.userId, table.name),
+    index("idx_tags_user_id").on(table.userId),
+  ],
+);
+
+/** tagsテーブルのSELECT型 */
+export type Tag = typeof tags.$inferSelect;
+
+/** tagsテーブルのINSERT型 */
+export type NewTag = typeof tags.$inferInsert;
+
+/**
+ * article_tags中間テーブル
+ * 記事とタグの多対多リレーションを管理する
+ */
+export const articleTags = sqliteTable(
+  "article_tags",
+  {
+    articleId: text("article_id")
+      .notNull()
+      .references(() => articles.id, { onDelete: "cascade" }),
+    tagId: text("tag_id")
+      .notNull()
+      .references(() => tags.id, { onDelete: "cascade" }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.articleId, table.tagId] }),
+  ],
+);
+
+/** article_tagsテーブルのSELECT型 */
+export type ArticleTag = typeof articleTags.$inferSelect;
+
+/** article_tagsテーブルのINSERT型 */
+export type NewArticleTag = typeof articleTags.$inferInsert;


### PR DESCRIPTION
## Summary
- `tags` テーブル（id, userId FK→users CASCADE, name notNull, createdAt, UNIQUE(userId, name)）を追加
- `article_tags` 中間テーブル（articleId FK→articles CASCADE, tagId FK→tags CASCADE, 複合PK）を追加
- 型エクスポート: `Tag`, `NewTag`, `ArticleTag`, `NewArticleTag`
- Vitestテスト9件追加（全19件パス）

Closes #31

## Test plan
- [x] tags schema の必須フィールド・notNull・型エクスポートのテスト
- [x] articleTags schema の必須フィールド・notNull・型エクスポートのテスト
- [x] 既存テスト（users, articles）が壊れていないことを確認

Co-Authored-By: Claude <noreply@anthropic.com>