### PR TITLE
feat: add API rate limit middleware #116

### DIFF
--- a/apps/api/__tests__/middleware/rateLimit.test.ts
+++ b/apps/api/__tests__/middleware/rateLimit.test.ts
@@ -1,0 +1,456 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type RateLimitConfig,
+  type RateLimitStore,
+  createRateLimitMiddleware,
+} from "../../src/middleware/rateLimit";
+
+/** レスポンスボディの型定義 */
+type RateLimitResponseBody = {
+  success: boolean;
+  error?: {
+    code: string;
+    message: string;
+  };
+  data?: unknown;
+};
+
+/** テスト用のインメモリストア */
+function createTestStore(): RateLimitStore {
+  const store = new Map<string, { count: number; resetAt: number }>();
+  return {
+    get: (key: string) => store.get(key) ?? null,
+    set: (key: string, value: { count: number; resetAt: number }) => {
+      store.set(key, value);
+    },
+    clear: () => store.clear(),
+  };
+}
+
+/** テスト用Honoアプリを作成する */
+function createTestApp(config: RateLimitConfig, store?: RateLimitStore) {
+  const app = new Hono();
+  const middleware = createRateLimitMiddleware(config, store);
+
+  app.use("/api/*", middleware);
+  app.get("/api/test", (c) => c.json({ success: true, data: "ok" }));
+  app.get("/public", (c) => c.json({ success: true, data: "公開リソース" }));
+
+  return app;
+}
+
+describe("createRateLimitMiddleware", () => {
+  let testStore: RateLimitStore;
+
+  beforeEach(() => {
+    testStore = createTestStore();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("制限内のリクエスト", () => {
+    it("制限内のリクエストは200を返すこと", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 5,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+
+      // Assert
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as RateLimitResponseBody;
+      expect(body.success).toBe(true);
+    });
+
+    it("制限ちょうどの回数まではリクエストが通ること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 3,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act & Assert: 3回まで成功
+      for (let i = 0; i < 3; i++) {
+        const res = await app.request("/api/test", {
+          headers: { "CF-Connecting-IP": "192.168.1.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it("異なるIPのリクエストは独立してカウントされること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 2,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: IP1で2回
+      for (let i = 0; i < 2; i++) {
+        const res = await app.request("/api/test", {
+          headers: { "CF-Connecting-IP": "192.168.1.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // Assert: IP2は別カウントなので成功
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.2" },
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("制限超過のリクエスト", () => {
+    it("制限を超えたリクエストは429を返すこと", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 2,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 2回リクエスト（制限内）
+      await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+
+      // 3回目（制限超過）
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+
+      // Assert
+      expect(res.status).toBe(429);
+    });
+
+    it("429レスポンスにRetry-Afterヘッダーが含まれること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 1回目（制限内）
+      await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      // 2回目（制限超過）
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+
+      // Assert
+      expect(res.status).toBe(429);
+      const retryAfter = res.headers.get("Retry-After");
+      expect(retryAfter).not.toBeNull();
+      expect(Number(retryAfter)).toBeGreaterThan(0);
+    });
+
+    it("429レスポンスがAPI設計規約に従った形式であること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act
+      await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+
+      // Assert
+      expect(res.status).toBe(429);
+      const body = (await res.json()) as RateLimitResponseBody;
+      expect(body).toMatchObject({
+        success: false,
+        error: {
+          code: "RATE_LIMIT_EXCEEDED",
+          message: "リクエストが多すぎます。しばらく待ってから再度お試しください",
+        },
+      });
+    });
+
+    it("ウィンドウ期間後はカウントがリセットされること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 制限を超える
+      await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      const resBefore = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      expect(resBefore.status).toBe(429);
+
+      // 時間を進める（ウィンドウ期間経過）
+      vi.advanceTimersByTime(61_000);
+
+      // Assert: リセット後は成功
+      const resAfter = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      expect(resAfter.status).toBe(200);
+    });
+  });
+
+  describe("ルート別の制限設定", () => {
+    it("認証ルートは10/minで制限されること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 10,
+        windowMs: 60_000,
+        keyPrefix: "auth",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 10回成功
+      for (let i = 0; i < 10; i++) {
+        const res = await app.request("/api/test", {
+          headers: { "CF-Connecting-IP": "192.168.1.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // 11回目は失敗
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      expect(res.status).toBe(429);
+    });
+
+    it("記事保存ルートは30/minで制限されること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 30,
+        windowMs: 60_000,
+        keyPrefix: "article",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 30回成功
+      for (let i = 0; i < 30; i++) {
+        const res = await app.request("/api/test", {
+          headers: { "CF-Connecting-IP": "192.168.1.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // 31回目は失敗
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      expect(res.status).toBe(429);
+    });
+
+    it("AIルートは10/minで制限されること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 10,
+        windowMs: 60_000,
+        keyPrefix: "ai",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 10回成功
+      for (let i = 0; i < 10; i++) {
+        const res = await app.request("/api/test", {
+          headers: { "CF-Connecting-IP": "192.168.1.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // 11回目は失敗
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      expect(res.status).toBe(429);
+    });
+
+    it("一般ルートは100/minで制限されること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 100,
+        windowMs: 60_000,
+        keyPrefix: "general",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 100回成功
+      for (let i = 0; i < 100; i++) {
+        const res = await app.request("/api/test", {
+          headers: { "CF-Connecting-IP": "192.168.1.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+
+      // 101回目は失敗
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "192.168.1.1" },
+      });
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe("IPアドレス取得", () => {
+    it("CF-Connecting-IPヘッダーからIPを取得すること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 同一IPで2回
+      await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "10.0.0.1" },
+      });
+      const res = await app.request("/api/test", {
+        headers: { "CF-Connecting-IP": "10.0.0.1" },
+      });
+
+      // Assert: 同一IPとして扱われ429
+      expect(res.status).toBe(429);
+    });
+
+    it("X-Forwarded-ForヘッダーからIPを取得すること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 同一IPで2回
+      await app.request("/api/test", {
+        headers: { "X-Forwarded-For": "10.0.0.2" },
+      });
+      const res = await app.request("/api/test", {
+        headers: { "X-Forwarded-For": "10.0.0.2" },
+      });
+
+      // Assert: 同一IPとして扱われ429
+      expect(res.status).toBe(429);
+    });
+
+    it("IPヘッダーがない場合はunknownとして扱われること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: ヘッダーなしで2回
+      await app.request("/api/test");
+      const res = await app.request("/api/test");
+
+      // Assert: unknown IPとして同一カウント
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe("ユーザーIDベースの制限", () => {
+    it("ユーザーIDが指定された場合はIPより優先されること", async () => {
+      // Arrange
+      const config: RateLimitConfig = {
+        limit: 1,
+        windowMs: 60_000,
+        keyPrefix: "test",
+        getUserId: (c) => c.req.header("X-User-Id") ?? null,
+      };
+      const app = createTestApp(config, testStore);
+
+      // Act: 同一ユーザーIDで2回（異なるIPから）
+      await app.request("/api/test", {
+        headers: {
+          "X-User-Id": "user_01",
+          "CF-Connecting-IP": "192.168.1.1",
+        },
+      });
+      const res = await app.request("/api/test", {
+        headers: {
+          "X-User-Id": "user_01",
+          "CF-Connecting-IP": "192.168.1.2", // 異なるIP
+        },
+      });
+
+      // Assert: 同一ユーザーとして扱われ429
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe("定義済みレート制限設定", () => {
+    it("RATE_LIMIT_CONFIGにauth設定が存在すること", async () => {
+      const { RATE_LIMIT_CONFIG } = await import("../../src/middleware/rateLimit");
+      expect(RATE_LIMIT_CONFIG.auth).toMatchObject({
+        limit: 10,
+        windowMs: 60_000,
+        keyPrefix: "auth",
+      });
+    });
+
+    it("RATE_LIMIT_CONFIGにarticleSave設定が存在すること", async () => {
+      const { RATE_LIMIT_CONFIG } = await import("../../src/middleware/rateLimit");
+      expect(RATE_LIMIT_CONFIG.articleSave).toMatchObject({
+        limit: 30,
+        windowMs: 60_000,
+        keyPrefix: "article_save",
+      });
+    });
+
+    it("RATE_LIMIT_CONFIGにai設定が存在すること", async () => {
+      const { RATE_LIMIT_CONFIG } = await import("../../src/middleware/rateLimit");
+      expect(RATE_LIMIT_CONFIG.ai).toMatchObject({
+        limit: 10,
+        windowMs: 60_000,
+        keyPrefix: "ai",
+      });
+    });
+
+    it("RATE_LIMIT_CONFIGにgeneral設定が存在すること", async () => {
+      const { RATE_LIMIT_CONFIG } = await import("../../src/middleware/rateLimit");
+      expect(RATE_LIMIT_CONFIG.general).toMatchObject({
+        limit: 100,
+        windowMs: 60_000,
+        keyPrefix: "general",
+      });
+    });
+  });
+});

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,0 +1,165 @@
+import type { Context, MiddlewareHandler } from "hono";
+
+/** HTTP 429 Too Many Requests ステータスコード */
+const HTTP_TOO_MANY_REQUESTS = 429;
+
+/** レート制限超過エラーコード */
+const RATE_LIMIT_ERROR_CODE = "RATE_LIMIT_EXCEEDED";
+
+/** レート制限超過エラーメッセージ */
+const RATE_LIMIT_ERROR_MESSAGE = "リクエストが多すぎます。しばらく待ってから再度お試しください";
+
+/**
+ * レート制限ストアのエントリー
+ */
+type RateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+/**
+ * レート制限ストアのインターフェース
+ *
+ * ローカル開発はインメモリMap、本番はCloudflare Workers KVを注入可能
+ */
+export type RateLimitStore = {
+  get: (key: string) => RateLimitEntry | null;
+  set: (key: string, value: RateLimitEntry) => void;
+  clear: () => void;
+};
+
+/**
+ * レート制限ミドルウェアの設定
+ */
+export type RateLimitConfig = {
+  /** ウィンドウ内の最大リクエスト数 */
+  limit: number;
+  /** ウィンドウの長さ（ミリ秒） */
+  windowMs: number;
+  /** ストアキーのプレフィックス */
+  keyPrefix: string;
+  /** ユーザーIDを取得する関数（未指定時はIPベース） */
+  getUserId?: (c: Context) => string | null;
+};
+
+/**
+ * 定義済みレート制限設定
+ *
+ * 各ルートカテゴリに対応した制限値を定義する
+ */
+export const RATE_LIMIT_CONFIG = {
+  /** 認証関連: 10リクエスト/分 */
+  auth: {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: "auth",
+  },
+  /** 記事保存: 30リクエスト/分 */
+  articleSave: {
+    limit: 30,
+    windowMs: 60_000,
+    keyPrefix: "article_save",
+  },
+  /** AI関連（要約・翻訳）: 10リクエスト/分 */
+  ai: {
+    limit: 10,
+    windowMs: 60_000,
+    keyPrefix: "ai",
+  },
+  /** 一般API: 100リクエスト/分 */
+  general: {
+    limit: 100,
+    windowMs: 60_000,
+    keyPrefix: "general",
+  },
+} as const satisfies Record<string, RateLimitConfig>;
+
+/**
+ * デフォルトのインメモリレート制限ストアを生成する
+ *
+ * @returns インメモリMapを使ったRateLimitStore
+ */
+export function createInMemoryStore(): RateLimitStore {
+  const store = new Map<string, RateLimitEntry>();
+  return {
+    get: (key: string) => store.get(key) ?? null,
+    set: (key: string, value: RateLimitEntry) => {
+      store.set(key, value);
+    },
+    clear: () => store.clear(),
+  };
+}
+
+/** デフォルトのインメモリストア（開発環境用） */
+const defaultStore = createInMemoryStore();
+
+/**
+ * リクエストのIPアドレスを取得する
+ *
+ * Cloudflare Workers環境ではCF-Connecting-IPを優先する
+ *
+ * @param c - Honoコンテキスト
+ * @returns IPアドレス文字列
+ */
+function getClientIp(c: Context): string {
+  const cfIp = c.req.header("CF-Connecting-IP");
+  if (cfIp) {
+    return cfIp;
+  }
+
+  const forwardedFor = c.req.header("X-Forwarded-For");
+  if (forwardedFor) {
+    return forwardedFor.split(",")[0].trim();
+  }
+
+  return "unknown";
+}
+
+/**
+ * レート制限ミドルウェアを生成する
+ *
+ * IPベースまたはユーザーIDベースでリクエスト数をカウントし、
+ * 制限を超えた場合は429を返す。Retry-Afterヘッダーも付与する。
+ *
+ * @param config - レート制限設定
+ * @param store - レート制限ストア（省略時はデフォルトのインメモリストア）
+ * @returns Hono ミドルウェアハンドラー
+ */
+export function createRateLimitMiddleware(
+  config: RateLimitConfig,
+  store: RateLimitStore = defaultStore,
+): MiddlewareHandler {
+  return async (c, next) => {
+    const identifier = config.getUserId ? (config.getUserId(c) ?? getClientIp(c)) : getClientIp(c);
+    const key = `${config.keyPrefix}:${identifier}`;
+    const now = Date.now();
+
+    const existing = store.get(key);
+
+    if (!existing || existing.resetAt <= now) {
+      store.set(key, { count: 1, resetAt: now + config.windowMs });
+      await next();
+      return;
+    }
+
+    if (existing.count >= config.limit) {
+      const retryAfterSeconds = Math.ceil((existing.resetAt - now) / 1000);
+
+      c.header("Retry-After", String(retryAfterSeconds));
+
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: RATE_LIMIT_ERROR_CODE,
+            message: RATE_LIMIT_ERROR_MESSAGE,
+          },
+        },
+        HTTP_TOO_MANY_REQUESTS,
+      );
+    }
+
+    store.set(key, { count: existing.count + 1, resetAt: existing.resetAt });
+    await next();
+  };
+}


### PR DESCRIPTION
## Summary

- IP-based and user-based rate limiting middleware for Hono/Cloudflare Workers
- In-memory Map store for local dev (KV integration ready via `RateLimitStore` interface)
- Predefined `RATE_LIMIT_CONFIG` with four categories: auth (10/min), articleSave (30/min), ai (10/min), general (100/min)
- Returns 429 with `Retry-After` header when limit exceeded, following API design rules

## Test plan

- [x] Requests within limit return 200
- [x] Requests exceeding limit return 429
- [x] Retry-After header present on 429
- [x] Different limits per route config (auth/articleSave/ai/general)
- [x] Window resets after windowMs elapses
- [x] Different IPs tracked independently
- [x] User-ID-based limiting overrides IP when `getUserId` provided
- [x] CF-Connecting-IP and X-Forwarded-For header extraction
- [x] RATE_LIMIT_CONFIG exports verified
- [x] All 791 tests pass, Biome clean

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)