### PR TITLE
feat: OWASP ZAP セキュリティテストをCIに追加

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,45 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  zap-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Start API server
+        run: pnpm --filter @tech-clip/api dev &
+        env:
+          TURSO_DATABASE_URL: file:local.db
+          TURSO_AUTH_TOKEN: dummy
+          RUNPOD_API_KEY: dummy
+          RUNPOD_ENDPOINT_ID: dummy
+          BETTER_AUTH_SECRET: test-secret-key-for-ci
+          ENVIRONMENT: test
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            curl -s http://localhost:8787/health && break
+            sleep 1
+          done
+      - name: OWASP ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: http://localhost:8787
+          rules_file_name: .zap/rules.tsv
+          cmd_options: '-a'
+          allow_issue_writing: false
+      - name: Upload ZAP Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: report_html.html

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,2 @@
+10003	WARN	(Vulnerable JS Library - Workers環境では該当しない)
+10015	WARN	(Incomplete or No Cache-control Header - API向けのため許容)


### PR DESCRIPTION
## Summary
- OWASP ZAP baseline scan をCIワークフローに追加（PR対象: mainブランチ）
- API サーバーを起動し、ZAP がエンドポイントをスキャンして脆弱性を検出
- `.zap/rules.tsv` でWorkers環境に該当しないルールをWARNに設定

Closes #223

## Test plan
- [ ] CI上で `security.yml` ワークフローが正常に起動すること
- [ ] ZAP baseline scan が実行され、レポートがartifactとしてアップロードされること
- [ ] `rules.tsv` の除外ルールが適用されること

Co-Authored-By: Claude <noreply@anthropic.com>