### PR TITLE
feat: sourceDetector URL→ソース自動判定 #42

### DIFF
--- a/apps/api/src/services/source-detector.test.ts
+++ b/apps/api/src/services/source-detector.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect } from "vitest";
+
+import { detectSource } from "./source-detector";
+
+describe("detectSource", () => {
+  describe("Zenn", () => {
+    it("zenn.dev の記事URLを判定できること", () => {
+      // Arrange
+      const url = "https://zenn.dev/user/articles/example-article";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("zenn");
+    });
+
+    it("zenn.dev のブックURLを判定できること", () => {
+      // Arrange
+      const url = "https://zenn.dev/user/books/example-book";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("zenn");
+    });
+  });
+
+  describe("Qiita", () => {
+    it("qiita.com の記事URLを判定できること", () => {
+      // Arrange
+      const url = "https://qiita.com/user/items/abc123";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("qiita");
+    });
+  });
+
+  describe("note", () => {
+    it("note.com の記事URLを判定できること", () => {
+      // Arrange
+      const url = "https://note.com/user/n/nxxxxxxx";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("note");
+    });
+  });
+
+  describe("はてなブログ", () => {
+    it("hatenablog.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://example.hatenablog.com/entry/2024/01/01/title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("hatena");
+    });
+
+    it("hatenablog.jp のURLを判定できること", () => {
+      // Arrange
+      const url = "https://example.hatenablog.jp/entry/2024/01/01/title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("hatena");
+    });
+
+    it("hateblo.jp のURLを判定できること", () => {
+      // Arrange
+      const url = "https://example.hateblo.jp/entry/2024/01/01/title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("hatena");
+    });
+  });
+
+  describe("SpeakerDeck", () => {
+    it("speakerdeck.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://speakerdeck.com/user/presentation-title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("speakerdeck");
+    });
+  });
+
+  describe("Dev.to", () => {
+    it("dev.to の記事URLを判定できること", () => {
+      // Arrange
+      const url = "https://dev.to/user/article-title-abc1";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("devto");
+    });
+  });
+
+  describe("Medium", () => {
+    it("medium.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://medium.com/@user/article-title-abc123";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("medium");
+    });
+
+    it("サブドメイン付きmedium.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://blog.medium.com/article-title-abc123";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("medium");
+    });
+  });
+
+  describe("Hacker News", () => {
+    it("news.ycombinator.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://news.ycombinator.com/item?id=12345678";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("hackernews");
+    });
+  });
+
+  describe("Hashnode", () => {
+    it("hashnode.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://hashnode.com/post/article-title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("hashnode");
+    });
+
+    it("hashnode.dev のサブドメインURLを判定できること", () => {
+      // Arrange
+      const url = "https://user.hashnode.dev/article-title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("hashnode");
+    });
+  });
+
+  describe("GitHub", () => {
+    it("github.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://github.com/user/repo";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("github");
+    });
+  });
+
+  describe("Stack Overflow", () => {
+    it("stackoverflow.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://stackoverflow.com/questions/12345/title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("stackoverflow");
+    });
+  });
+
+  describe("Reddit", () => {
+    it("reddit.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://www.reddit.com/r/programming/comments/abc123/title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("reddit");
+    });
+
+    it("old.reddit.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://old.reddit.com/r/programming/comments/abc123/title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("reddit");
+    });
+  });
+
+  describe("freeCodeCamp", () => {
+    it("freecodecamp.org のURLを判定できること", () => {
+      // Arrange
+      const url = "https://www.freecodecamp.org/news/article-title";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("freecodecamp");
+    });
+  });
+
+  describe("LogRocket", () => {
+    it("blog.logrocket.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://blog.logrocket.com/article-title/";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("logrocket");
+    });
+  });
+
+  describe("CSS-Tricks", () => {
+    it("css-tricks.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://css-tricks.com/article-title/";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("css-tricks");
+    });
+  });
+
+  describe("Smashing Magazine", () => {
+    it("smashingmagazine.com のURLを判定できること", () => {
+      // Arrange
+      const url = "https://www.smashingmagazine.com/2024/01/article-title/";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("smashing");
+    });
+  });
+
+  describe("その他", () => {
+    it("未知のドメインの場合otherを返すこと", () => {
+      // Arrange
+      const url = "https://example.com/article";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("other");
+    });
+
+    it("個人ブログのURLの場合otherを返すこと", () => {
+      // Arrange
+      const url = "https://blog.personal-site.com/posts/my-article";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("other");
+    });
+  });
+});

