### PR TITLE
feat: add GET/PATCH /api/users/me profile API

### DIFF
--- a/apps/api/src/routes/users.test.ts
+++ b/apps/api/src/routes/users.test.ts
@@ -1,0 +1,641 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createUsersRoute } from "./users";
+
+/** テスト用のモックユーザー */
+const MOCK_USER = {
+  id: "user_01HXYZ",
+  email: "test@example.com",
+  name: "テストユーザー",
+  image: null,
+  emailVerified: true,
+  username: "testuser",
+  bio: "テスト用のプロフィールです",
+  websiteUrl: "https://example.com",
+  githubUsername: "testuser",
+  twitterUsername: "testuser",
+  avatarUrl: null,
+  isProfilePublic: true,
+  preferredLanguage: "ja",
+  isPremium: false,
+  premiumExpiresAt: null,
+  freeAiUsesRemaining: 5,
+  freeAiResetAt: null,
+  pushToken: null,
+  pushEnabled: true,
+  createdAt: "2024-01-15T00:00:00Z",
+  updatedAt: "2024-01-15T00:00:00Z",
+};
+
+/** HTTP 200 OK ステータスコード */
+const HTTP_OK = 200;
+
+/** HTTP 401 Unauthorized ステータスコード */
+const HTTP_UNAUTHORIZED = 401;
+
+/** HTTP 404 Not Found ステータスコード */
+const HTTP_NOT_FOUND = 404;
+
+/** HTTP 422 Unprocessable Entity ステータスコード */
+const HTTP_UNPROCESSABLE_ENTITY = 422;
+
+/** HTTP 409 Conflict ステータスコード */
+const HTTP_CONFLICT = 409;
+
+/** エラーレスポンスの型定義 */
+type ErrorResponseBody = {
+  success: boolean;
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+};
+
+/** 成功レスポンスの型定義 */
+type UserResponseBody = {
+  success: boolean;
+  data?: Record<string, unknown>;
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+};
+
+/** モックのDB操作関数 */
+const mockSelectFrom = vi.fn();
+const mockSelectWhere = vi.fn();
+const mockSelect = vi.fn().mockReturnValue({
+  from: mockSelectFrom,
+});
+
+const mockUpdateSet = vi.fn();
+const mockUpdateWhere = vi.fn();
+const mockUpdateReturning = vi.fn();
+const mockUpdate = vi.fn().mockReturnValue({
+  set: mockUpdateSet,
+});
+
+/** モックのDBインスタンス */
+const mockDb = {
+  select: mockSelect,
+  update: mockUpdate,
+};
+
+/**
+ * GET テスト用Honoアプリを作成する（認証済み）
+ *
+ * @returns テスト用Honoアプリ
+ */
+function createGetTestApp() {
+  type Variables = {
+    user: typeof MOCK_USER;
+    session: Record<string, unknown>;
+  };
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.use("*", (c, next) => {
+    c.set("user", MOCK_USER);
+    c.set("session", { id: "session_01" });
+    return next();
+  });
+
+  const usersRoute = createUsersRoute({ db: mockDb as never });
+  app.route("/api/users", usersRoute);
+
+  return app;
+}
+
+/**
+ * GET テスト用Honoアプリを作成する（未認証）
+ *
+ * @returns テスト用Honoアプリ（認証ミドルウェアなし）
+ */
+function createGetTestAppWithoutAuth() {
+  const app = new Hono();
+
+  const usersRoute = createUsersRoute({ db: mockDb as never });
+  app.route("/api/users", usersRoute);
+
+  return app;
+}
+
+/**
+ * PATCH リクエストを送信するヘルパー
+ */
+function patchUser(app: { request: Hono["request"] }, body: Record<string, unknown>) {
+  return app.request("/api/users/me", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/users/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("認証", () => {
+    it("認証済みユーザーが自分のプロフィールを取得できること", async () => {
+      // Arrange
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        id: MOCK_USER.id,
+        email: MOCK_USER.email,
+        name: MOCK_USER.name,
+      });
+    });
+
+    it("未認証の場合401が返ること", async () => {
+      // Arrange
+      const app = createGetTestAppWithoutAuth();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_REQUIRED");
+    });
+  });
+
+  describe("レスポンス形式", () => {
+    it("統一レスポンス形式に従っていること", async () => {
+      // Arrange
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body).toHaveProperty("success", true);
+      expect(body).toHaveProperty("data");
+    });
+
+    it("Content-Typeがapplication/jsonであること", async () => {
+      // Arrange
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      expect(res.headers.get("Content-Type")).toContain("application/json");
+    });
+
+    it("機密情報がレスポンスに含まれないこと", async () => {
+      // Arrange
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.data).not.toHaveProperty("pushToken");
+      expect(body.data).not.toHaveProperty("freeAiResetAt");
+    });
+
+    it("プロフィールフィールドがレスポンスに含まれること", async () => {
+      // Arrange
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.data).toHaveProperty("username");
+      expect(body.data).toHaveProperty("bio");
+      expect(body.data).toHaveProperty("websiteUrl");
+      expect(body.data).toHaveProperty("githubUsername");
+      expect(body.data).toHaveProperty("twitterUsername");
+    });
+  });
+
+  describe("ユーザー未存在", () => {
+    it("DBにユーザーが存在しない場合404が返ること", async () => {
+      // Arrange
+      mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+      mockSelectWhere.mockResolvedValue([]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await app.request("/api/users/me");
+
+      // Assert
+      expect(res.status).toBe(HTTP_NOT_FOUND);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("NOT_FOUND");
+    });
+  });
+});
+
+describe("PATCH /api/users/me", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+    mockSelectWhere.mockResolvedValue([MOCK_USER]);
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
+  });
+
+  describe("認証", () => {
+    it("未認証の場合401が返ること", async () => {
+      // Arrange
+      const app = createGetTestAppWithoutAuth();
+
+      // Act
+      const res = await patchUser(app, { name: "新しい名前" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_REQUIRED");
+    });
+  });
+
+  describe("正常系", () => {
+    it("nameを更新できること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, name: "新しい名前" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { name: "新しい名前" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ name: "新しい名前" });
+    });
+
+    it("usernameを更新できること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, username: "newusername" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { username: "newusername" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ username: "newusername" });
+    });
+
+    it("bioを更新できること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, bio: "新しい自己紹介" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { bio: "新しい自己紹介" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ bio: "新しい自己紹介" });
+    });
+
+    it("websiteUrlを更新できること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, websiteUrl: "https://new-site.com" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { websiteUrl: "https://new-site.com" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ websiteUrl: "https://new-site.com" });
+    });
+
+    it("複数フィールドを同時に更新できること", async () => {
+      // Arrange
+      const updatedUser = {
+        ...MOCK_USER,
+        name: "新しい名前",
+        bio: "新しい自己紹介",
+        websiteUrl: "https://new-site.com",
+      };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, {
+        name: "新しい名前",
+        bio: "新しい自己紹介",
+        websiteUrl: "https://new-site.com",
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        name: "新しい名前",
+        bio: "新しい自己紹介",
+        websiteUrl: "https://new-site.com",
+      });
+    });
+
+    it("githubUsernameを更新できること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, githubUsername: "newgithub" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { githubUsername: "newgithub" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ githubUsername: "newgithub" });
+    });
+
+    it("twitterUsernameを更新できること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, twitterUsername: "newtwitter" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { twitterUsername: "newtwitter" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ twitterUsername: "newtwitter" });
+    });
+
+    it("nullを設定してフィールドをクリアできること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, bio: null, websiteUrl: null };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { bio: null, websiteUrl: null });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ bio: null, websiteUrl: null });
+    });
+  });
+
+  describe("バリデーションエラー", () => {
+    it("nameが100文字を超える場合422が返ること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+      const longName = "あ".repeat(101);
+
+      // Act
+      const res = await patchUser(app, { name: longName });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("usernameが30文字を超える場合422が返ること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+      const longUsername = "a".repeat(31);
+
+      // Act
+      const res = await patchUser(app, { username: longUsername });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("usernameに不正な文字が含まれる場合422が返ること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { username: "user name!" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("bioが500文字を超える場合422が返ること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+      const longBio = "あ".repeat(501);
+
+      // Act
+      const res = await patchUser(app, { bio: longBio });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("websiteUrlが不正な形式の場合422が返ること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { websiteUrl: "not-a-url" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("更新可能でないフィールドが無視されること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, name: "新しい名前" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, {
+        name: "新しい名前",
+        email: "hacker@evil.com",
+        isPremium: true,
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({ name: "新しい名前" });
+    });
+
+    it("空のリクエストボディの場合422が返ること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, {});
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("エラーメッセージが日本語であること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { name: "あ".repeat(101) });
+
+      // Assert
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.error.message).toBe("入力内容を確認してください");
+    });
+  });
+
+  describe("username重複", () => {
+    it("usernameが他のユーザーと重複する場合409が返ること", async () => {
+      // Arrange
+      mockSelectWhere.mockResolvedValue([{ id: "other_user", username: "taken" }]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { username: "taken" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_CONFLICT);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("DUPLICATE");
+    });
+
+    it("自分自身のusernameと同じ場合は重複エラーにならないこと", async () => {
+      // Arrange
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      mockUpdateReturning.mockResolvedValue([MOCK_USER]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { username: MOCK_USER.username });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe("レスポンス形式", () => {
+    it("成功レスポンスがAPI設計規約に従った形式であること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, name: "新しい名前" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { name: "新しい名前" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as UserResponseBody;
+      expect(body).toHaveProperty("success", true);
+      expect(body).toHaveProperty("data");
+    });
+
+    it("エラーレスポンスがAPI設計規約に従った形式であること", async () => {
+      // Arrange
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { name: "あ".repeat(101) });
+
+      // Assert
+      const body = (await res.json()) as UserResponseBody;
+      expect(body).toHaveProperty("success", false);
+      expect(body).toHaveProperty("error");
+      expect(body.error).toHaveProperty("code");
+      expect(body.error).toHaveProperty("message");
+    });
+
+    it("Content-Typeがapplication/jsonであること", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, name: "新しい名前" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { name: "新しい名前" });
+
+      // Assert
+      expect(res.headers.get("Content-Type")).toContain("application/json");
+    });
+
+    it("機密情報が更新レスポンスに含まれないこと", async () => {
+      // Arrange
+      const updatedUser = { ...MOCK_USER, name: "新しい名前" };
+      mockUpdateReturning.mockResolvedValue([updatedUser]);
+      const app = createGetTestApp();
+
+      // Act
+      const res = await patchUser(app, { name: "新しい名前" });
+
+      // Assert
+      const body = (await res.json()) as UserResponseBody;
+      expect(body.data).not.toHaveProperty("pushToken");
+      expect(body.data).not.toHaveProperty("freeAiResetAt");
+    });
+  });
+});

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -1,0 +1,264 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import type { Database } from "../db";
+import { users } from "../db/schema";
+
+/** HTTP 401 Unauthorized ステータスコード */
+const HTTP_UNAUTHORIZED = 401;
+
+/** HTTP 404 Not Found ステータスコード */
+const HTTP_NOT_FOUND = 404;
+
+/** HTTP 409 Conflict ステータスコード */
+const HTTP_CONFLICT = 409;
+
+/** HTTP 422 Unprocessable Entity ステータスコード */
+const HTTP_UNPROCESSABLE_ENTITY = 422;
+
+/** 未認証エラーコード */
+const AUTH_ERROR_CODE = "AUTH_REQUIRED";
+
+/** 未認証エラーメッセージ */
+const AUTH_ERROR_MESSAGE = "ログインが必要です";
+
+/** バリデーションエラーコード */
+const VALIDATION_ERROR_CODE = "VALIDATION_FAILED";
+
+/** バリデーションエラーメッセージ */
+const VALIDATION_ERROR_MESSAGE = "入力内容を確認してください";
+
+/** 名前最大文字数 */
+const NAME_MAX_LENGTH = 100;
+
+/** ユーザー名最大文字数 */
+const USERNAME_MAX_LENGTH = 30;
+
+/** 自己紹介最大文字数 */
+const BIO_MAX_LENGTH = 500;
+
+/** URL最大文字数 */
+const URL_MAX_LENGTH = 2048;
+
+/** GitHubユーザー名最大文字数 */
+const GITHUB_USERNAME_MAX_LENGTH = 39;
+
+/** Twitterユーザー名最大文字数 */
+const TWITTER_USERNAME_MAX_LENGTH = 15;
+
+/** ユーザー名の正規表現（半角英数字とアンダースコア、ハイフンのみ） */
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+/** レスポンスから除外する機密フィールド */
+const SENSITIVE_FIELDS = [
+  "pushToken",
+  "pushEnabled",
+  "freeAiUsesRemaining",
+  "freeAiResetAt",
+  "premiumExpiresAt",
+] as const;
+
+/** プロフィール更新スキーマ */
+const UpdateProfileSchema = z.object({
+  name: z
+    .string()
+    .max(NAME_MAX_LENGTH, `名前は${NAME_MAX_LENGTH}文字以内で入力してください`)
+    .trim()
+    .nullable()
+    .optional(),
+  username: z
+    .string()
+    .max(USERNAME_MAX_LENGTH, `ユーザー名は${USERNAME_MAX_LENGTH}文字以内で入力してください`)
+    .regex(USERNAME_REGEX, "ユーザー名は半角英数字、アンダースコア、ハイフンのみ使用できます")
+    .nullable()
+    .optional(),
+  bio: z
+    .string()
+    .max(BIO_MAX_LENGTH, `自己紹介は${BIO_MAX_LENGTH}文字以内で入力してください`)
+    .nullable()
+    .optional(),
+  websiteUrl: z
+    .string()
+    .max(URL_MAX_LENGTH, `URLは${URL_MAX_LENGTH}文字以内で入力してください`)
+    .url("URLの形式が正しくありません")
+    .nullable()
+    .optional(),
+  githubUsername: z
+    .string()
+    .max(
+      GITHUB_USERNAME_MAX_LENGTH,
+      `GitHubユーザー名は${GITHUB_USERNAME_MAX_LENGTH}文字以内で入力してください`,
+    )
+    .nullable()
+    .optional(),
+  twitterUsername: z
+    .string()
+    .max(
+      TWITTER_USERNAME_MAX_LENGTH,
+      `Twitterユーザー名は${TWITTER_USERNAME_MAX_LENGTH}文字以内で入力してください`,
+    )
+    .nullable()
+    .optional(),
+  isProfilePublic: z.boolean().optional(),
+  preferredLanguage: z.string().optional(),
+});
+
+/** createUsersRouteのオプション */
+type UsersRouteOptions = {
+  db: Database;
+};
+
+/**
+ * レスポンスから機密フィールドを除外する
+ *
+ * @param user - ユーザーデータ
+ * @returns 機密情報を除いたユーザーデータ
+ */
+function omitSensitiveFields(user: Record<string, unknown>): Record<string, unknown> {
+  const result = { ...user };
+  for (const field of SENSITIVE_FIELDS) {
+    delete result[field];
+  }
+  return result;
+}
+
+/**
+ * ユーザールートを生成する
+ *
+ * GET /me: 自分のプロフィール取得
+ * PATCH /me: 自分のプロフィール更新
+ *
+ * @param options - DB インスタンス
+ * @returns Hono ルーターインスタンス
+ */
+export function createUsersRoute(options: UsersRouteOptions) {
+  const { db } = options;
+  const route = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
+
+  route.get("/me", async (c) => {
+    const user = c.get("user");
+    if (!user) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: AUTH_ERROR_CODE,
+            message: AUTH_ERROR_MESSAGE,
+          },
+        },
+        HTTP_UNAUTHORIZED,
+      );
+    }
+
+    const [found] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, user.id as string));
+
+    if (!found) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: "NOT_FOUND",
+            message: "ユーザーが見つかりません",
+          },
+        },
+        HTTP_NOT_FOUND,
+      );
+    }
+
+    return c.json({
+      success: true,
+      data: omitSensitiveFields(found as unknown as Record<string, unknown>),
+    });
+  });
+
+  route.patch("/me", async (c) => {
+    const user = c.get("user");
+    if (!user) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: AUTH_ERROR_CODE,
+            message: AUTH_ERROR_MESSAGE,
+          },
+        },
+        HTTP_UNAUTHORIZED,
+      );
+    }
+
+    const userId = user.id as string;
+
+    const body = await c.req.json().catch(() => ({}));
+    const validation = UpdateProfileSchema.safeParse(body);
+
+    if (!validation.success) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: VALIDATION_ERROR_CODE,
+            message: VALIDATION_ERROR_MESSAGE,
+            details: validation.error.issues.map((e) => ({
+              field: e.path.join("."),
+              message: e.message,
+            })),
+          },
+        },
+        HTTP_UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    const updateData = validation.data;
+
+    if (Object.keys(updateData).length === 0) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: VALIDATION_ERROR_CODE,
+            message: VALIDATION_ERROR_MESSAGE,
+            details: [{ field: "", message: "更新するフィールドを指定してください" }],
+          },
+        },
+        HTTP_UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    if (updateData.username !== undefined && updateData.username !== null) {
+      const [existing] = await db
+        .select()
+        .from(users)
+        .where(eq(users.username, updateData.username));
+
+      if (existing && (existing as unknown as Record<string, unknown>).id !== userId) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: "DUPLICATE",
+              message: "このユーザー名はすでに使用されています",
+            },
+          },
+          HTTP_CONFLICT,
+        );
+      }
+    }
+
+    const [updated] = await db
+      .update(users)
+      .set(updateData)
+      .where(eq(users.id, userId))
+      .returning();
+
+    return c.json({
+      success: true,
+      data: omitSensitiveFields(updated as unknown as Record<string, unknown>),
+    });
+  });
+
+  return route;
+}


