### PR TITLE
feat: Cloudflare Workers デプロイ設定 (本番/ステージング)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,6 +6,8 @@
     "dev": "wrangler dev",
     "build": "wrangler deploy --dry-run",
     "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:production": "wrangler deploy --env production",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -3,8 +3,8 @@ main = "src/index.ts"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat"]
 
-# [vars]
-# ENVIRONMENT = "production"
+[vars]
+ENVIRONMENT = "development"
 
 # [[r2_buckets]]
 # binding = "AVATARS_BUCKET"
@@ -15,3 +15,15 @@ compatibility_flags = ["nodejs_compat"]
 # TURSO_AUTH_TOKEN
 # RUNPOD_API_KEY
 # RUNPOD_ENDPOINT_ID
+
+# --- ステージング環境 ---
+[env.staging]
+name = "tech-clip-api-staging"
+[env.staging.vars]
+ENVIRONMENT = "staging"
+
+# --- 本番環境 ---
+[env.production]
+name = "tech-clip-api-production"
+[env.production.vars]
+ENVIRONMENT = "production"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "lint": "biome check .",
-    "lint:fix": "biome check --write ."
+    "lint:fix": "biome check --write .",
+    "deploy:staging": "turbo run deploy:staging --filter=@tech-clip/api",
+    "deploy:production": "turbo run deploy:production --filter=@tech-clip/api"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- `wrangler.toml` に `env.staging` / `env.production` セクションを追加し、環境別ワーカー名と `ENVIRONMENT` 変数を設定
- `apps/api/package.json` に `deploy:staging` / `deploy:production` スクリプトを追加
- ルート `package.json` に Turborepo 経由のデプロイスクリプトを追加

Closes #111

## Test plan
- [ ] `wrangler deploy --env staging --dry-run` でステージング設定が正しく読み込まれること
- [ ] `wrangler deploy --env production --dry-run` で本番設定が正しく読み込まれること
- [ ] `pnpm deploy:staging` / `pnpm deploy:production` が正しいフィルタで実行されること

Co-Authored-By: Claude <noreply@anthropic.com>