--- a/apps/api/src/services/source-detector.ts
+++ b/apps/api/src/services/source-detector.ts
@@ -1,0 +1,97 @@
+import type { ArticleSource } from "@tech-clip/types";
+
+/** ソースマッピングの型定義 */
+type SourceMapping = {
+  pattern: RegExp;
+  source: ArticleSource;
+};
+
+/** Zennブック判定パターン */
+const ZENN_BOOKS_PATTERN = /^zenn\.dev\/.*\/books\//;
+
+/** Zenn判定パターン */
+const ZENN_PATTERN = /^zenn\.dev/;
+
+/** Qiita判定パターン */
+const QIITA_PATTERN = /^qiita\.com/;
+
+/** note判定パターン */
+const NOTE_PATTERN = /^note\.com/;
+
+/** はてなブログ判定パターン */
+const HATENA_PATTERN = /^.*\.hatenablog\.(com|jp)|.*\.hateblo\.jp/;
+
+/** SpeakerDeck判定パターン */
+const SPEAKERDECK_PATTERN = /^speakerdeck\.com/;
+
+/** Dev.to判定パターン */
+const DEVTO_PATTERN = /^dev\.to/;
+
+/** Medium判定パターン */
+const MEDIUM_PATTERN = /^(.*\.)?medium\.com/;
+
+/** Hacker News判定パターン */
+const HACKERNEWS_PATTERN = /^news\.ycombinator\.com/;
+
+/** Hashnode判定パターン */
+const HASHNODE_PATTERN = /^hashnode\.com|.*\.hashnode\.dev/;
+
+/** GitHub判定パターン */
+const GITHUB_PATTERN = /^github\.com/;
+
+/** Stack Overflow判定パターン */
+const STACKOVERFLOW_PATTERN = /^stackoverflow\.com/;
+
+/** Reddit判定パターン */
+const REDDIT_PATTERN = /^(.*\.)?reddit\.com/;
+
+/** freeCodeCamp判定パターン */
+const FREECODECAMP_PATTERN = /^(www\.)?freecodecamp\.org/;
+
+/** LogRocket判定パターン */
+const LOGROCKET_PATTERN = /^blog\.logrocket\.com/;
+
+/** CSS-Tricks判定パターン */
+const CSS_TRICKS_PATTERN = /^css-tricks\.com/;
+
+/** Smashing Magazine判定パターン */
+const SMASHING_PATTERN = /^(www\.)?smashingmagazine\.com/;
+
+/** URLホスト+パスとArticleSourceの対応表 */
+const SOURCE_MAPPINGS: SourceMapping[] = [
+  { pattern: ZENN_BOOKS_PATTERN, source: "zenn" },
+  { pattern: ZENN_PATTERN, source: "zenn" },
+  { pattern: QIITA_PATTERN, source: "qiita" },
+  { pattern: NOTE_PATTERN, source: "note" },
+  { pattern: HATENA_PATTERN, source: "hatena" },
+  { pattern: SPEAKERDECK_PATTERN, source: "speakerdeck" },
+  { pattern: DEVTO_PATTERN, source: "devto" },
+  { pattern: MEDIUM_PATTERN, source: "medium" },
+  { pattern: HACKERNEWS_PATTERN, source: "hackernews" },
+  { pattern: HASHNODE_PATTERN, source: "hashnode" },
+  { pattern: GITHUB_PATTERN, source: "github" },
+  { pattern: STACKOVERFLOW_PATTERN, source: "stackoverflow" },
+  { pattern: REDDIT_PATTERN, source: "reddit" },
+  { pattern: FREECODECAMP_PATTERN, source: "freecodecamp" },
+  { pattern: LOGROCKET_PATTERN, source: "logrocket" },
+  { pattern: CSS_TRICKS_PATTERN, source: "css-tricks" },
+  { pattern: SMASHING_PATTERN, source: "smashing" },
+];
+
+/**
+ * URLからArticleSourceを自動判定する
+ *
+ * @param url - 判定対象のURL文字列
+ * @returns 判定されたArticleSource。該当なしの場合は"other"
+ */
+export function detectSource(url: string): ArticleSource {
+  const parsed = new URL(url);
+  const hostAndPath = parsed.hostname + parsed.pathname;
+
+  for (const { pattern, source } of SOURCE_MAPPINGS) {
+    if (pattern.test(hostAndPath)) {
+      return source;
+    }
+  }
+  return "other";
+}


### PR DESCRIPTION
## Summary
- URLのホスト名+パスからArticleSource種別を自動判定する`detectSource`関数を実装
- 17種のソース（Zenn, Qiita, note, はてな, Medium, GitHub等）に対応、該当なしは"other"を返却
- TDDで24テストケース作成（全ソース+境界値をカバー）

Closes #42

## Test plan
- [x] 各ソースのURL判定テスト（正常系: 17ソース）
- [x] はてなブログの3ドメインバリエーション（hatenablog.com, hatenablog.jp, hateblo.jp）
- [x] サブドメイン付きURL（Medium, Reddit）
- [x] 未知ドメインでother判定（異常系: 2ケース）
- [x] 全24テスト通過確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)