### PR TITLE
feat: 汎用パーサー (Readability + linkedom + turndown) #43

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,13 +16,17 @@
   },
   "dependencies": {
     "@libsql/client": "^0.14.0",
+    "@mozilla/readability": "^0.6.0",
+    "@tech-clip/types": "workspace:*",
     "better-auth": "^1.5.6",
     "drizzle-orm": "^0.43.0",
     "hono": "^4.7.5",
-    "@tech-clip/types": "workspace:*"
+    "linkedom": "^0.18.12",
+    "turndown": "^7.2.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250321.0",
+    "@types/turndown": "^5.0.6",
     "drizzle-kit": "^0.31.0",
     "typescript": "^5.8.2",
     "vitest": "^4.1.1",

--- a/apps/api/src/services/parsers/generic.test.ts
+++ b/apps/api/src/services/parsers/generic.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseGeneric } from "./generic";
+
+/** テスト用HTMLテンプレート */
+const SAMPLE_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>テスト記事タイトル</title>
+  <meta property="og:image" content="https://example.com/thumb.jpg" />
+  <meta property="article:author" content="テスト著者" />
+  <meta property="article:published_time" content="2024-06-15T10:00:00Z" />
+</head>
+<body>
+  <article>
+    <h1>テスト記事タイトル</h1>
+    <p>これはテスト記事の本文です。十分な長さのコンテンツが必要です。</p>
+    <p>Readabilityが本文として認識するために、ある程度の文字数が必要になります。</p>
+    <p>段落を複数用意して、記事らしい構造を作ります。</p>
+    <p>技術記事のパーサーをテストしています。HTMLからMarkdownへの変換を検証します。</p>
+    <p>最後の段落です。これで十分な本文量になるはずです。</p>
+  </article>
+</body>
+</html>
+`;
+
+/** OGPメタタグなしのHTML */
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>最小限の記事</title>
+</head>
+<body>
+  <article>
+    <h1>最小限の記事</h1>
+    <p>本文のみの記事です。メタ情報はありません。</p>
+    <p>Readabilityが認識できるように複数の段落を用意します。</p>
+    <p>段落を追加してコンテンツ量を確保します。</p>
+    <p>さらに追加の段落でボリュームを増やします。</p>
+    <p>最後の段落です。パーサーのテストに使用します。</p>
+  </article>
+</body>
+</html>
+`;
+
+/** 本文が空のHTML */
+const EMPTY_CONTENT_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>空の記事</title></head>
+<body></body>
+</html>
+`;
+
+/** fetchのモック */
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseGeneric", () => {
+  describe("正常系", () => {
+    it("HTMLから記事情報を抽出してMarkdownに変換できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://example.com/article";
+
+      // Act
+      const result = await parseGeneric(url);
+
+      // Assert
+      expect(result.title).toBe("テスト記事タイトル");
+      expect(result.content).toContain("テスト記事の本文");
+      expect(result.source).toBe("example.com");
+    });
+
+    it("OGPメタタグからサムネイルURLを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/article");
+
+      // Assert
+      expect(result.thumbnailUrl).toBe("https://example.com/thumb.jpg");
+    });
+
+    it("OGPメタタグから著者名を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/article");
+
+      // Assert
+      expect(result.author).toBe("テスト著者");
+    });
+
+    it("OGPメタタグから公開日を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/article");
+
+      // Assert
+      expect(result.publishedAt).toBe("2024-06-15T10:00:00Z");
+    });
+
+    it("読了時間が計算されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/article");
+
+      // Assert
+      expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+    });
+
+    it("sourceにドメイン名が設定されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://blog.example.co.jp/article");
+
+      // Assert
+      expect(result.source).toBe("blog.example.co.jp");
+    });
+  });
+
+  describe("OGPメタタグなし", () => {
+    it("メタタグがない場合でも記事を抽出できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(MINIMAL_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/article");
+
+      // Assert
+      expect(result.title).toBe("最小限の記事");
+      expect(result.content).toContain("本文のみの記事");
+      expect(result.thumbnailUrl).toBeNull();
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+    });
+  });
+
+  describe("異常系", () => {
+    it("fetchが失敗した場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      // Act & Assert
+      await expect(parseGeneric("https://example.com/not-found")).rejects.toThrow(
+        "HTMLの取得に失敗しました",
+      );
+    });
+
+    it("本文が抽出できない場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(EMPTY_CONTENT_HTML),
+      });
+
+      // Act & Assert
+      await expect(parseGeneric("https://example.com/empty")).rejects.toThrow(
+        "記事本文の抽出に失敗しました",
+      );
+    });
+
+    it("ネットワークエラーの場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      // Act & Assert
+      await expect(parseGeneric("https://example.com/error")).rejects.toThrow();
+    });
+  });
+
+  describe("Markdown変換", () => {
+    it("変換結果がMarkdown形式であること", async () => {
+      // Arrange
+      const htmlWithFormatting = `
+<!DOCTYPE html>
+<html>
+<head><title>書式付き記事</title></head>
+<body>
+  <article>
+    <h1>書式付き記事</h1>
+    <h2>セクション1</h2>
+    <p>通常のテキストと<strong>太字</strong>と<em>イタリック</em>があります。</p>
+    <p>追加の段落です。Readabilityが認識できるようにします。</p>
+    <p>さらに段落を追加します。テストの信頼性を高めます。</p>
+    <ul>
+      <li>リスト項目1</li>
+      <li>リスト項目2</li>
+    </ul>
+    <p>最後の段落です。十分な量のコンテンツです。</p>
+  </article>
+</body>
+</html>
+`;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(htmlWithFormatting),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/formatted");
+
+      // Assert
+      expect(result.content).toContain("**太字**");
+      expect(result.content).toContain("_イタリック_");
+    });
+  });
+});

--- a/apps/api/src/services/parsers/generic.ts
+++ b/apps/api/src/services/parsers/generic.ts
@@ -1,0 +1,105 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import TurndownService from "turndown";
+
+import type { ParsedArticle } from "../../types/article";
+
+/** 読了速度（文字/分） */
+const READING_SPEED_CHARS_PER_MIN = 500;
+
+/** 最小読了時間（分） */
+const MIN_READING_TIME_MINUTES = 1;
+
+/** fetch時のUser-Agent */
+const USER_AGENT = "Mozilla/5.0 (compatible; TechClipBot/1.0; +https://techclip.app)";
+
+/**
+ * linkedomのドキュメント型
+ *
+ * Cloudflare Workers環境にはDOM型が存在しないため、
+ * linkedomが返すドキュメントオブジェクトの必要なインターフェースのみ定義する
+ */
+type LinkedomDocument = {
+  querySelector: (selector: string) => { getAttribute: (name: string) => string | null } | null;
+};
+
+/**
+ * HTMLからOGPメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param property - metaタグのproperty属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaContent(doc: LinkedomDocument, property: string): string | null {
+  const meta = doc.querySelector(`meta[property="${property}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * 文字数から読了時間を計算する
+ *
+ * @param text - 本文テキスト
+ * @returns 推定読了時間（分、最小1分）
+ */
+function calculateReadingTime(text: string): number {
+  const charCount = text.length;
+  const minutes = Math.ceil(charCount / READING_SPEED_CHARS_PER_MIN);
+  return Math.max(minutes, MIN_READING_TIME_MINUTES);
+}
+
+/**
+ * 任意のURLからHTML取得 → 本文抽出 → Markdown変換する汎用パーサー
+ *
+ * @param url - パース対象のURL
+ * @returns パースされた記事情報
+ * @throws Error - HTMLの取得またはパースに失敗した場合
+ */
+export async function parseGeneric(url: string): Promise<ParsedArticle> {
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTMLの取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+
+  const reader = new Readability(document);
+  const article = reader.parse();
+
+  if (!article?.content) {
+    throw new Error("記事本文の抽出に失敗しました");
+  }
+
+  const turndown = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
+  const markdown = turndown.turndown(article.content);
+
+  const { document: originalDoc } = parseHTML(html);
+  const doc = originalDoc as unknown as LinkedomDocument;
+  const thumbnailUrl = getMetaContent(doc, "og:image");
+  const author = getMetaContent(doc, "article:author");
+  const publishedAt = getMetaContent(doc, "article:published_time");
+
+  const parsed = new URL(url);
+  const title = article.title ?? "";
+  const textContent = article.textContent ?? "";
+
+  return {
+    title,
+    author,
+    content: markdown,
+    excerpt: article.excerpt ?? null,
+    thumbnailUrl,
+    readingTimeMinutes: calculateReadingTime(textContent),
+    publishedAt,
+    source: parsed.hostname,
+  };
+}

--- a/apps/api/src/types/article.ts
+++ b/apps/api/src/types/article.ts
@@ -1,0 +1,21 @@
+/**
+ * パーサーが抽出した記事データの型定義
+ */
+export type ParsedArticle = {
+  /** 記事タイトル */
+  title: string;
+  /** 著者名 */
+  author: string | null;
+  /** Markdown変換済み本文 */
+  content: string;
+  /** 記事の概要 */
+  excerpt: string | null;
+  /** サムネイル画像URL */
+  thumbnailUrl: string | null;
+  /** 推定読了時間（分） */
+  readingTimeMinutes: number;
+  /** 公開日（ISO 8601形式） */
+  publishedAt: string | null;
+  /** 記事ソース識別子 */
+  source: string;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
+      '@mozilla/readability':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@tech-clip/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -35,10 +38,19 @@ importers:
       hono:
         specifier: ^4.7.5
         version: 4.12.9
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.12
+      turndown:
+        specifier: ^7.2.2
+        version: 7.2.2
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250321.0
         version: 4.20260317.1
+      '@types/turndown':
+        specifier: ^5.0.6
+        version: 5.0.6
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.10
@@ -1519,7 +1531,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -1934,6 +1946,13 @@ packages:
     resolution: {integrity: sha512-7pJzOWzPm6oJUxml+PCDRzYQ4A1hTMHAciTAHfFK4fkbDZX33nWPVG7Y3vqdKtslcwAzwmrNDc6sXy2nwWnbiw==}
     cpu: [x64]
     os: [win32]
+
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@mozilla/readability@0.6.0':
+    resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
+    engines: {node: '>=14.0.0'}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -2375,6 +2394,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/turndown@5.0.6':
+    resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2745,6 +2767,9 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   bplist-creator@0.0.7:
     resolution: {integrity: sha512-xp/tcaV3T5PCiaY04mXga7o/TE+t95gqeLmADeBI1CvZtdWTbgBt3uLpvh4UWtenKeBhCV6oVxGk38yZr2uYEA==}
 
@@ -3030,6 +3055,13 @@ packages:
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -3165,10 +3197,23 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -3305,8 +3350,16 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-editor@0.4.2:
@@ -3804,6 +3857,12 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -4256,6 +4315,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@1.4.2:
@@ -4401,6 +4461,15 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -4787,6 +4856,9 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -5744,6 +5816,9 @@ packages:
     resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
     hasBin: true
 
+  turndown@7.2.2:
+    resolution: {integrity: sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==}
+
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -5768,6 +5843,9 @@ packages:
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
     hasBin: true
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -8193,6 +8271,10 @@ snapshots:
   '@libsql/win32-x64-msvc@0.4.7':
     optional: true
 
+  '@mixmark-io/domino@2.2.0': {}
+
+  '@mozilla/readability@0.6.0': {}
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.9.1
@@ -8731,6 +8813,8 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/turndown@5.0.6': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 25.5.0
@@ -9096,6 +9180,8 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
+  boolbase@1.0.0: {}
+
   bplist-creator@0.0.7:
     dependencies:
       stream-buffers: 2.2.0
@@ -9419,6 +9505,16 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
 
   cssom@0.3.8: {}
@@ -9509,9 +9605,27 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
   domexception@4.0.0:
     dependencies:
       webidl-conversions: 7.0.0
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv-expand@11.0.7:
     dependencies:
@@ -9559,7 +9673,11 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  entities@4.5.0: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-editor@0.4.2: {}
 
@@ -10185,6 +10303,15 @@ snapshots:
       whatwg-encoding: 2.0.0
 
   html-escaper@2.0.2: {}
+
+  html-escaper@3.0.3: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-errors@2.0.1:
     dependencies:
@@ -10985,6 +11112,14 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   locate-path@3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -11567,6 +11702,10 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   nullthrows@1.1.1: {}
 
@@ -12603,6 +12742,10 @@ snapshots:
       '@turbo/windows-64': 2.8.20
       '@turbo/windows-arm64': 2.8.20
 
+  turndown@7.2.2:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
+
   type-detect@4.0.8: {}
 
   type-fest@0.16.0: {}
@@ -12614,6 +12757,8 @@ snapshots:
   typescript@5.9.3: {}
 
   ua-parser-js@1.0.41: {}
+
+  uhyphen@0.2.0: {}
 
   undici-types@7.18.2: {}
 


### PR DESCRIPTION
## Summary
- Readability + linkedom + turndown を使った汎用HTMLパーサー `parseGeneric()` を実装
- OGPメタタグからサムネイル・著者・公開日を取得、本文をMarkdownに変換
- 11テストケース（正常系・異常系・Markdown変換）で動作を検証済み

Closes #43

## Test plan
- [x] 正常系: HTML→Markdown変換、OGPメタ取得、読了時間計算
- [x] 異常系: fetch失敗、空コンテンツ、ネットワークエラー
- [x] lint / typecheck / test 全パス（119テスト全通過）

Generated with [Claude Code](https://claude.ai/code)