### PR TITLE
feat: freeCodeCamp / LogRocket / CSS-Tricks / Smashing Magazine parsers

### DIFF
--- a/apps/api/src/services/parsers/css-tricks.test.ts
+++ b/apps/api/src/services/parsers/css-tricks.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseCssTricks } from "./css-tricks";
+
+/** CSS-Tricks記事のHTMLテンプレート */
+const SAMPLE_CSS_TRICKS_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>A Complete Guide to Flexbox</title>
+  <meta property="og:title" content="A Complete Guide to Flexbox" />
+  <meta property="og:image" content="https://css-tricks.com/wp-content/uploads/2024/03/flexbox-guide.png" />
+  <meta property="article:author" content="https://css-tricks.com/author/testauthor/" />
+  <meta property="article:published_time" content="2024-05-10T08:30:00.000Z" />
+  <meta name="author" content="CSS-Tricksテスト著者" />
+</head>
+<body>
+  <article>
+    <h1>A Complete Guide to Flexbox</h1>
+    <p>Flexbox is a one-dimensional layout method for arranging items in rows or columns.</p>
+    <p>It makes it easier to design flexible responsive layout structures.</p>
+    <h2>Flexbox Properties</h2>
+    <p>The flex container becomes flexible by setting the display property to flex.</p>
+    <p>The flex-direction property defines the direction of the flex items.</p>
+    <p>Understanding these properties is essential for modern CSS layouts.</p>
+  </article>
+</body>
+</html>
+`;
+
+/** OGPメタタグなしのHTML */
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>最小限のCSS-Tricks記事</title>
+</head>
+<body>
+  <article>
+    <h1>最小限のCSS-Tricks記事</h1>
+    <p>メタ情報のない記事です。本文のみ含まれています。</p>
+    <p>Readabilityが認識できるように複数の段落を用意します。</p>
+    <p>段落を追加してコンテンツ量を確保します。</p>
+    <p>さらに追加の段落でボリュームを増やします。</p>
+    <p>最後の段落です。パーサーのテストに使用します。</p>
+  </article>
+</body>
+</html>
+`;
+
+/** 本文が空のHTML */
+const EMPTY_CONTENT_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>空の記事</title></head>
+<body></body>
+</html>
+`;
+
+/** fetchのモック */
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseCssTricks", () => {
+  describe("URL検証", () => {
+    it("CSS-Tricks以外のURLの場合エラーになること", async () => {
+      // Arrange
+      const url = "https://example.com/article";
+
+      // Act & Assert
+      await expect(parseCssTricks(url)).rejects.toThrow("CSS-TricksのURLではありません");
+    });
+
+    it("css-tricks.comドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.source).toBe("css-tricks.com");
+    });
+
+    it("www.css-tricks.comドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://www.css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.source).toBe("www.css-tricks.com");
+    });
+  });
+
+  describe("正常系", () => {
+    it("記事のタイトルを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.title).toBe("A Complete Guide to Flexbox");
+    });
+
+    it("記事本文をMarkdown形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.content).toContain("Flexbox");
+    });
+
+    it("OGPメタタグからサムネイルURLを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.thumbnailUrl).toBe(
+        "https://css-tricks.com/wp-content/uploads/2024/03/flexbox-guide.png",
+      );
+    });
+
+    it("metaタグから著者名を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.author).toBe("CSS-Tricksテスト著者");
+    });
+
+    it("公開日をISO 8601形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.publishedAt).toBe("2024-05-10T08:30:00.000Z");
+    });
+
+    it("読了時間が1分以上で計算されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("OGPメタタグなし", () => {
+    it("メタタグがない場合でも記事を抽出できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(MINIMAL_HTML),
+      });
+      const url = "https://css-tricks.com/minimal-article/";
+
+      // Act
+      const result = await parseCssTricks(url);
+
+      // Assert
+      expect(result.title).toBe("最小限のCSS-Tricks記事");
+      expect(result.content).toContain("メタ情報のない記事");
+      expect(result.thumbnailUrl).toBeNull();
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+    });
+  });
+
+  describe("異常系", () => {
+    it("fetchが失敗した場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+      const url = "https://css-tricks.com/not-found/";
+
+      // Act & Assert
+      await expect(parseCssTricks(url)).rejects.toThrow("CSS-Tricks記事の取得に失敗しました");
+    });
+
+    it("本文が抽出できない場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(EMPTY_CONTENT_HTML),
+      });
+      const url = "https://css-tricks.com/empty/";
+
+      // Act & Assert
+      await expect(parseCssTricks(url)).rejects.toThrow("CSS-Tricks記事の本文の抽出に失敗しました");
+    });
+
+    it("ネットワークエラーの場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+      const url = "https://css-tricks.com/error/";
+
+      // Act & Assert
+      await expect(parseCssTricks(url)).rejects.toThrow();
+    });
+  });
+
+  describe("fetchリクエスト", () => {
+    it("User-Agentヘッダーを送信すること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_CSS_TRICKS_HTML),
+      });
+      const url = "https://css-tricks.com/a-complete-guide-to-flexbox/";
+
+      // Act
+      await parseCssTricks(url);
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "User-Agent": expect.stringContaining("TechClipBot"),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/services/parsers/css-tricks.ts
+++ b/apps/api/src/services/parsers/css-tricks.ts
@@ -1,0 +1,140 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import TurndownService from "turndown";
+
+import type { ParsedArticle } from "../../types/article";
+
+/** CSS-Tricksのホスト名 */
+const CSS_TRICKS_HOSTNAME = "css-tricks.com";
+
+/** fetch時のUser-Agent */
+const USER_AGENT = "Mozilla/5.0 (compatible; TechClipBot/1.0; +https://techclip.app)";
+
+/** 読了速度（文字/分） */
+const READING_SPEED_CHARS_PER_MIN = 500;
+
+/** 最小読了時間（分） */
+const MIN_READING_TIME_MINUTES = 1;
+
+/**
+ * linkedomのドキュメント型
+ *
+ * Cloudflare Workers環境にはDOM型が存在しないため、
+ * linkedomが返すドキュメントオブジェクトの必要なインターフェースのみ定義する
+ */
+type LinkedomDocument = {
+  querySelector: (selector: string) => { getAttribute: (name: string) => string | null } | null;
+};
+
+/**
+ * URLがCSS-Tricksのドメインかどうかを検証する
+ *
+ * @param hostname - 検証対象のホスト名
+ * @returns CSS-Tricksドメインの場合true
+ */
+function isCssTricksDomain(hostname: string): boolean {
+  return hostname === CSS_TRICKS_HOSTNAME || hostname.endsWith(`.${CSS_TRICKS_HOSTNAME}`);
+}
+
+/**
+ * HTMLからOGPメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param property - metaタグのproperty属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaContent(doc: LinkedomDocument, property: string): string | null {
+  const meta = doc.querySelector(`meta[property="${property}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * HTMLからname属性のメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param name - metaタグのname属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaNameContent(doc: LinkedomDocument, name: string): string | null {
+  const meta = doc.querySelector(`meta[name="${name}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * 文字数から読了時間を計算する
+ *
+ * @param text - 本文テキスト
+ * @returns 推定読了時間（分、最小1分）
+ */
+function calculateReadingTime(text: string): number {
+  const charCount = text.length;
+  const minutes = Math.ceil(charCount / READING_SPEED_CHARS_PER_MIN);
+  return Math.max(minutes, MIN_READING_TIME_MINUTES);
+}
+
+/**
+ * CSS-Tricks記事URLからHTML取得 → Readability本文抽出 → Markdown変換するパーサー
+ *
+ * 対応ドメイン: css-tricks.com, www.css-tricks.com
+ *
+ * @param url - CSS-Tricks記事のURL
+ * @returns パースされた記事情報
+ * @throws Error - URLがCSS-Tricksでない、HTML取得失敗、本文抽出失敗の場合
+ */
+export async function parseCssTricks(url: string): Promise<ParsedArticle> {
+  const parsed = new URL(url);
+
+  if (!isCssTricksDomain(parsed.hostname)) {
+    throw new Error("CSS-TricksのURLではありません");
+  }
+
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`CSS-Tricks記事の取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+
+  const reader = new Readability(document);
+  const article = reader.parse();
+
+  if (!article?.content) {
+    throw new Error("CSS-Tricks記事の本文の抽出に失敗しました");
+  }
+
+  const turndown = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
+  const markdown = turndown.turndown(article.content);
+
+  const { document: originalDoc } = parseHTML(html);
+  const doc = originalDoc as unknown as LinkedomDocument;
+  const thumbnailUrl = getMetaContent(doc, "og:image");
+  const author = getMetaNameContent(doc, "author") ?? getMetaContent(doc, "article:author");
+  const publishedAt = getMetaContent(doc, "article:published_time");
+
+  const title = article.title ?? "";
+  const textContent = article.textContent ?? "";
+
+  return {
+    title,
+    author,
+    content: markdown,
+    excerpt: article.excerpt ?? null,
+    thumbnailUrl,
+    readingTimeMinutes: calculateReadingTime(textContent),
+    publishedAt,
+    source: parsed.hostname,
+  };
+}

--- a/apps/api/src/services/parsers/freecodecamp.test.ts
+++ b/apps/api/src/services/parsers/freecodecamp.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseFreecodecamp } from "./freecodecamp";
+
+/** freeCodeCamp記事のHTMLテンプレート */
+const SAMPLE_FREECODECAMP_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>How to Build a REST API with Node.js</title>
+  <meta property="og:title" content="How to Build a REST API with Node.js" />
+  <meta property="og:image" content="https://www.freecodecamp.org/news/content/images/2024/01/rest-api-cover.png" />
+  <meta property="article:author" content="https://www.freecodecamp.org/news/author/testauthor/" />
+  <meta property="article:published_time" content="2024-07-20T09:00:00.000Z" />
+  <meta name="author" content="fccテスト著者" />
+</head>
+<body>
+  <article>
+    <h1>How to Build a REST API with Node.js</h1>
+    <p>In this tutorial, you will learn how to build a RESTful API using Node.js and Express.</p>
+    <p>REST APIs are the backbone of modern web applications.</p>
+    <h2>Prerequisites</h2>
+    <p>Before we start, make sure you have Node.js installed on your machine.</p>
+    <p>You should also be familiar with JavaScript fundamentals.</p>
+    <p>Let's get started with our project setup.</p>
+  </article>
+</body>
+</html>
+`;
+
+/** OGPメタタグなしのHTML */
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>最小限のfreeCodeCamp記事</title>
+</head>
+<body>
+  <article>
+    <h1>最小限のfreeCodeCamp記事</h1>
+    <p>メタ情報のない記事です。本文のみ含まれています。</p>
+    <p>Readabilityが認識できるように複数の段落を用意します。</p>
+    <p>段落を追加してコンテンツ量を確保します。</p>
+    <p>さらに追加の段落でボリュームを増やします。</p>
+    <p>最後の段落です。パーサーのテストに使用します。</p>
+  </article>
+</body>
+</html>
+`;
+
+/** 本文が空のHTML */
+const EMPTY_CONTENT_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>空の記事</title></head>
+<body></body>
+</html>
+`;
+
+/** fetchのモック */
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseFreecodecamp", () => {
+  describe("URL検証", () => {
+    it("freeCodeCamp以外のURLの場合エラーになること", async () => {
+      // Arrange
+      const url = "https://example.com/article";
+
+      // Act & Assert
+      await expect(parseFreecodecamp(url)).rejects.toThrow("freeCodeCampのURLではありません");
+    });
+
+    it("www.freecodecamp.orgドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.source).toBe("www.freecodecamp.org");
+    });
+
+    it("freecodecamp.orgドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.source).toBe("freecodecamp.org");
+    });
+  });
+
+  describe("正常系", () => {
+    it("記事のタイトルを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.title).toBe("How to Build a REST API with Node.js");
+    });
+
+    it("記事本文をMarkdown形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.content).toContain("RESTful API");
+    });
+
+    it("OGPメタタグからサムネイルURLを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.thumbnailUrl).toBe(
+        "https://www.freecodecamp.org/news/content/images/2024/01/rest-api-cover.png",
+      );
+    });
+
+    it("metaタグから著者名を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.author).toBe("fccテスト著者");
+    });
+
+    it("公開日をISO 8601形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.publishedAt).toBe("2024-07-20T09:00:00.000Z");
+    });
+
+    it("読了時間が1分以上で計算されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("OGPメタタグなし", () => {
+    it("メタタグがない場合でも記事を抽出できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(MINIMAL_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/minimal-article/";
+
+      // Act
+      const result = await parseFreecodecamp(url);
+
+      // Assert
+      expect(result.title).toBe("最小限のfreeCodeCamp記事");
+      expect(result.content).toContain("メタ情報のない記事");
+      expect(result.thumbnailUrl).toBeNull();
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+    });
+  });
+
+  describe("異常系", () => {
+    it("fetchが失敗した場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+      const url = "https://www.freecodecamp.org/news/not-found/";
+
+      // Act & Assert
+      await expect(parseFreecodecamp(url)).rejects.toThrow("freeCodeCamp記事の取得に失敗しました");
+    });
+
+    it("本文が抽出できない場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(EMPTY_CONTENT_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/empty/";
+
+      // Act & Assert
+      await expect(parseFreecodecamp(url)).rejects.toThrow(
+        "freeCodeCamp記事の本文の抽出に失敗しました",
+      );
+    });
+
+    it("ネットワークエラーの場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+      const url = "https://www.freecodecamp.org/news/error/";
+
+      // Act & Assert
+      await expect(parseFreecodecamp(url)).rejects.toThrow();
+    });
+  });
+
+  describe("fetchリクエスト", () => {
+    it("User-Agentヘッダーを送信すること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_FREECODECAMP_HTML),
+      });
+      const url = "https://www.freecodecamp.org/news/how-to-build-rest-api/";
+
+      // Act
+      await parseFreecodecamp(url);
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "User-Agent": expect.stringContaining("TechClipBot"),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/services/parsers/freecodecamp.ts
+++ b/apps/api/src/services/parsers/freecodecamp.ts
@@ -1,0 +1,140 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import TurndownService from "turndown";
+
+import type { ParsedArticle } from "../../types/article";
+
+/** freeCodeCampのホスト名 */
+const FREECODECAMP_HOSTNAME = "freecodecamp.org";
+
+/** fetch時のUser-Agent */
+const USER_AGENT = "Mozilla/5.0 (compatible; TechClipBot/1.0; +https://techclip.app)";
+
+/** 読了速度（文字/分） */
+const READING_SPEED_CHARS_PER_MIN = 500;
+
+/** 最小読了時間（分） */
+const MIN_READING_TIME_MINUTES = 1;
+
+/**
+ * linkedomのドキュメント型
+ *
+ * Cloudflare Workers環境にはDOM型が存在しないため、
+ * linkedomが返すドキュメントオブジェクトの必要なインターフェースのみ定義する
+ */
+type LinkedomDocument = {
+  querySelector: (selector: string) => { getAttribute: (name: string) => string | null } | null;
+};
+
+/**
+ * URLがfreeCodeCampのドメインかどうかを検証する
+ *
+ * @param hostname - 検証対象のホスト名
+ * @returns freeCodeCampドメインの場合true
+ */
+function isFreecodecampDomain(hostname: string): boolean {
+  return hostname === FREECODECAMP_HOSTNAME || hostname.endsWith(`.${FREECODECAMP_HOSTNAME}`);
+}
+
+/**
+ * HTMLからOGPメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param property - metaタグのproperty属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaContent(doc: LinkedomDocument, property: string): string | null {
+  const meta = doc.querySelector(`meta[property="${property}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * HTMLからname属性のメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param name - metaタグのname属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaNameContent(doc: LinkedomDocument, name: string): string | null {
+  const meta = doc.querySelector(`meta[name="${name}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * 文字数から読了時間を計算する
+ *
+ * @param text - 本文テキスト
+ * @returns 推定読了時間（分、最小1分）
+ */
+function calculateReadingTime(text: string): number {
+  const charCount = text.length;
+  const minutes = Math.ceil(charCount / READING_SPEED_CHARS_PER_MIN);
+  return Math.max(minutes, MIN_READING_TIME_MINUTES);
+}
+
+/**
+ * freeCodeCamp記事URLからHTML取得 → Readability本文抽出 → Markdown変換するパーサー
+ *
+ * 対応ドメイン: freecodecamp.org, www.freecodecamp.org
+ *
+ * @param url - freeCodeCamp記事のURL
+ * @returns パースされた記事情報
+ * @throws Error - URLがfreeCodeCampでない、HTML取得失敗、本文抽出失敗の場合
+ */
+export async function parseFreecodecamp(url: string): Promise<ParsedArticle> {
+  const parsed = new URL(url);
+
+  if (!isFreecodecampDomain(parsed.hostname)) {
+    throw new Error("freeCodeCampのURLではありません");
+  }
+
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`freeCodeCamp記事の取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+
+  const reader = new Readability(document);
+  const article = reader.parse();
+
+  if (!article?.content) {
+    throw new Error("freeCodeCamp記事の本文の抽出に失敗しました");
+  }
+
+  const turndown = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
+  const markdown = turndown.turndown(article.content);
+
+  const { document: originalDoc } = parseHTML(html);
+  const doc = originalDoc as unknown as LinkedomDocument;
+  const thumbnailUrl = getMetaContent(doc, "og:image");
+  const author = getMetaNameContent(doc, "author") ?? getMetaContent(doc, "article:author");
+  const publishedAt = getMetaContent(doc, "article:published_time");
+
+  const title = article.title ?? "";
+  const textContent = article.textContent ?? "";
+
+  return {
+    title,
+    author,
+    content: markdown,
+    excerpt: article.excerpt ?? null,
+    thumbnailUrl,
+    readingTimeMinutes: calculateReadingTime(textContent),
+    publishedAt,
+    source: parsed.hostname,
+  };
+}

--- a/apps/api/src/services/parsers/logrocket.test.ts
+++ b/apps/api/src/services/parsers/logrocket.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseLogrocket } from "./logrocket";
+
+/** LogRocket記事のHTMLテンプレート */
+const SAMPLE_LOGROCKET_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>A complete guide to React Hooks</title>
+  <meta property="og:title" content="A complete guide to React Hooks" />
+  <meta property="og:image" content="https://blog.logrocket.com/wp-content/uploads/2024/02/react-hooks-guide.png" />
+  <meta property="article:author" content="https://blog.logrocket.com/author/testauthor/" />
+  <meta property="article:published_time" content="2024-06-15T14:00:00.000Z" />
+  <meta name="author" content="LogRocketテスト著者" />
+</head>
+<body>
+  <article>
+    <h1>A complete guide to React Hooks</h1>
+    <p>React Hooks revolutionized the way we write React components.</p>
+    <p>In this comprehensive guide, we will explore all the built-in hooks.</p>
+    <h2>useState</h2>
+    <p>The useState hook allows you to add state to functional components.</p>
+    <p>It returns an array with two elements: the current state and a function to update it.</p>
+    <p>This is the most commonly used hook in React applications.</p>
+  </article>
+</body>
+</html>
+`;
+
+/** OGPメタタグなしのHTML */
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>最小限のLogRocket記事</title>
+</head>
+<body>
+  <article>
+    <h1>最小限のLogRocket記事</h1>
+    <p>メタ情報のない記事です。本文のみ含まれています。</p>
+    <p>Readabilityが認識できるように複数の段落を用意します。</p>
+    <p>段落を追加してコンテンツ量を確保します。</p>
+    <p>さらに追加の段落でボリュームを増やします。</p>
+    <p>最後の段落です。パーサーのテストに使用します。</p>
+  </article>
+</body>
+</html>
+`;
+
+/** 本文が空のHTML */
+const EMPTY_CONTENT_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>空の記事</title></head>
+<body></body>
+</html>
+`;
+
+/** fetchのモック */
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseLogrocket", () => {
+  describe("URL検証", () => {
+    it("LogRocket以外のURLの場合エラーになること", async () => {
+      // Arrange
+      const url = "https://example.com/article";
+
+      // Act & Assert
+      await expect(parseLogrocket(url)).rejects.toThrow("LogRocketのURLではありません");
+    });
+
+    it("blog.logrocket.comドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.source).toBe("blog.logrocket.com");
+    });
+  });
+
+  describe("正常系", () => {
+    it("記事のタイトルを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.title).toBe("A complete guide to React Hooks");
+    });
+
+    it("記事本文をMarkdown形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.content).toContain("React Hooks");
+    });
+
+    it("OGPメタタグからサムネイルURLを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.thumbnailUrl).toBe(
+        "https://blog.logrocket.com/wp-content/uploads/2024/02/react-hooks-guide.png",
+      );
+    });
+
+    it("metaタグから著者名を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.author).toBe("LogRocketテスト著者");
+    });
+
+    it("公開日をISO 8601形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.publishedAt).toBe("2024-06-15T14:00:00.000Z");
+    });
+
+    it("読了時間が1分以上で計算されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("OGPメタタグなし", () => {
+    it("メタタグがない場合でも記事を抽出できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(MINIMAL_HTML),
+      });
+      const url = "https://blog.logrocket.com/minimal-article/";
+
+      // Act
+      const result = await parseLogrocket(url);
+
+      // Assert
+      expect(result.title).toBe("最小限のLogRocket記事");
+      expect(result.content).toContain("メタ情報のない記事");
+      expect(result.thumbnailUrl).toBeNull();
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+    });
+  });
+
+  describe("異常系", () => {
+    it("fetchが失敗した場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+      const url = "https://blog.logrocket.com/not-found/";
+
+      // Act & Assert
+      await expect(parseLogrocket(url)).rejects.toThrow("LogRocket記事の取得に失敗しました");
+    });
+
+    it("本文が抽出できない場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(EMPTY_CONTENT_HTML),
+      });
+      const url = "https://blog.logrocket.com/empty/";
+
+      // Act & Assert
+      await expect(parseLogrocket(url)).rejects.toThrow("LogRocket記事の本文の抽出に失敗しました");
+    });
+
+    it("ネットワークエラーの場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+      const url = "https://blog.logrocket.com/error/";
+
+      // Act & Assert
+      await expect(parseLogrocket(url)).rejects.toThrow();
+    });
+  });
+
+  describe("fetchリクエスト", () => {
+    it("User-Agentヘッダーを送信すること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_LOGROCKET_HTML),
+      });
+      const url = "https://blog.logrocket.com/complete-guide-react-hooks/";
+
+      // Act
+      await parseLogrocket(url);
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "User-Agent": expect.stringContaining("TechClipBot"),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/services/parsers/logrocket.ts
+++ b/apps/api/src/services/parsers/logrocket.ts
@@ -1,0 +1,140 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import TurndownService from "turndown";
+
+import type { ParsedArticle } from "../../types/article";
+
+/** LogRocketブログのホスト名 */
+const LOGROCKET_HOSTNAME = "blog.logrocket.com";
+
+/** fetch時のUser-Agent */
+const USER_AGENT = "Mozilla/5.0 (compatible; TechClipBot/1.0; +https://techclip.app)";
+
+/** 読了速度（文字/分） */
+const READING_SPEED_CHARS_PER_MIN = 500;
+
+/** 最小読了時間（分） */
+const MIN_READING_TIME_MINUTES = 1;
+
+/**
+ * linkedomのドキュメント型
+ *
+ * Cloudflare Workers環境にはDOM型が存在しないため、
+ * linkedomが返すドキュメントオブジェクトの必要なインターフェースのみ定義する
+ */
+type LinkedomDocument = {
+  querySelector: (selector: string) => { getAttribute: (name: string) => string | null } | null;
+};
+
+/**
+ * URLがLogRocketブログのドメインかどうかを検証する
+ *
+ * @param hostname - 検証対象のホスト名
+ * @returns LogRocketブログドメインの場合true
+ */
+function isLogrocketDomain(hostname: string): boolean {
+  return hostname === LOGROCKET_HOSTNAME;
+}
+
+/**
+ * HTMLからOGPメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param property - metaタグのproperty属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaContent(doc: LinkedomDocument, property: string): string | null {
+  const meta = doc.querySelector(`meta[property="${property}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * HTMLからname属性のメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param name - metaタグのname属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaNameContent(doc: LinkedomDocument, name: string): string | null {
+  const meta = doc.querySelector(`meta[name="${name}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * 文字数から読了時間を計算する
+ *
+ * @param text - 本文テキスト
+ * @returns 推定読了時間（分、最小1分）
+ */
+function calculateReadingTime(text: string): number {
+  const charCount = text.length;
+  const minutes = Math.ceil(charCount / READING_SPEED_CHARS_PER_MIN);
+  return Math.max(minutes, MIN_READING_TIME_MINUTES);
+}
+
+/**
+ * LogRocketブログ記事URLからHTML取得 → Readability本文抽出 → Markdown変換するパーサー
+ *
+ * 対応ドメイン: blog.logrocket.com
+ *
+ * @param url - LogRocketブログ記事のURL
+ * @returns パースされた記事情報
+ * @throws Error - URLがLogRocketでない、HTML取得失敗、本文抽出失敗の場合
+ */
+export async function parseLogrocket(url: string): Promise<ParsedArticle> {
+  const parsed = new URL(url);
+
+  if (!isLogrocketDomain(parsed.hostname)) {
+    throw new Error("LogRocketのURLではありません");
+  }
+
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`LogRocket記事の取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+
+  const reader = new Readability(document);
+  const article = reader.parse();
+
+  if (!article?.content) {
+    throw new Error("LogRocket記事の本文の抽出に失敗しました");
+  }
+
+  const turndown = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
+  const markdown = turndown.turndown(article.content);
+
+  const { document: originalDoc } = parseHTML(html);
+  const doc = originalDoc as unknown as LinkedomDocument;
+  const thumbnailUrl = getMetaContent(doc, "og:image");
+  const author = getMetaNameContent(doc, "author") ?? getMetaContent(doc, "article:author");
+  const publishedAt = getMetaContent(doc, "article:published_time");
+
+  const title = article.title ?? "";
+  const textContent = article.textContent ?? "";
+
+  return {
+    title,
+    author,
+    content: markdown,
+    excerpt: article.excerpt ?? null,
+    thumbnailUrl,
+    readingTimeMinutes: calculateReadingTime(textContent),
+    publishedAt,
+    source: parsed.hostname,
+  };
+}

--- a/apps/api/src/services/parsers/smashing.test.ts
+++ b/apps/api/src/services/parsers/smashing.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseSmashing } from "./smashing";
+
+/** Smashing Magazine記事のHTMLテンプレート */
+const SAMPLE_SMASHING_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Modern CSS Solutions for Old CSS Problems</title>
+  <meta property="og:title" content="Modern CSS Solutions for Old CSS Problems" />
+  <meta property="og:image" content="https://www.smashingmagazine.com/images/2024/04/modern-css-solutions.png" />
+  <meta property="article:author" content="https://www.smashingmagazine.com/author/testauthor/" />
+  <meta property="article:published_time" content="2024-04-25T10:00:00.000Z" />
+  <meta name="author" content="Smashingテスト著者" />
+</head>
+<body>
+  <article>
+    <h1>Modern CSS Solutions for Old CSS Problems</h1>
+    <p>CSS has evolved dramatically over the past few years.</p>
+    <p>Many common problems that required JavaScript or complex workarounds can now be solved with pure CSS.</p>
+    <h2>Container Queries</h2>
+    <p>Container queries allow you to style elements based on their container size.</p>
+    <p>This is a game-changer for component-based design systems.</p>
+    <p>Let's explore how to use them effectively in your projects.</p>
+  </article>
+</body>
+</html>
+`;
+
+/** OGPメタタグなしのHTML */
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>最小限のSmashing Magazine記事</title>
+</head>
+<body>
+  <article>
+    <h1>最小限のSmashing Magazine記事</h1>
+    <p>メタ情報のない記事です。本文のみ含まれています。</p>
+    <p>Readabilityが認識できるように複数の段落を用意します。</p>
+    <p>段落を追加してコンテンツ量を確保します。</p>
+    <p>さらに追加の段落でボリュームを増やします。</p>
+    <p>最後の段落です。パーサーのテストに使用します。</p>
+  </article>
+</body>
+</html>
+`;
+
+/** 本文が空のHTML */
+const EMPTY_CONTENT_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>空の記事</title></head>
+<body></body>
+</html>
+`;
+
+/** fetchのモック */
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseSmashing", () => {
+  describe("URL検証", () => {
+    it("Smashing Magazine以外のURLの場合エラーになること", async () => {
+      // Arrange
+      const url = "https://example.com/article";
+
+      // Act & Assert
+      await expect(parseSmashing(url)).rejects.toThrow("Smashing MagazineのURLではありません");
+    });
+
+    it("www.smashingmagazine.comドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.source).toBe("www.smashingmagazine.com");
+    });
+
+    it("smashingmagazine.comドメインを受け付けること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.source).toBe("smashingmagazine.com");
+    });
+  });
+
+  describe("正常系", () => {
+    it("記事のタイトルを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.title).toBe("Modern CSS Solutions for Old CSS Problems");
+    });
+
+    it("記事本文をMarkdown形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.content).toContain("Container Queries");
+    });
+
+    it("OGPメタタグからサムネイルURLを取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.thumbnailUrl).toBe(
+        "https://www.smashingmagazine.com/images/2024/04/modern-css-solutions.png",
+      );
+    });
+
+    it("metaタグから著者名を取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.author).toBe("Smashingテスト著者");
+    });
+
+    it("公開日をISO 8601形式で取得できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.publishedAt).toBe("2024-04-25T10:00:00.000Z");
+    });
+
+    it("読了時間が1分以上で計算されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("OGPメタタグなし", () => {
+    it("メタタグがない場合でも記事を抽出できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(MINIMAL_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/minimal-article/";
+
+      // Act
+      const result = await parseSmashing(url);
+
+      // Assert
+      expect(result.title).toBe("最小限のSmashing Magazine記事");
+      expect(result.content).toContain("メタ情報のない記事");
+      expect(result.thumbnailUrl).toBeNull();
+      expect(result.author).toBeNull();
+      expect(result.publishedAt).toBeNull();
+    });
+  });
+
+  describe("異常系", () => {
+    it("fetchが失敗した場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/not-found/";
+
+      // Act & Assert
+      await expect(parseSmashing(url)).rejects.toThrow("Smashing Magazine記事の取得に失敗しました");
+    });
+
+    it("本文が抽出できない場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(EMPTY_CONTENT_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/empty/";
+
+      // Act & Assert
+      await expect(parseSmashing(url)).rejects.toThrow(
+        "Smashing Magazine記事の本文の抽出に失敗しました",
+      );
+    });
+
+    it("ネットワークエラーの場合エラーになること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+      const url = "https://www.smashingmagazine.com/2024/04/error/";
+
+      // Act & Assert
+      await expect(parseSmashing(url)).rejects.toThrow();
+    });
+  });
+
+  describe("fetchリクエスト", () => {
+    it("User-Agentヘッダーを送信すること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_SMASHING_HTML),
+      });
+      const url = "https://www.smashingmagazine.com/2024/04/modern-css-solutions/";
+
+      // Act
+      await parseSmashing(url);
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "User-Agent": expect.stringContaining("TechClipBot"),
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/api/src/services/parsers/smashing.ts
+++ b/apps/api/src/services/parsers/smashing.ts
@@ -1,0 +1,140 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+import TurndownService from "turndown";
+
+import type { ParsedArticle } from "../../types/article";
+
+/** Smashing Magazineのホスト名 */
+const SMASHING_HOSTNAME = "smashingmagazine.com";
+
+/** fetch時のUser-Agent */
+const USER_AGENT = "Mozilla/5.0 (compatible; TechClipBot/1.0; +https://techclip.app)";
+
+/** 読了速度（文字/分） */
+const READING_SPEED_CHARS_PER_MIN = 500;
+
+/** 最小読了時間（分） */
+const MIN_READING_TIME_MINUTES = 1;
+
+/**
+ * linkedomのドキュメント型
+ *
+ * Cloudflare Workers環境にはDOM型が存在しないため、
+ * linkedomが返すドキュメントオブジェクトの必要なインターフェースのみ定義する
+ */
+type LinkedomDocument = {
+  querySelector: (selector: string) => { getAttribute: (name: string) => string | null } | null;
+};
+
+/**
+ * URLがSmashing Magazineのドメインかどうかを検証する
+ *
+ * @param hostname - 検証対象のホスト名
+ * @returns Smashing Magazineドメインの場合true
+ */
+function isSmashingDomain(hostname: string): boolean {
+  return hostname === SMASHING_HOSTNAME || hostname.endsWith(`.${SMASHING_HOSTNAME}`);
+}
+
+/**
+ * HTMLからOGPメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param property - metaタグのproperty属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaContent(doc: LinkedomDocument, property: string): string | null {
+  const meta = doc.querySelector(`meta[property="${property}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * HTMLからname属性のメタタグの値を取得する
+ *
+ * @param doc - linkedomのドキュメントオブジェクト
+ * @param name - metaタグのname属性値
+ * @returns メタタグのcontent値。存在しない場合はnull
+ */
+function getMetaNameContent(doc: LinkedomDocument, name: string): string | null {
+  const meta = doc.querySelector(`meta[name="${name}"]`);
+  if (!meta) {
+    return null;
+  }
+  return meta.getAttribute("content");
+}
+
+/**
+ * 文字数から読了時間を計算する
+ *
+ * @param text - 本文テキスト
+ * @returns 推定読了時間（分、最小1分）
+ */
+function calculateReadingTime(text: string): number {
+  const charCount = text.length;
+  const minutes = Math.ceil(charCount / READING_SPEED_CHARS_PER_MIN);
+  return Math.max(minutes, MIN_READING_TIME_MINUTES);
+}
+
+/**
+ * Smashing Magazine記事URLからHTML取得 → Readability本文抽出 → Markdown変換するパーサー
+ *
+ * 対応ドメイン: smashingmagazine.com, www.smashingmagazine.com
+ *
+ * @param url - Smashing Magazine記事のURL
+ * @returns パースされた記事情報
+ * @throws Error - URLがSmashing Magazineでない、HTML取得失敗、本文抽出失敗の場合
+ */
+export async function parseSmashing(url: string): Promise<ParsedArticle> {
+  const parsed = new URL(url);
+
+  if (!isSmashingDomain(parsed.hostname)) {
+    throw new Error("Smashing MagazineのURLではありません");
+  }
+
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Smashing Magazine記事の取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+
+  const reader = new Readability(document);
+  const article = reader.parse();
+
+  if (!article?.content) {
+    throw new Error("Smashing Magazine記事の本文の抽出に失敗しました");
+  }
+
+  const turndown = new TurndownService({
+    headingStyle: "atx",
+    codeBlockStyle: "fenced",
+  });
+  const markdown = turndown.turndown(article.content);
+
+  const { document: originalDoc } = parseHTML(html);
+  const doc = originalDoc as unknown as LinkedomDocument;
+  const thumbnailUrl = getMetaContent(doc, "og:image");
+  const author = getMetaNameContent(doc, "author") ?? getMetaContent(doc, "article:author");
+  const publishedAt = getMetaContent(doc, "article:published_time");
+
+  const title = article.title ?? "";
+  const textContent = article.textContent ?? "";
+
+  return {
+    title,
+    author,
+    content: markdown,
+    excerpt: article.excerpt ?? null,
+    thumbnailUrl,
+    readingTimeMinutes: calculateReadingTime(textContent),
+    publishedAt,
+    source: parsed.hostname,
+  };
+}


### PR DESCRIPTION
## Summary
- Add 4 site-specific parsers: freeCodeCamp, LogRocket, CSS-Tricks, Smashing Magazine
- All follow the HTML + Readability + Turndown pattern (fetch HTML, extract with Readability, convert to Markdown)
- Each parser includes domain validation, OGP metadata extraction, reading time calculation

## Test plan
- [x] All 4 parsers have comprehensive test suites (URL validation, normal flow, OGP metadata, error cases)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @tech-clip/api test` passes (340 tests)

Closes #56

🤖 Generated with [Claude Code](https://claude.ai/code)