### PR DESCRIPTION
## Summary
- GET `/api/users/me` -- 認証済みユーザーの自分のプロフィール取得（機密フィールド除外）
- PATCH `/api/users/me` -- プロフィール更新（name, username, bio, websiteUrl, githubUsername, twitterUsername等）
- Zodバリデーション、username重複チェック、認証必須、統一レスポンス形式

Closes #67

## Test plan
- [x] GET /api/users/me: 認証済みユーザーがプロフィール取得できること
- [x] GET /api/users/me: 未認証で401が返ること
- [x] GET /api/users/me: ユーザー未存在で404が返ること
- [x] GET /api/users/me: 機密情報がレスポンスに含まれないこと
- [x] PATCH /api/users/me: 各フィールド（name, username, bio, websiteUrl等）を個別・複数同時に更新できること
- [x] PATCH /api/users/me: nullでフィールドクリアできること
- [x] PATCH /api/users/me: バリデーションエラー（文字数超過、不正形式等）で422が返ること
- [x] PATCH /api/users/me: 更新不可フィールド（email, isPremium等）が無視されること
- [x] PATCH /api/users/me: username重複で409が返ること
- [x] PATCH /api/users/me: 自分自身のusernameは重複エラーにならないこと
- [x] 全テスト499件パス、typecheck・biome check クリア

🤖 Generated with [Claude Code](https://claude.ai/code)