### PR TITLE
feat: Drizzle schema barrel export + migration scripts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,10 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@libsql/client": "^0.14.0",

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -1,0 +1,29 @@
+export { users } from "./users";
+export type { User, NewUser } from "./users";
+
+export { sessions } from "./sessions";
+export type { Session, NewSession } from "./sessions";
+
+export { accounts } from "./accounts";
+export type { Account, NewAccount } from "./accounts";
+
+export { verifications } from "./verifications";
+export type { Verification, NewVerification } from "./verifications";
+
+export { articles } from "./articles";
+export type { Article, NewArticle } from "./articles";
+
+export { summaries } from "./summaries";
+export type { Summary, NewSummary } from "./summaries";
+
+export { translations } from "./translations";
+export type { Translation, NewTranslation } from "./translations";
+
+export { tags, articleTags } from "./tags";
+export type { Tag, NewTag, ArticleTag, NewArticleTag } from "./tags";
+
+export { notifications } from "./notifications";
+export type { Notification, NewNotification } from "./notifications";
+
+export { follows } from "./follows";
+export type { Follow, NewFollow } from "./follows";


### PR DESCRIPTION
## Summary
- Add `apps/api/src/db/schema/index.ts` as a barrel export for all schema tables and types (users, sessions, accounts, verifications, articles, summaries, translations, tags, articleTags, notifications, follows)
- Add `db:generate`, `db:migrate`, `db:studio` scripts to `apps/api/package.json` (`db:push` intentionally omitted per project convention)

Closes #34

## Test plan
- [x] TypeScript type check passes (`pnpm run typecheck`)
- [x] All existing tests unaffected
- [x] Verify barrel export re-exports all tables and types correctly

Generated with [Claude Code](https://claude.ai/code)