### PR TITLE
feat: セキュリティヘッダーミドルウェア (Workers API)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,5 +1,7 @@
 import { Hono } from "hono";
 
+import { securityHeadersMiddleware } from "./middleware/security-headers";
+
 /** Cloudflare Workers バインディング型定義 */
 type Bindings = {
   TURSO_DATABASE_URL: string;
@@ -11,6 +13,8 @@ type Bindings = {
 };
 
 const app = new Hono<{ Bindings: Bindings }>();
+
+app.use("*", securityHeadersMiddleware);
 
 app.get("/health", (c) => {
   return c.json({

--- a/apps/api/src/middleware/security-headers.test.ts
+++ b/apps/api/src/middleware/security-headers.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { securityHeadersMiddleware } from "./security-headers";
+
+/** テスト用Honoアプリを作成する */
+function createTestApp(env: Record<string, string> = {}) {
+  const app = new Hono<{ Bindings: Record<string, string> }>();
+  app.use("*", securityHeadersMiddleware);
+  app.get("/test", (c) => c.json({ status: "ok" }));
+  return { app, env };
+}
+
+describe("securityHeadersMiddleware", () => {
+  describe("共通ヘッダー", () => {
+    it("X-Content-Type-Optionsがnosniffであること", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    });
+
+    it("X-Frame-OptionsがDENYであること", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    });
+
+    it("X-XSS-Protectionが1; mode=blockであること", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.headers.get("X-XSS-Protection")).toBe("1; mode=block");
+    });
+
+    it("Referrer-Policyがstrict-origin-when-cross-originであること", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.headers.get("Referrer-Policy")).toBe(
+        "strict-origin-when-cross-origin",
+      );
+    });
+
+    it("Permissions-Policyでカメラ・マイク・位置情報が無効であること", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.headers.get("Permissions-Policy")).toBe(
+        "camera=(), microphone=(), geolocation=()",
+      );
+    });
+  });
+
+  describe("HSTS（本番環境のみ）", () => {
+    it("ENVIRONMENT=productionの場合HSTSヘッダーが付与されること", async () => {
+      // Arrange
+      const app = new Hono<{ Bindings: Record<string, string> }>();
+      app.use("*", securityHeadersMiddleware);
+      app.get("/test", (c) => c.json({ status: "ok" }));
+
+      // Act
+      const res = await app.request("/test", undefined, {
+        ENVIRONMENT: "production",
+      });
+
+      // Assert
+      expect(res.headers.get("Strict-Transport-Security")).toBe(
+        "max-age=31536000; includeSubDomains",
+      );
+    });
+
+    it("ENVIRONMENT=developmentの場合HSTSヘッダーが付与されないこと", async () => {
+      // Arrange
+      const app = new Hono<{ Bindings: Record<string, string> }>();
+      app.use("*", securityHeadersMiddleware);
+      app.get("/test", (c) => c.json({ status: "ok" }));
+
+      // Act
+      const res = await app.request("/test", undefined, {
+        ENVIRONMENT: "development",
+      });
+
+      // Assert
+      expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+    });
+
+    it("ENVIRONMENTが未設定の場合HSTSヘッダーが付与されないこと", async () => {
+      // Arrange
+      const app = new Hono<{ Bindings: Record<string, string> }>();
+      app.use("*", securityHeadersMiddleware);
+      app.get("/test", (c) => c.json({ status: "ok" }));
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+    });
+  });
+
+  describe("レスポンスボディへの影響", () => {
+    it("レスポンスボディが変更されないこと", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+      const body = await res.json();
+
+      // Assert
+      expect(body).toEqual({ status: "ok" });
+    });
+
+    it("ステータスコードが変更されないこと", async () => {
+      // Arrange
+      const { app } = createTestApp();
+
+      // Act
+      const res = await app.request("/test");
+
+      // Assert
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/apps/api/src/middleware/security-headers.ts
+++ b/apps/api/src/middleware/security-headers.ts
@@ -1,0 +1,22 @@
+import type { MiddlewareHandler } from "hono";
+
+/**
+ * セキュリティヘッダーミドルウェア
+ *
+ * すべてのレスポンスにセキュリティ関連のHTTPヘッダーを付与する。
+ * HSTSは本番環境（ENVIRONMENT=production）のみ有効。
+ */
+export const securityHeadersMiddleware: MiddlewareHandler = async (c, next) => {
+  await next();
+  c.header("X-Content-Type-Options", "nosniff");
+  c.header("X-Frame-Options", "DENY");
+  c.header("X-XSS-Protection", "1; mode=block");
+  c.header("Referrer-Policy", "strict-origin-when-cross-origin");
+  c.header("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  if (c.env?.ENVIRONMENT === "production") {
+    c.header(
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- Workers APIの全レスポンスにセキュリティヘッダー（X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy）を付与するミドルウェアを追加
- 本番環境（ENVIRONMENT=production）のみHSTS（Strict-Transport-Security）を有効化
- Honoのtestclientを使用した10件のテストで全ケースをカバー（共通ヘッダー、HSTS条件分岐、レスポンスボディ非干渉）

## Test plan
- [x] 共通セキュリティヘッダー5種が全レスポンスに付与されることを検証
- [x] ENVIRONMENT=production時のみHSTSが付与されることを検証
- [x] ENVIRONMENT=development / 未設定時にHSTSが付与されないことを検証
- [x] ミドルウェアがレスポンスボディ・ステータスコードに影響しないことを検証
- [x] TypeScript型チェック通過

Closes #124

🤖 Generated with [Claude Code](https://claude.ai/code)