### PR TITLE
feat: 通知トリガーロジック #72

### DIFF
--- a/apps/api/src/services/notification-trigger.test.ts
+++ b/apps/api/src/services/notification-trigger.test.ts
@@ -1,0 +1,344 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type NotificationTriggerOptions,
+  createFollowNotification,
+  createSummaryCompleteNotification,
+} from "./notification-trigger";
+
+/** テスト用ユーザーID */
+const FOLLOWER_USER_ID = "user_follower_01";
+
+/** テスト用フォロー対象ユーザーID */
+const FOLLOWING_USER_ID = "user_following_01";
+
+/** テスト用記事ID */
+const TEST_ARTICLE_ID = "article_test_01";
+
+/** テスト用要約ID */
+const TEST_SUMMARY_ID = "summary_test_01";
+
+/** テスト用フォロワー名 */
+const FOLLOWER_NAME = "テストフォロワー";
+
+/** テスト用記事タイトル */
+const TEST_ARTICLE_TITLE = "テスト記事タイトル";
+
+/** モックの db.insert クエリ結果 */
+const mockInsertReturning = vi.fn();
+const mockInsertValues = vi.fn().mockReturnValue({
+  returning: mockInsertReturning,
+});
+const mockInsert = vi.fn().mockReturnValue({
+  values: mockInsertValues,
+});
+
+/** モックのDBインスタンス */
+const mockDb = {
+  insert: mockInsert,
+};
+
+describe("notification-trigger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("createFollowNotification", () => {
+    it("フォロー時に通知レコードが作成されること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_001",
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+        title: "新しいフォロワー",
+        body: `${FOLLOWER_NAME}さんがあなたをフォローしました`,
+        isRead: false,
+        data: JSON.stringify({ followerId: FOLLOWER_USER_ID }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      const result = await createFollowNotification({
+        db: mockDb as never,
+        followerId: FOLLOWER_USER_ID,
+        followingId: FOLLOWING_USER_ID,
+        followerName: FOLLOWER_NAME,
+      });
+
+      // Assert
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+      });
+    });
+
+    it("通知のtypeがfollowであること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_001",
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+        title: "新しいフォロワー",
+        body: `${FOLLOWER_NAME}さんがあなたをフォローしました`,
+        isRead: false,
+        data: JSON.stringify({ followerId: FOLLOWER_USER_ID }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createFollowNotification({
+        db: mockDb as never,
+        followerId: FOLLOWER_USER_ID,
+        followingId: FOLLOWING_USER_ID,
+        followerName: FOLLOWER_NAME,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      expect(insertedValues.type).toBe("follow");
+      expect(insertedValues.userId).toBe(FOLLOWING_USER_ID);
+    });
+
+    it("通知のtitleが正しいこと", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_001",
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+        title: "新しいフォロワー",
+        body: `${FOLLOWER_NAME}さんがあなたをフォローしました`,
+        isRead: false,
+        data: JSON.stringify({ followerId: FOLLOWER_USER_ID }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createFollowNotification({
+        db: mockDb as never,
+        followerId: FOLLOWER_USER_ID,
+        followingId: FOLLOWING_USER_ID,
+        followerName: FOLLOWER_NAME,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      expect(insertedValues.title).toBe("新しいフォロワー");
+    });
+
+    it("通知のbodyにフォロワー名が含まれること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_001",
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+        title: "新しいフォロワー",
+        body: `${FOLLOWER_NAME}さんがあなたをフォローしました`,
+        isRead: false,
+        data: JSON.stringify({ followerId: FOLLOWER_USER_ID }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createFollowNotification({
+        db: mockDb as never,
+        followerId: FOLLOWER_USER_ID,
+        followingId: FOLLOWING_USER_ID,
+        followerName: FOLLOWER_NAME,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      expect(insertedValues.body).toContain(FOLLOWER_NAME);
+    });
+
+    it("通知のdataにfolloweIdが含まれること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_001",
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+        title: "新しいフォロワー",
+        body: `${FOLLOWER_NAME}さんがあなたをフォローしました`,
+        isRead: false,
+        data: JSON.stringify({ followerId: FOLLOWER_USER_ID }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createFollowNotification({
+        db: mockDb as never,
+        followerId: FOLLOWER_USER_ID,
+        followingId: FOLLOWING_USER_ID,
+        followerName: FOLLOWER_NAME,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      const parsedData = JSON.parse(insertedValues.data);
+      expect(parsedData.followerId).toBe(FOLLOWER_USER_ID);
+    });
+
+    it("followerNameが未指定の場合デフォルト名が使われること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_001",
+        userId: FOLLOWING_USER_ID,
+        type: "follow",
+        title: "新しいフォロワー",
+        body: "ユーザーさんがあなたをフォローしました",
+        isRead: false,
+        data: JSON.stringify({ followerId: FOLLOWER_USER_ID }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createFollowNotification({
+        db: mockDb as never,
+        followerId: FOLLOWER_USER_ID,
+        followingId: FOLLOWING_USER_ID,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      expect(insertedValues.body).toContain("ユーザー");
+    });
+  });
+
+  describe("createSummaryCompleteNotification", () => {
+    it("要約完了時に通知レコードが作成されること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_002",
+        userId: FOLLOWER_USER_ID,
+        type: "summary_complete",
+        title: "要約が完了しました",
+        body: `「${TEST_ARTICLE_TITLE}」の要約が完了しました`,
+        isRead: false,
+        data: JSON.stringify({
+          articleId: TEST_ARTICLE_ID,
+          summaryId: TEST_SUMMARY_ID,
+        }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      const result = await createSummaryCompleteNotification({
+        db: mockDb as never,
+        userId: FOLLOWER_USER_ID,
+        articleId: TEST_ARTICLE_ID,
+        articleTitle: TEST_ARTICLE_TITLE,
+        summaryId: TEST_SUMMARY_ID,
+      });
+
+      // Assert
+      expect(mockInsert).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        userId: FOLLOWER_USER_ID,
+        type: "summary_complete",
+      });
+    });
+
+    it("通知のtypeがsummary_completeであること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_002",
+        userId: FOLLOWER_USER_ID,
+        type: "summary_complete",
+        title: "要約が完了しました",
+        body: `「${TEST_ARTICLE_TITLE}」の要約が完了しました`,
+        isRead: false,
+        data: JSON.stringify({
+          articleId: TEST_ARTICLE_ID,
+          summaryId: TEST_SUMMARY_ID,
+        }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createSummaryCompleteNotification({
+        db: mockDb as never,
+        userId: FOLLOWER_USER_ID,
+        articleId: TEST_ARTICLE_ID,
+        articleTitle: TEST_ARTICLE_TITLE,
+        summaryId: TEST_SUMMARY_ID,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      expect(insertedValues.type).toBe("summary_complete");
+    });
+
+    it("通知のbodyに記事タイトルが含まれること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_002",
+        userId: FOLLOWER_USER_ID,
+        type: "summary_complete",
+        title: "要約が完了しました",
+        body: `「${TEST_ARTICLE_TITLE}」の要約が完了しました`,
+        isRead: false,
+        data: JSON.stringify({
+          articleId: TEST_ARTICLE_ID,
+          summaryId: TEST_SUMMARY_ID,
+        }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createSummaryCompleteNotification({
+        db: mockDb as never,
+        userId: FOLLOWER_USER_ID,
+        articleId: TEST_ARTICLE_ID,
+        articleTitle: TEST_ARTICLE_TITLE,
+        summaryId: TEST_SUMMARY_ID,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      expect(insertedValues.body).toContain(TEST_ARTICLE_TITLE);
+    });
+
+    it("通知のdataにarticleIdとsummaryIdが含まれること", async () => {
+      // Arrange
+      const mockNotification = {
+        id: "notif_002",
+        userId: FOLLOWER_USER_ID,
+        type: "summary_complete",
+        title: "要約が完了しました",
+        body: `「${TEST_ARTICLE_TITLE}」の要約が完了しました`,
+        isRead: false,
+        data: JSON.stringify({
+          articleId: TEST_ARTICLE_ID,
+          summaryId: TEST_SUMMARY_ID,
+        }),
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      mockInsertReturning.mockResolvedValue([mockNotification]);
+
+      // Act
+      await createSummaryCompleteNotification({
+        db: mockDb as never,
+        userId: FOLLOWER_USER_ID,
+        articleId: TEST_ARTICLE_ID,
+        articleTitle: TEST_ARTICLE_TITLE,
+        summaryId: TEST_SUMMARY_ID,
+      });
+
+      // Assert
+      const insertedValues = mockInsertValues.mock.calls[0][0];
+      const parsedData = JSON.parse(insertedValues.data);
+      expect(parsedData.articleId).toBe(TEST_ARTICLE_ID);
+      expect(parsedData.summaryId).toBe(TEST_SUMMARY_ID);
+    });
+  });
+});

--- a/apps/api/src/services/notification-trigger.ts
+++ b/apps/api/src/services/notification-trigger.ts
@@ -1,0 +1,96 @@
+import type { Database } from "../db";
+import { notifications } from "../db/schema";
+
+/** フォロー通知タイプ */
+const NOTIFICATION_TYPE_FOLLOW = "follow";
+
+/** 要約完了通知タイプ */
+const NOTIFICATION_TYPE_SUMMARY_COMPLETE = "summary_complete";
+
+/** フォロー通知タイトル */
+const FOLLOW_NOTIFICATION_TITLE = "新しいフォロワー";
+
+/** 要約完了通知タイトル */
+const SUMMARY_COMPLETE_NOTIFICATION_TITLE = "要約が完了しました";
+
+/** フォロワー名未指定時のデフォルト名 */
+const DEFAULT_FOLLOWER_NAME = "ユーザー";
+
+/** 通知トリガーの共通オプション */
+export type NotificationTriggerOptions = {
+  db: Database;
+};
+
+/** フォロー通知作成のオプション */
+type FollowNotificationOptions = NotificationTriggerOptions & {
+  followerId: string;
+  followingId: string;
+  followerName?: string;
+};
+
+/** 要約完了通知作成のオプション */
+type SummaryCompleteNotificationOptions = NotificationTriggerOptions & {
+  userId: string;
+  articleId: string;
+  articleTitle: string;
+  summaryId: string;
+};
+
+/**
+ * フォロー通知を作成する
+ *
+ * フォローされたユーザーに対して通知レコードをnotificationsテーブルに挿入する。
+ *
+ * @param options - フォロー通知作成に必要なオプション
+ * @returns 作成された通知レコード
+ */
+export async function createFollowNotification(options: FollowNotificationOptions) {
+  const { db, followerId, followingId, followerName } = options;
+  const displayName = followerName ?? DEFAULT_FOLLOWER_NAME;
+
+  const id = crypto.randomUUID();
+
+  const [inserted] = await db
+    .insert(notifications)
+    .values({
+      id,
+      userId: followingId,
+      type: NOTIFICATION_TYPE_FOLLOW,
+      title: FOLLOW_NOTIFICATION_TITLE,
+      body: `${displayName}さんがあなたをフォローしました`,
+      data: JSON.stringify({ followerId }),
+    })
+    .returning();
+
+  return inserted;
+}
+
+/**
+ * 要約完了通知を作成する
+ *
+ * 要約が完了した記事の所有者に対して通知レコードをnotificationsテーブルに挿入する。
+ *
+ * @param options - 要約完了通知作成に必要なオプション
+ * @returns 作成された通知レコード
+ */
+export async function createSummaryCompleteNotification(
+  options: SummaryCompleteNotificationOptions,
+) {
+  const { db, userId, articleId, articleTitle, summaryId } = options;
+
+  const id = crypto.randomUUID();
+
+  const [inserted] = await db
+    .insert(notifications)
+    .values({
+      id,
+      userId,
+      type: NOTIFICATION_TYPE_SUMMARY_COMPLETE,
+      title: SUMMARY_COMPLETE_NOTIFICATION_TITLE,
+      body: `「${articleTitle}」の要約が完了しました`,
+      data: JSON.stringify({ articleId, summaryId }),
+    })
+    .returning();
+
+  return inserted;
+}


### PR DESCRIPTION
## Summary
- フォロー時にフォロー対象ユーザーへ通知レコードを作成する `createFollowNotification` を追加
- 要約完了時に記事所有者へ通知レコードを作成する `createSummaryCompleteNotification` を追加
- notificationsテーブルに type/title/body/data を挿入するサービス関数

## Test plan
- [x] フォロー通知: type=follow, userId=フォロー対象, body にフォロワー名含む
- [x] フォロー通知: data に followerId 含む
- [x] フォロー通知: followerName 未指定時にデフォルト名使用
- [x] 要約完了通知: type=summary_complete, body に記事タイトル含む
- [x] 要約完了通知: data に articleId/summaryId 含む
- [x] biome lint pass
- [x] typecheck pass

Closes #72