### PR TITLE
feat: AI使用回数制限ミドルウェア #107

### DIFF
--- a/apps/api/src/middleware/ai-limit.test.ts
+++ b/apps/api/src/middleware/ai-limit.test.ts
@@ -1,0 +1,338 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createAiLimitMiddleware } from "./ai-limit";
+
+/** テスト用ユーザーID */
+const TEST_USER_ID = "user_test_01";
+
+/** テスト用プレミアムユーザーID */
+const PREMIUM_USER_ID = "user_premium_01";
+
+/** HTTP 402 Payment Required ステータスコード */
+const HTTP_PAYMENT_REQUIRED = 402;
+
+/** HTTP 200 OK ステータスコード */
+const HTTP_OK = 200;
+
+/** HTTP 401 Unauthorized ステータスコード */
+const HTTP_UNAUTHORIZED = 401;
+
+/** テスト用のフリーユーザーデータ */
+function createFreeUserData(options?: {
+  remaining?: number;
+  resetAt?: string | null;
+}) {
+  return {
+    id: TEST_USER_ID,
+    email: "test@example.com",
+    name: "テストユーザー",
+    isPremium: false,
+    freeAiUsesRemaining: options?.remaining ?? 5,
+    freeAiResetAt: options?.resetAt ?? null,
+  };
+}
+
+/** テスト用のプレミアムユーザーデータ */
+function createPremiumUserData() {
+  return {
+    id: PREMIUM_USER_ID,
+    email: "premium@example.com",
+    name: "プレミアムユーザー",
+    isPremium: true,
+    freeAiUsesRemaining: 0,
+    freeAiResetAt: null,
+  };
+}
+
+/** モックの db.select クエリ結果 */
+const mockSelectWhere = vi.fn();
+const mockSelectFrom = vi.fn().mockReturnValue({
+  where: mockSelectWhere,
+});
+const mockSelect = vi.fn().mockReturnValue({
+  from: mockSelectFrom,
+});
+
+/** モックの db.update クエリ結果 */
+const mockUpdateWhere = vi.fn();
+const mockUpdateSet = vi.fn().mockReturnValue({
+  where: mockUpdateWhere,
+});
+const mockUpdate = vi.fn().mockReturnValue({
+  set: mockUpdateSet,
+});
+
+/** モックのDBインスタンス */
+const mockDb = {
+  select: mockSelect,
+  update: mockUpdate,
+};
+
+/** テスト用のHonoアプリを作成する */
+function createTestApp(userId?: string) {
+  const app = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
+
+  if (userId) {
+    app.use("/ai/*", async (c, next) => {
+      c.set("user", { id: userId });
+      await next();
+    });
+  }
+
+  app.use("/ai/*", createAiLimitMiddleware(mockDb as never));
+  app.post("/ai/summarize", (c) => {
+    return c.json({ success: true, data: { summary: "テスト要約" } }, HTTP_OK);
+  });
+
+  return app;
+}
+
+describe("aiLimitMiddleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateWhere.mockResolvedValue(undefined);
+  });
+
+  describe("無料ユーザー - 残回数あり", () => {
+    it("残回数が1以上の場合リクエストが通過すること", async () => {
+      // Arrange
+      const userData = createFreeUserData({ remaining: 3 });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+    });
+
+    it("リクエスト後にdb.updateが呼ばれデクリメントされること", async () => {
+      // Arrange
+      const userData = createFreeUserData({ remaining: 3 });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+      expect(mockUpdateWhere).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("無料ユーザー - 残回数なし", () => {
+    it("残回数が0でリセット期限内の場合402が返ること", async () => {
+      // Arrange
+      const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      const userData = createFreeUserData({ remaining: 0, resetAt: futureDate });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_PAYMENT_REQUIRED);
+    });
+
+    it("402レスポンスがAPI規約に従った形式であること", async () => {
+      // Arrange
+      const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      const userData = createFreeUserData({ remaining: 0, resetAt: futureDate });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      const body = await res.json();
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: "AI_LIMIT_EXCEEDED",
+          message:
+            "無料のAI使用回数の上限に達しました。プレミアムプランにアップグレードしてください",
+        },
+      });
+    });
+
+    it("残回数が0でリセット期限内の場合db.updateが呼ばれないこと", async () => {
+      // Arrange
+      const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      const userData = createFreeUserData({ remaining: 0, resetAt: futureDate });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("プレミアムユーザー", () => {
+    it("プレミアムユーザーはfreeAiUsesRemainingに関係なくリクエストが通過すること", async () => {
+      // Arrange
+      const userData = createPremiumUserData();
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(PREMIUM_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+    });
+
+    it("プレミアムユーザーの場合db.updateが呼ばれないこと", async () => {
+      // Arrange
+      const userData = createPremiumUserData();
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(PREMIUM_USER_ID);
+
+      // Act
+      await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("月次リセット", () => {
+    it("freeAiResetAtが過去の場合リセットされて通過すること", async () => {
+      // Arrange
+      const pastDate = new Date("2025-01-01T00:00:00Z").toISOString();
+      const userData = createFreeUserData({ remaining: 0, resetAt: pastDate });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+    });
+
+    it("リセット時にfreeAiUsesRemainingが4にセットされること（5 - 今回1使用）", async () => {
+      // Arrange
+      const pastDate = new Date("2025-01-01T00:00:00Z").toISOString();
+      const userData = createFreeUserData({ remaining: 0, resetAt: pastDate });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+      const setArg = mockUpdateSet.mock.calls[0][0];
+      expect(setArg.freeAiUsesRemaining).toBe(4);
+      expect(setArg.freeAiResetAt).not.toBe(pastDate);
+      expect(setArg.freeAiResetAt).not.toBeNull();
+    });
+
+    it("freeAiResetAtがnullの場合もリセットされて通過すること", async () => {
+      // Arrange
+      const userData = createFreeUserData({ remaining: 0, resetAt: null });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+    });
+  });
+
+  describe("未認証ユーザー", () => {
+    it("contextにuser.idがセットされていない場合401が返ること", async () => {
+      // Arrange
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = await res.json();
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: "AUTH_REQUIRED",
+          message: "ログインが必要です",
+        },
+      });
+    });
+
+    it("ユーザーがDBに存在しない場合401が返ること", async () => {
+      // Arrange
+      mockSelectWhere.mockResolvedValue([]);
+      const app = createTestApp("nonexistent_user_id");
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+    });
+  });
+
+  describe("レスポンス形式", () => {
+    it("Content-Typeがapplication/jsonであること", async () => {
+      // Arrange
+      const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+      const userData = createFreeUserData({ remaining: 0, resetAt: futureDate });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+      });
+
+      // Assert
+      expect(res.headers.get("Content-Type")).toContain("application/json");
+    });
+  });
+});

--- a/apps/api/src/middleware/ai-limit.ts
+++ b/apps/api/src/middleware/ai-limit.ts
@@ -1,0 +1,150 @@
+import { eq } from "drizzle-orm";
+import type { MiddlewareHandler } from "hono";
+
+import type { Database } from "../db";
+import { users } from "../db/schema";
+
+/** HTTP 401 Unauthorized ステータスコード */
+const HTTP_UNAUTHORIZED = 401;
+
+/** HTTP 402 Payment Required ステータスコード */
+const HTTP_PAYMENT_REQUIRED = 402;
+
+/** 未認証エラーコード */
+const AUTH_ERROR_CODE = "AUTH_REQUIRED";
+
+/** 未認証エラーメッセージ */
+const AUTH_ERROR_MESSAGE = "ログインが必要です";
+
+/** AI使用回数上限エラーコード */
+const AI_LIMIT_ERROR_CODE = "AI_LIMIT_EXCEEDED";
+
+/** AI使用回数上限エラーメッセージ */
+const AI_LIMIT_ERROR_MESSAGE =
+  "無料のAI使用回数の上限に達しました。プレミアムプランにアップグレードしてください";
+
+/** 無料ユーザーの月間AI使用上限回数 */
+const FREE_AI_USES_PER_MONTH = 5;
+
+/** 1ヶ月のミリ秒数（30日） */
+const ONE_MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * 次のリセット日時を計算する
+ *
+ * @returns 現在時刻から1ヶ月後のISO文字列
+ */
+function calculateNextResetAt(): string {
+  return new Date(Date.now() + ONE_MONTH_MS).toISOString();
+}
+
+/**
+ * リセット期限が過ぎているかチェックする
+ *
+ * @param resetAt - リセット予定日時のISO文字列（nullの場合は期限切れとみなす）
+ * @returns 期限切れの場合true
+ */
+function isResetExpired(resetAt: string | null): boolean {
+  if (!resetAt) {
+    return true;
+  }
+  return new Date(resetAt).getTime() <= Date.now();
+}
+
+/**
+ * AI使用回数制限ミドルウェアを生成する
+ *
+ * 要約/翻訳API呼び出し前にユーザーのfreeAiUsesRemainingをチェックし、
+ * 無料ユーザーの使用回数を制限する。
+ * - プレミアムユーザー: 制限なし（通過）
+ * - 無料ユーザー（残回数あり）: 通過後にデクリメント
+ * - 無料ユーザー（残回数なし、リセット期限切れ）: リセットして通過
+ * - 無料ユーザー（残回数なし、リセット期限内）: 402を返却
+ *
+ * @param db - Drizzle ORMデータベースインスタンス
+ * @returns Hono ミドルウェアハンドラー
+ */
+export function createAiLimitMiddleware(db: Database): MiddlewareHandler {
+  return async (c, next) => {
+    const user = c.get("user") as Record<string, unknown> | undefined;
+
+    if (!user?.id) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: AUTH_ERROR_CODE,
+            message: AUTH_ERROR_MESSAGE,
+          },
+        },
+        HTTP_UNAUTHORIZED,
+      );
+    }
+
+    const userId = user.id as string;
+
+    const userResults = await db.select().from(users).where(eq(users.id, userId));
+
+    if (userResults.length === 0) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: AUTH_ERROR_CODE,
+            message: AUTH_ERROR_MESSAGE,
+          },
+        },
+        HTTP_UNAUTHORIZED,
+      );
+    }
+
+    const dbUser = userResults[0];
+
+    if (dbUser.isPremium) {
+      await next();
+      return;
+    }
+
+    const remaining = dbUser.freeAiUsesRemaining ?? 0;
+
+    if (remaining > 0) {
+      await db
+        .update(users)
+        .set({
+          freeAiUsesRemaining: remaining - 1,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(eq(users.id, userId));
+
+      await next();
+      return;
+    }
+
+    if (isResetExpired(dbUser.freeAiResetAt)) {
+      const nextResetAt = calculateNextResetAt();
+
+      await db
+        .update(users)
+        .set({
+          freeAiUsesRemaining: FREE_AI_USES_PER_MONTH - 1,
+          freeAiResetAt: nextResetAt,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(eq(users.id, userId));
+
+      await next();
+      return;
+    }
+
+    return c.json(
+      {
+        success: false,
+        error: {
+          code: AI_LIMIT_ERROR_CODE,
+          message: AI_LIMIT_ERROR_MESSAGE,
+        },
+      },
+      HTTP_PAYMENT_REQUIRED,
+    );
+  };
+}


### PR DESCRIPTION
## Summary
- 無料ユーザーのAI使用回数（月5回）を制限するHonoミドルウェアを追加
- 残回数0かつリセット期限内なら402 Payment Required返却
- プレミアムユーザーは制限なし、月次リセットロジック内蔵

## Test plan
- [x] 無料ユーザー: 残回数ありでリクエスト通過・デクリメント確認
- [x] 無料ユーザー: 残回数0でリセット期限内なら402返却
- [x] プレミアムユーザー: 制限なし通過・デクリメントなし
- [x] 月次リセット: 期限切れでリセット・残回数4確認
- [x] 未認証: 401返却
- [x] biome lint pass
- [x] typecheck pass

Closes #107