### PR TITLE
feat: Speakerdeck parser (OGP meta tag extraction)

### DIFF
--- a/apps/api/src/services/parsers/speakerdeck.test.ts
+++ b/apps/api/src/services/parsers/speakerdeck.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseSpeakerdeck } from "./speakerdeck";
+
+/** SpeakerdeckページのHTMLモック（OGPメタタグあり） */
+const SAMPLE_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Rubyの型チェック事情 by testuser - Speaker Deck</title>
+  <meta property="og:title" content="Rubyの型チェック事情" />
+  <meta property="og:description" content="RubyKaigi 2024で発表したスライドです。RBSとSteepを使った型チェックの実践について解説します。" />
+  <meta property="og:image" content="https://files.speakerdeck.com/presentations/abc123/slide_0.jpg" />
+  <meta name="author" content="testuser" />
+  <meta property="article:published_time" content="2024-05-15T00:00:00Z" />
+</head>
+<body>
+  <div class="deck-header">
+    <h1>Rubyの型チェック事情</h1>
+    <div class="deck-description">
+      <p>RubyKaigi 2024で発表したスライドです。RBSとSteepを使った型チェックの実践について解説します。</p>
+    </div>
+  </div>
+  <div class="speakerdeck-embed" data-id="abc123"></div>
+</body>
+</html>
+`;
+
+/** OGPメタタグ最小限のHTML */
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>最小限のスライド - Speaker Deck</title>
+  <meta property="og:title" content="最小限のスライド" />
+</head>
+<body>
+  <div class="deck-header">
+    <h1>最小限のスライド</h1>
+  </div>
+</body>
+</html>
+`;
+
+/** タイトルがないHTML */
+const NO_TITLE_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title></title>
+</head>
+<body></body>
+</html>
+`;
+
+/** fetchのモック */
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseSpeakerdeck", () => {
+  describe("正常系", () => {
+    it("OGPメタタグからタイトルを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.title).toBe("Rubyの型チェック事情");
+    });
+
+    it("OGPメタタグから概要を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.excerpt).toContain("RubyKaigi 2024");
+    });
+
+    it("OGPメタタグからサムネイルURLを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.thumbnailUrl).toBe(
+        "https://files.speakerdeck.com/presentations/abc123/slide_0.jpg",
+      );
+    });
+
+    it("authorメタタグから著者名を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.author).toBe("testuser");
+    });
+
+    it("公開日を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.publishedAt).toBe("2024-05-15T00:00:00Z");
+    });
+
+    it("sourceにspeakerdeck.comが設定されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.source).toBe("speakerdeck.com");
+    });
+
+    it("contentにOGP概要が含まれること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.content).toContain("RubyKaigi 2024");
+    });
+
+    it("読了時間が1分以上になること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("OGPメタタグなし", () => {
+    it("メタタグが最小限でも記事情報を返せること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(MINIMAL_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/minimal-slide";
+
+      // Act
+      const result = await parseSpeakerdeck(url);
+
+      // Assert
+      expect(result.title).toBe("最小限のスライド");
+      expect(result.thumbnailUrl).toBeNull();
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+      expect(result.excerpt).toBeNull();
+    });
+  });
+
+  describe("URL検証", () => {
+    it("Speakerdeck以外のURLの場合エラーになること", async () => {
+      // Arrange
+      const url = "https://example.com/slides/test";
+
+      // Act & Assert
+      await expect(parseSpeakerdeck(url)).rejects.toThrow("Speakerdeck");
+    });
+
+    it("正しいURLでfetchが呼ばれること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/ruby-type-checking";
+
+      // Act
+      await parseSpeakerdeck(url);
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "User-Agent": expect.stringContaining("TechClipBot"),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("異常系", () => {
+    it("fetchが失敗した場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+      const url = "https://speakerdeck.com/testuser/not-found";
+
+      // Act & Assert
+      await expect(parseSpeakerdeck(url)).rejects.toThrow("取得に失敗しました");
+    });
+
+    it("ネットワークエラーの場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+      const url = "https://speakerdeck.com/testuser/some-slide";
+
+      // Act & Assert
+      await expect(parseSpeakerdeck(url)).rejects.toThrow();
+    });
+
+    it("タイトルが取得できない場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(NO_TITLE_HTML),
+      });
+      const url = "https://speakerdeck.com/testuser/empty-slide";
+
+      // Act & Assert
+      await expect(parseSpeakerdeck(url)).rejects.toThrow("タイトル");
+    });
+  });
+});

--- a/apps/api/src/services/parsers/speakerdeck.ts
+++ b/apps/api/src/services/parsers/speakerdeck.ts
@@ -1,0 +1,133 @@
+import { parseHTML } from "linkedom";
+
+import type { ParsedArticle } from "../../types/article";
+
+/** Speakerdeckのホスト名 */
+const SPEAKERDECK_HOSTNAME = "speakerdeck.com";
+
+/** fetch時のUser-Agent */
+const USER_AGENT = "Mozilla/5.0 (compatible; TechClipBot/1.0; +https://techclip.app)";
+
+/** 読了速度（文字/分） */
+const READING_SPEED_CHARS_PER_MIN = 500;
+
+/** 最小読了時間（分） */
+const MIN_READING_TIME_MINUTES = 1;
+
+/**
+ * linkedomのドキュメント型
+ *
+ * Cloudflare Workers環境にはDOM型が存在しないため、
+ * linkedomが返すドキュメントオブジェクトの必要なインターフェースのみ定義する
+ */
+type LinkedomDocument = {
+  querySelector: (
+    selector: string,
+  ) => { getAttribute: (name: string) => string | null; textContent: string | null } | null;
+};
+
+/**
+ * HTMLからOGPメタタグのcontent値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param property - metaタグのproperty属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaContent(doc: LinkedomDocument, property: string): string | null {
+  const meta = doc.querySelector(`meta[property="${property}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * HTMLからname属性のメタタグのcontent値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param name - metaタグのname属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaNameContent(doc: LinkedomDocument, name: string): string | null {
+  const meta = doc.querySelector(`meta[name="${name}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * 文字数から読了時間を計算する
+ *
+ * @param text - 本文テキスト
+ * @returns 推定読了時間（分、最小1分）
+ */
+function calculateReadingTime(text: string): number {
+  const charCount = text.length;
+  const minutes = Math.ceil(charCount / READING_SPEED_CHARS_PER_MIN);
+  return Math.max(minutes, MIN_READING_TIME_MINUTES);
+}
+
+/**
+ * URLがSpeakerdeckのものか検証する
+ *
+ * @param url - 検証対象のURL
+ * @throws Error - Speakerdeck以外のURLの場合
+ */
+function validateSpeakerdeckUrl(url: string): void {
+  const parsed = new URL(url);
+
+  if (parsed.hostname !== SPEAKERDECK_HOSTNAME) {
+    throw new Error("SpeakerdeckのURLではありません");
+  }
+}
+
+/**
+ * SpeakerdeckのURLからHTML取得し、OGPメタタグからスライド情報を抽出する
+ *
+ * スライド本文はiframeで埋め込まれるため直接抽出できない。
+ * OGPメタタグからタイトル、著者、概要、サムネイルを取得する。
+ *
+ * @param url - SpeakerdeckスライドのURL（例: https://speakerdeck.com/user/slide-name）
+ * @returns パースされた記事情報
+ * @throws Error - URLの検証、HTML取得、またはパースに失敗した場合
+ */
+export async function parseSpeakerdeck(url: string): Promise<ParsedArticle> {
+  validateSpeakerdeckUrl(url);
+
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Speakerdeckページの取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+  const doc = document as unknown as LinkedomDocument;
+
+  const title = getMetaContent(doc, "og:title");
+
+  if (!title) {
+    throw new Error("スライドのタイトルを取得できません");
+  }
+
+  const description = getMetaContent(doc, "og:description");
+  const thumbnailUrl = getMetaContent(doc, "og:image");
+  const author = getMetaNameContent(doc, "author");
+  const publishedAt = getMetaContent(doc, "article:published_time");
+
+  const content = description ?? "";
+
+  return {
+    title,
+    author,
+    content,
+    excerpt: description,
+    thumbnailUrl,
+    readingTimeMinutes: calculateReadingTime(content),
+    publishedAt,
+    source: SPEAKERDECK_HOSTNAME,
+  };
+}


### PR DESCRIPTION
## Summary
- Speakerdeck URL からHTMLを取得し、OGPメタタグからタイトル・著者・概要・サムネイルを抽出するパーサーを追加
- スライド本文はiframeのため直接抽出不可。OGP description をcontent/excerptとして利用
- 既存パーサー（generic, zenn, qiita）と同一の `ParsedArticle` 型を返却

Closes #50

## Test plan
- [x] OGPメタタグからタイトル、著者、概要、サムネイル、公開日を正しく抽出
- [x] メタタグが最小限の場合でもnull返却で正常動作
- [x] Speakerdeck以外のURLでエラー
- [x] fetch失敗・ネットワークエラー・タイトル欠落の異常系
- [x] pnpm lint / typecheck / test すべて通過（199 tests passed）

🤖 Generated with [Claude Code](https://claude.ai/code)