### PR TITLE
feat: summaries/translations テーブルスキーマ #30

### DIFF
--- a/apps/api/src/db/schema/summaries.test.ts
+++ b/apps/api/src/db/schema/summaries.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns, getTableName } from "drizzle-orm";
+import { summaries } from "./summaries";
+
+describe("summaries schema", () => {
+  it("テーブル名がsummariesであること", () => {
+    // Arrange & Act
+    const tableName = getTableName(summaries);
+
+    // Assert
+    expect(tableName).toBe("summaries");
+  });
+
+  it("必須フィールドが定義されていること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.id).toBeDefined();
+    expect(columns.articleId).toBeDefined();
+    expect(columns.language).toBeDefined();
+    expect(columns.summary).toBeDefined();
+    expect(columns.model).toBeDefined();
+    expect(columns.createdAt).toBeDefined();
+  });
+
+  it("idが主キーであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.id.primary).toBe(true);
+  });
+
+  it("articleIdがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.articleId.notNull).toBe(true);
+  });
+
+  it("languageがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.language.notNull).toBe(true);
+  });
+
+  it("summaryがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.summary.notNull).toBe(true);
+  });
+
+  it("modelがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.model.notNull).toBe(true);
+  });
+
+  it("createdAtがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+
+    // Assert
+    expect(columns.createdAt.notNull).toBe(true);
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(summaries);
+    const columnNames = Object.keys(columns);
+
+    // Assert
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("articleId");
+    expect(columnNames).toContain("language");
+    expect(columnNames).toContain("summary");
+    expect(columnNames).toContain("model");
+    expect(columnNames).toContain("createdAt");
+  });
+});

--- a/apps/api/src/db/schema/summaries.ts
+++ b/apps/api/src/db/schema/summaries.ts
@@ -1,0 +1,39 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  unique,
+} from "drizzle-orm/sqlite-core";
+import { articles } from "./articles";
+
+/**
+ * summariesテーブル
+ * AI要約結果をキャッシュする
+ */
+export const summaries = sqliteTable(
+  "summaries",
+  {
+    id: text("id").primaryKey(),
+    articleId: text("article_id")
+      .notNull()
+      .references(() => articles.id, { onDelete: "cascade" }),
+    language: text("language").notNull(),
+    summary: text("summary").notNull(),
+    model: text("model").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [
+    unique("unq_summaries_article_language").on(
+      table.articleId,
+      table.language,
+    ),
+    index("idx_summaries_article").on(table.articleId),
+  ],
+);
+
+/** summariesテーブルのSELECT型 */
+export type Summary = typeof summaries.$inferSelect;
+
+/** summariesテーブルのINSERT型 */
+export type NewSummary = typeof summaries.$inferInsert;

--- a/apps/api/src/db/schema/translations.test.ts
+++ b/apps/api/src/db/schema/translations.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { getTableColumns, getTableName } from "drizzle-orm";
+import { translations } from "./translations";
+
+describe("translations schema", () => {
+  it("テーブル名がtranslationsであること", () => {
+    // Arrange & Act
+    const tableName = getTableName(translations);
+
+    // Assert
+    expect(tableName).toBe("translations");
+  });
+
+  it("必須フィールドが定義されていること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.id).toBeDefined();
+    expect(columns.articleId).toBeDefined();
+    expect(columns.targetLanguage).toBeDefined();
+    expect(columns.translatedTitle).toBeDefined();
+    expect(columns.translatedContent).toBeDefined();
+    expect(columns.model).toBeDefined();
+    expect(columns.createdAt).toBeDefined();
+  });
+
+  it("idが主キーであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.id.primary).toBe(true);
+  });
+
+  it("articleIdがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.articleId.notNull).toBe(true);
+  });
+
+  it("targetLanguageがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.targetLanguage.notNull).toBe(true);
+  });
+
+  it("translatedTitleがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.translatedTitle.notNull).toBe(true);
+  });
+
+  it("translatedContentがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.translatedContent.notNull).toBe(true);
+  });
+
+  it("modelがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.model.notNull).toBe(true);
+  });
+
+  it("createdAtがNOT NULLであること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+
+    // Assert
+    expect(columns.createdAt.notNull).toBe(true);
+  });
+
+  it("TypeScript型が正しくエクスポートされること", () => {
+    // Arrange & Act
+    const columns = getTableColumns(translations);
+    const columnNames = Object.keys(columns);
+
+    // Assert
+    expect(columnNames).toContain("id");
+    expect(columnNames).toContain("articleId");
+    expect(columnNames).toContain("targetLanguage");
+    expect(columnNames).toContain("translatedTitle");
+    expect(columnNames).toContain("translatedContent");
+    expect(columnNames).toContain("model");
+    expect(columnNames).toContain("createdAt");
+  });
+});

--- a/apps/api/src/db/schema/translations.ts
+++ b/apps/api/src/db/schema/translations.ts
@@ -1,0 +1,40 @@
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  unique,
+} from "drizzle-orm/sqlite-core";
+import { articles } from "./articles";
+
+/**
+ * translationsテーブル
+ * AI翻訳結果をキャッシュする
+ */
+export const translations = sqliteTable(
+  "translations",
+  {
+    id: text("id").primaryKey(),
+    articleId: text("article_id")
+      .notNull()
+      .references(() => articles.id, { onDelete: "cascade" }),
+    targetLanguage: text("target_language").notNull(),
+    translatedTitle: text("translated_title").notNull(),
+    translatedContent: text("translated_content").notNull(),
+    model: text("model").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => [
+    unique("unq_translations_article_language").on(
+      table.articleId,
+      table.targetLanguage,
+    ),
+    index("idx_translations_article").on(table.articleId),
+  ],
+);
+
+/** translationsテーブルのSELECT型 */
+export type Translation = typeof translations.$inferSelect;
+
+/** translationsテーブルのINSERT型 */
+export type NewTranslation = typeof translations.$inferInsert;


### PR DESCRIPTION
## Summary
- AI要約結果をキャッシュする `summaries` テーブルのDrizzleスキーマを追加
- AI翻訳結果をキャッシュする `translations` テーブルのDrizzleスキーマを追加
- UNIQUE制約 (articleId, language/targetLanguage) で同一記事×言語の重複防止
- CASCADE DELETEで記事削除時に関連データを自動削除
- 全19テストケース通過（既存テスト含め全29テスト通過、リグレッションなし）

## 変更ファイル
- `apps/api/src/db/schema/summaries.ts` - summariesテーブル定義
- `apps/api/src/db/schema/summaries.test.ts` - summariesスキーマテスト
- `apps/api/src/db/schema/translations.ts` - translationsテーブル定義
- `apps/api/src/db/schema/translations.test.ts` - translationsスキーマテスト

## Test plan
- [x] summaries schema: 必須フィールド定義、PK、NOT NULL制約、型エクスポート（10テスト）
- [x] translations schema: 必須フィールド定義、PK、NOT NULL制約、型エクスポート（9テスト）
- [x] 既存テスト（users, articles）にリグレッションなし

Closes #30