### PR TITLE
feat: アプリアイコン + スプラッシュスクリーン設定 #94

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -8,19 +8,27 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "platforms": ["ios", "android", "web"],
+    "icon": "./assets/images/icon.svg",
+    "splash": {
+      "image": "./assets/images/splash-icon.svg",
+      "resizeMode": "contain",
+      "backgroundColor": "#0c0a09"
+    },
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.techclip.app"
     },
     "android": {
       "adaptiveIcon": {
-        "backgroundColor": "#ffffff"
+        "foregroundImage": "./assets/images/adaptive-icon.svg",
+        "backgroundColor": "#0c0a09"
       },
       "package": "com.techclip.app"
     },
     "web": {
       "bundler": "metro",
-      "output": "static"
+      "output": "static",
+      "favicon": "./assets/images/favicon.svg"
     },
     "plugins": [
       [

--- a/apps/mobile/assets/images/adaptive-icon.svg
+++ b/apps/mobile/assets/images/adaptive-icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <!-- Transparent background for adaptive icon foreground layer -->
+  <!-- TechClip mark centered, sized for safe zone (66% of canvas) -->
+  <!-- Vertical bar of T -->
+  <rect x="462" y="220" width="100" height="584" rx="12" fill="#14b8a6"/>
+  <!-- Horizontal bar of T -->
+  <rect x="262" y="220" width="500" height="100" rx="12" fill="#14b8a6"/>
+  <!-- Clip accent lines -->
+  <rect x="562" y="600" width="180" height="16" rx="8" fill="#0d9488"/>
+  <rect x="562" y="640" width="130" height="16" rx="8" fill="#0d9488"/>
+  <rect x="562" y="680" width="80" height="16" rx="8" fill="#0d9488"/>
+</svg>

--- a/apps/mobile/assets/images/favicon.svg
+++ b/apps/mobile/assets/images/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Dark background -->
+  <rect width="32" height="32" rx="4" fill="#0c0a09"/>
+  <!-- T mark scaled to 32x32 -->
+  <!-- Vertical bar -->
+  <rect x="14" y="7" width="4" height="18" rx="1" fill="#14b8a6"/>
+  <!-- Horizontal bar -->
+  <rect x="8" y="7" width="16" height="4" rx="1" fill="#14b8a6"/>
+</svg>

--- a/apps/mobile/assets/images/icon.svg
+++ b/apps/mobile/assets/images/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" width="1024" height="1024">
+  <!-- Dark background -->
+  <rect width="1024" height="1024" rx="180" fill="#0c0a09"/>
+  <!-- TechClip: stylized "T" and clip mark -->
+  <!-- Vertical bar of T -->
+  <rect x="462" y="220" width="100" height="584" rx="12" fill="#14b8a6"/>
+  <!-- Horizontal bar of T -->
+  <rect x="262" y="220" width="500" height="100" rx="12" fill="#14b8a6"/>
+  <!-- Clip accent mark (bottom-right) -->
+  <rect x="562" y="600" width="180" height="16" rx="8" fill="#0d9488"/>
+  <rect x="562" y="640" width="130" height="16" rx="8" fill="#0d9488"/>
+  <rect x="562" y="680" width="80" height="16" rx="8" fill="#0d9488"/>
+</svg>

--- a/apps/mobile/assets/images/splash-icon.svg
+++ b/apps/mobile/assets/images/splash-icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <!-- Splash icon: T mark only, used as center image on dark splash background -->
+  <!-- Vertical bar of T -->
+  <rect x="90" y="40" width="20" height="120" rx="3" fill="#14b8a6"/>
+  <!-- Horizontal bar of T -->
+  <rect x="50" y="40" width="100" height="20" rx="3" fill="#14b8a6"/>
+  <!-- Clip accent lines -->
+  <rect x="110" y="120" width="36" height="4" rx="2" fill="#0d9488"/>
+  <rect x="110" y="130" width="26" height="4" rx="2" fill="#0d9488"/>
+  <rect x="110" y="140" width="16" height="4" rx="2" fill="#0d9488"/>
+</svg>


### PR DESCRIPTION
## Summary

- SVGベースのアプリアイコン・スプラッシュスクリーン・アダプティブアイコン・ファビコンを追加
- ダークモダンテーマ（背景: `#0c0a09`、プライマリ: `#14b8a6` teal）で統一
- `app.json` にアイコン・スプラッシュ・ファビコンのパスと設定を追加

## Changes

- `apps/mobile/assets/images/icon.svg` — 1024x1024 アプリアイコン（丸角ダーク背景 + T字マーク）
- `apps/mobile/assets/images/adaptive-icon.svg` — Android アダプティブアイコン前景レイヤー
- `apps/mobile/assets/images/splash-icon.svg` — スプラッシュスクリーン中央アイコン
- `apps/mobile/assets/images/favicon.svg` — Web ファビコン（32x32）
- `apps/mobile/app.json` — `icon`, `splash`, `android.adaptiveIcon`, `web.favicon` フィールドを追加

## Test plan

- [ ] `app.json` の JSON 構文が正しいことを確認
- [ ] SVGファイルが正しいパスに配置されていることを確認
- [ ] `expo start` でスプラッシュ背景色 `#0c0a09` が適用されることを確認

> Note: TDD対象外（デザイン/設定のみのissue — CLAUDE.md「TDD対象外」規定に準拠）

Closes #94

🤖 Generated with [Claude Code](https://claude.ai/code)