### PR TITLE
feat: フォロワー/フォロー中一覧画面

### DIFF
--- a/apps/mobile/app/profile/followers.tsx
+++ b/apps/mobile/app/profile/followers.tsx
@@ -2,13 +2,7 @@ import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { ArrowLeft } from "lucide-react-native";
 import { useCallback, useState } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  Pressable,
-  Text,
-  View,
-} from "react-native";
+import { ActivityIndicator, FlatList, Pressable, Text, View } from "react-native";
 
 /** タブの種類 */
 type TabType = "followers" | "following";
@@ -186,9 +180,7 @@ export default function FollowersScreen() {
   }, []);
 
   const renderItem = useCallback(
-    ({ item }: { item: UserItem }) => (
-      <UserListItem item={item} onPress={handleUserPress} />
-    ),
+    ({ item }: { item: UserItem }) => <UserListItem item={item} onPress={handleUserPress} />,
     [handleUserPress],
   );
 
@@ -199,9 +191,7 @@ export default function FollowersScreen() {
       return null;
     }
     const message =
-      activeTab === "followers"
-        ? "フォロワーはまだいません"
-        : "フォロー中のユーザーはいません";
+      activeTab === "followers" ? "フォロワーはまだいません" : "フォロー中のユーザーはいません";
     return (
       <View testID="followers-empty" className="items-center py-12 px-4">
         <Text className="text-text-muted text-sm text-center">{message}</Text>


### PR DESCRIPTION
## Summary
- `apps/mobile/app/profile/followers.tsx` を新規作成
- フォロワー/フォロー中のタブ切り替え付き FlatList 表示
- ユーザーアイテムタップでプロフィール画面 (`/profile/[id]`) へ遷移
- クエリパラメータ `tab` で初期タブ指定に対応
- プレースホルダーデータ（API実装後に置き換え予定）

Closes #114

## Test plan
- [ ] フォロワータブが初期表示されること
- [ ] タブ切り替えでフォロー中リストに切り替わること
- [ ] ユーザーアイテムタップでプロフィール画面へ遷移すること
- [ ] `?tab=following` で初期タブがフォロー中になること
- [ ] 空リスト時にメッセージが表示されること

Co-Authored-By: Claude <noreply@anthropic.com>