### PR TITLE
feat: API入力バリデーション Zodスキーマ全エンドポイント対応 #125

### DIFF
--- a/apps/api/__tests__/validators/ai.test.ts
+++ b/apps/api/__tests__/validators/ai.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { GenerateSummarySchema, GenerateTranslationSchema } from "../../src/validators/ai";
+
+describe("GenerateTranslationSchema", () => {
+  describe("正常系", () => {
+    it("targetLanguage=enでバリデーションが通ること", () => {
+      // Arrange
+      const input = { targetLanguage: "en" };
+
+      // Act
+      const result = GenerateTranslationSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.targetLanguage).toBe("en");
+    });
+
+    it("targetLanguage=jaでバリデーションが通ること", () => {
+      // Arrange
+      const input = { targetLanguage: "ja" };
+
+      // Act
+      const result = GenerateTranslationSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.targetLanguage).toBe("ja");
+    });
+  });
+
+  describe("異常系", () => {
+    it("サポートされていない言語コードでエラーになること", () => {
+      // Arrange
+      const input = { targetLanguage: "fr" };
+
+      // Act
+      const result = GenerateTranslationSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("en");
+    });
+
+    it("targetLanguageが未指定の場合エラーになること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = GenerateTranslationSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("targetLanguageが空文字の場合エラーになること", () => {
+      // Arrange
+      const input = { targetLanguage: "" };
+
+      // Act
+      const result = GenerateTranslationSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("GenerateSummarySchema", () => {
+  describe("正常系", () => {
+    it("languageを指定しない場合デフォルト値でバリデーションが通ること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = GenerateSummarySchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("language=jaを指定してバリデーションが通ること", () => {
+      // Arrange
+      const input = { language: "ja" };
+
+      // Act
+      const result = GenerateSummarySchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.language).toBe("ja");
+    });
+
+    it("language=enを指定してバリデーションが通ること", () => {
+      // Arrange
+      const input = { language: "en" };
+
+      // Act
+      const result = GenerateSummarySchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.language).toBe("en");
+    });
+  });
+
+  describe("異常系", () => {
+    it("サポートされていない言語コードでエラーになること", () => {
+      // Arrange
+      const input = { language: "zh" };
+
+      // Act
+      const result = GenerateSummarySchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/api/__tests__/validators/articles.test.ts
+++ b/apps/api/__tests__/validators/articles.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import {
+  CreateArticleSchema,
+  SearchArticlesSchema,
+  UpdateArticleSchema,
+} from "../../src/validators/articles";
+
+describe("CreateArticleSchema", () => {
+  describe("正常系", () => {
+    it("有効なhttps URLでバリデーションが通ること", () => {
+      // Arrange
+      const input = { url: "https://example.com/article" };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("有効なhttp URLでバリデーションが通ること", () => {
+      // Arrange
+      const input = { url: "http://example.com/article" };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("クエリパラメータ付きURLでバリデーションが通ること", () => {
+      // Arrange
+      const input = { url: "https://example.com/article?id=123&ref=top" };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("urlが空文字の場合エラーになること", () => {
+      // Arrange
+      const input = { url: "" };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("urlがURL形式でない場合エラーになること", () => {
+      // Arrange
+      const input = { url: "not-a-url" };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("URL");
+    });
+
+    it("urlがftp://の場合エラーになること", () => {
+      // Arrange
+      const input = { url: "ftp://example.com/file" };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("https://");
+    });
+
+    it("urlが2048文字を超える場合エラーになること", () => {
+      // Arrange
+      const longPath = "a".repeat(2040);
+      const input = { url: `https://example.com/${longPath}` };
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("2048");
+    });
+
+    it("urlが未指定の場合エラーになること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = CreateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("UpdateArticleSchema", () => {
+  describe("正常系", () => {
+    it("isReadのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { isRead: true };
+
+      // Act
+      const result = UpdateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.isRead).toBe(true);
+    });
+
+    it("isFavoriteのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { isFavorite: false };
+
+      // Act
+      const result = UpdateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.isFavorite).toBe(false);
+    });
+
+    it("isPublicのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { isPublic: true };
+
+      // Act
+      const result = UpdateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.isPublic).toBe(true);
+    });
+
+    it("複数フィールド指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { isRead: true, isFavorite: false, isPublic: true };
+
+      // Act
+      const result = UpdateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("フィールドが何も指定されない場合エラーになること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = UpdateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("1つ以上");
+    });
+
+    it("isReadに文字列を渡した場合エラーになること", () => {
+      // Arrange
+      const input = { isRead: "true" };
+
+      // Act
+      const result = UpdateArticleSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("SearchArticlesSchema", () => {
+  describe("正常系", () => {
+    it("有効な検索キーワードでバリデーションが通ること", () => {
+      // Arrange
+      const input = { q: "TypeScript" };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.q).toBe("TypeScript");
+    });
+
+    it("limitを指定してバリデーションが通ること", () => {
+      // Arrange
+      const input = { q: "React", limit: 10 };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.limit).toBe(10);
+    });
+
+    it("limitを省略した場合デフォルト値20になること", () => {
+      // Arrange
+      const input = { q: "Next.js" };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.limit).toBe(20);
+    });
+  });
+
+  describe("異常系", () => {
+    it("qが空文字の場合エラーになること", () => {
+      // Arrange
+      const input = { q: "" };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("qが200文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { q: "a".repeat(201) };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("200");
+    });
+
+    it("limitが0の場合エラーになること", () => {
+      // Arrange
+      const input = { q: "test", limit: 0 };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("limitが51の場合エラーになること", () => {
+      // Arrange
+      const input = { q: "test", limit: 51 };
+
+      // Act
+      const result = SearchArticlesSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/api/__tests__/validators/tags.test.ts
+++ b/apps/api/__tests__/validators/tags.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { CreateTagSchema, UpdateArticleTagsSchema } from "../../src/validators/tags";
+
+describe("CreateTagSchema", () => {
+  describe("正常系", () => {
+    it("有効なタグ名でバリデーションが通ること", () => {
+      // Arrange
+      const input = { name: "TypeScript" };
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe("TypeScript");
+    });
+
+    it("日本語タグ名でバリデーションが通ること", () => {
+      // Arrange
+      const input = { name: "フロントエンド" };
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe("フロントエンド");
+    });
+
+    it("前後の空白がトリムされること", () => {
+      // Arrange
+      const input = { name: "  React  " };
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe("React");
+    });
+
+    it("50文字のタグ名でバリデーションが通ること", () => {
+      // Arrange
+      const input = { name: "a".repeat(50) };
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("nameが空文字の場合エラーになること", () => {
+      // Arrange
+      const input = { name: "" };
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("タグ名");
+    });
+
+    it("nameが50文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { name: "a".repeat(51) };
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("50");
+    });
+
+    it("nameが未指定の場合エラーになること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = CreateTagSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("UpdateArticleTagsSchema", () => {
+  describe("正常系", () => {
+    it("空の配列でバリデーションが通ること", () => {
+      // Arrange
+      const input = { tagIds: [] };
+
+      // Act
+      const result = UpdateArticleTagsSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.tagIds).toEqual([]);
+    });
+
+    it("タグIDの配列でバリデーションが通ること", () => {
+      // Arrange
+      const input = { tagIds: ["tag_001", "tag_002", "tag_003"] };
+
+      // Act
+      const result = UpdateArticleTagsSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.tagIds).toEqual(["tag_001", "tag_002", "tag_003"]);
+    });
+  });
+
+  describe("異常系", () => {
+    it("tagIdsが未指定の場合エラーになること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = UpdateArticleTagsSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("tagIdsが配列でない場合エラーになること", () => {
+      // Arrange
+      const input = { tagIds: "tag_001" };
+
+      // Act
+      const result = UpdateArticleTagsSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("tagIdsに数値が含まれる場合エラーになること", () => {
+      // Arrange
+      const input = { tagIds: [1, 2, 3] };
+
+      // Act
+      const result = UpdateArticleTagsSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/api/__tests__/validators/users.test.ts
+++ b/apps/api/__tests__/validators/users.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { UpdateProfileSchema, UploadAvatarSchema } from "../../src/validators/users";
+
+describe("UpdateProfileSchema", () => {
+  describe("正常系", () => {
+    it("nameのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { name: "テストユーザー" };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe("テストユーザー");
+    });
+
+    it("usernameのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { username: "test_user-123" };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.username).toBe("test_user-123");
+    });
+
+    it("bioのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { bio: "自己紹介テキスト" };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("websiteUrlのみ指定でバリデーションが通ること", () => {
+      // Arrange
+      const input = { websiteUrl: "https://example.com" };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("nullを渡してフィールドをクリアできること", () => {
+      // Arrange
+      const input = { name: null, bio: null };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBeNull();
+    });
+
+    it("すべてのフィールドを指定してバリデーションが通ること", () => {
+      // Arrange
+      const input = {
+        name: "テストユーザー",
+        username: "test_user",
+        bio: "自己紹介",
+        websiteUrl: "https://example.com",
+        githubUsername: "testuser",
+        twitterUsername: "testuser",
+        isProfilePublic: true,
+        preferredLanguage: "ja",
+      };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("nameが100文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { name: "あ".repeat(101) };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("100");
+    });
+
+    it("usernameに使用不可文字が含まれる場合エラーになること", () => {
+      // Arrange
+      const input = { username: "invalid user!" };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("半角英数字");
+    });
+
+    it("usernameが30文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { username: "a".repeat(31) };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("30");
+    });
+
+    it("bioが500文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { bio: "あ".repeat(501) };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("500");
+    });
+
+    it("websiteUrlがURL形式でない場合エラーになること", () => {
+      // Arrange
+      const input = { websiteUrl: "not-a-url" };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("URL");
+    });
+
+    it("githubUsernameが39文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { githubUsername: "a".repeat(40) };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("39");
+    });
+
+    it("twitterUsernameが15文字を超える場合エラーになること", () => {
+      // Arrange
+      const input = { twitterUsername: "a".repeat(16) };
+
+      // Act
+      const result = UpdateProfileSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0].message).toContain("15");
+    });
+  });
+});
+
+describe("UploadAvatarSchema", () => {
+  describe("正常系", () => {
+    it("有効なJPEGファイルでバリデーションが通ること", () => {
+      // Arrange
+      const mockFile = new File(["data"], "avatar.jpg", { type: "image/jpeg" });
+      const input = { avatar: mockFile };
+
+      // Act
+      const result = UploadAvatarSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("有効なPNGファイルでバリデーションが通ること", () => {
+      // Arrange
+      const mockFile = new File(["data"], "avatar.png", { type: "image/png" });
+      const input = { avatar: mockFile };
+
+      // Act
+      const result = UploadAvatarSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("異常系", () => {
+    it("avatarフィールドが未指定の場合エラーになること", () => {
+      // Arrange
+      const input = {};
+
+      // Act
+      const result = UploadAvatarSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+
+    it("avatarが文字列の場合エラーになること", () => {
+      // Arrange
+      const input = { avatar: "not-a-file" };
+
+      // Act
+      const result = UploadAvatarSchema.safeParse(input);
+
+      // Assert
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/middleware/validate.ts
+++ b/apps/api/src/middleware/validate.ts
@@ -1,0 +1,77 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { z } from "zod";
+
+/** HTTP 422 Unprocessable Entity ステータスコード */
+const HTTP_UNPROCESSABLE_ENTITY = 422;
+
+/** バリデーションエラーコード */
+const VALIDATION_ERROR_CODE = "VALIDATION_FAILED";
+
+/** バリデーションエラーメッセージ */
+const VALIDATION_ERROR_MESSAGE = "入力内容を確認してください";
+
+/**
+ * Zodスキーマを使ってJSONボディをバリデーションするHonoミドルウェアを生成する
+ *
+ * @param schema - Zodスキーマ
+ * @returns Honoミドルウェアハンドラー
+ */
+export function validateJson<S extends z.ZodTypeAny>(schema: S): MiddlewareHandler {
+  return async (c: Context, next) => {
+    const body = await c.req.json().catch(() => ({}));
+    const result = schema.safeParse(body);
+
+    if (!result.success) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: VALIDATION_ERROR_CODE,
+            message: VALIDATION_ERROR_MESSAGE,
+            details: result.error.issues.map((issue) => ({
+              field: issue.path.join("."),
+              message: issue.message,
+            })),
+          },
+        },
+        HTTP_UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    c.set("validatedBody", result.data);
+    await next();
+  };
+}
+
+/**
+ * Zodスキーマを使ってクエリパラメータをバリデーションするHonoミドルウェアを生成する
+ *
+ * @param schema - Zodスキーマ
+ * @returns Honoミドルウェアハンドラー
+ */
+export function validateQuery<S extends z.ZodTypeAny>(schema: S): MiddlewareHandler {
+  return async (c: Context, next) => {
+    const query = c.req.query();
+    const result = schema.safeParse(query);
+
+    if (!result.success) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: VALIDATION_ERROR_CODE,
+            message: VALIDATION_ERROR_MESSAGE,
+            details: result.error.issues.map((issue) => ({
+              field: issue.path.join("."),
+              message: issue.message,
+            })),
+          },
+        },
+        HTTP_UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    c.set("validatedQuery", result.data);
+    await next();
+  };
+}

--- a/apps/api/src/validators/ai.ts
+++ b/apps/api/src/validators/ai.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/** サポートされる言語 */
+const SUPPORTED_LANGUAGES = ["en", "ja"] as const;
+
+/**
+ * 翻訳生成リクエストのZodスキーマ
+ */
+export const GenerateTranslationSchema = z.object({
+  targetLanguage: z.enum(SUPPORTED_LANGUAGES, {
+    error: "targetLanguageはenまたはjaで指定してください",
+  }),
+});
+
+/**
+ * 要約生成リクエストのZodスキーマ
+ */
+export const GenerateSummarySchema = z.object({
+  language: z
+    .enum(SUPPORTED_LANGUAGES, {
+      error: "languageはenまたはjaで指定してください",
+    })
+    .optional(),
+});
+
+/** GenerateTranslationSchemaの型 */
+export type GenerateTranslationInput = z.infer<typeof GenerateTranslationSchema>;
+
+/** GenerateSummarySchemaの型 */
+export type GenerateSummaryInput = z.infer<typeof GenerateSummarySchema>;

--- a/apps/api/src/validators/articles.ts
+++ b/apps/api/src/validators/articles.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+
+/** URL最大文字数 */
+const URL_MAX_LENGTH = 2048;
+
+/** デフォルトのページサイズ */
+const DEFAULT_LIMIT = 20;
+
+/** 最小ページサイズ */
+const MIN_LIMIT = 1;
+
+/** 最大ページサイズ */
+const MAX_LIMIT = 50;
+
+/** 検索キーワード最大文字数 */
+const QUERY_MAX_LENGTH = 200;
+
+/**
+ * 記事保存リクエストのZodスキーマ
+ */
+export const CreateArticleSchema = z.object({
+  url: z
+    .string({ error: "URLは必須です" })
+    .min(1, "URLを入力してください")
+    .max(URL_MAX_LENGTH, `URLは${URL_MAX_LENGTH}文字以内で入力してください`)
+    .url("URLの形式が正しくありません")
+    .refine(
+      (val) => {
+        try {
+          const parsed = new URL(val);
+          return parsed.protocol === "http:" || parsed.protocol === "https:";
+        } catch {
+          return false;
+        }
+      },
+      { message: "URLはhttp://またはhttps://で始まる必要があります" },
+    ),
+});
+
+/**
+ * 記事更新リクエストのZodスキーマ
+ */
+export const UpdateArticleSchema = z
+  .object({
+    isRead: z.boolean({ error: "isReadはブール値で指定してください" }).optional(),
+    isFavorite: z.boolean({ error: "isFavoriteはブール値で指定してください" }).optional(),
+    isPublic: z.boolean({ error: "isPublicはブール値で指定してください" }).optional(),
+  })
+  .refine(
+    (data) =>
+      data.isRead !== undefined || data.isFavorite !== undefined || data.isPublic !== undefined,
+    {
+      message: "更新するフィールドを1つ以上指定してください",
+    },
+  );
+
+/**
+ * 記事検索クエリパラメータのZodスキーマ
+ */
+export const SearchArticlesSchema = z.object({
+  q: z
+    .string({ error: "検索キーワードは必須です" })
+    .min(1, "検索キーワードを入力してください")
+    .max(QUERY_MAX_LENGTH, `検索キーワードは${QUERY_MAX_LENGTH}文字以内で入力してください`),
+  limit: z
+    .number()
+    .int("limitは整数で指定してください")
+    .min(MIN_LIMIT, `limitは${MIN_LIMIT}以上で指定してください`)
+    .max(MAX_LIMIT, `limitは${MAX_LIMIT}以下で指定してください`)
+    .default(DEFAULT_LIMIT),
+  cursor: z.string().optional(),
+});
+
+/** CreateArticleSchemaの型 */
+export type CreateArticleInput = z.infer<typeof CreateArticleSchema>;
+
+/** UpdateArticleSchemaの型 */
+export type UpdateArticleInput = z.infer<typeof UpdateArticleSchema>;
+
+/** SearchArticlesSchemaの型 */
+export type SearchArticlesInput = z.infer<typeof SearchArticlesSchema>;

--- a/apps/api/src/validators/tags.ts
+++ b/apps/api/src/validators/tags.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+/** タグ名最大文字数 */
+const TAG_NAME_MAX_LENGTH = 50;
+
+/**
+ * タグ作成リクエストのZodスキーマ
+ */
+export const CreateTagSchema = z.object({
+  name: z
+    .string({ error: "タグ名は必須です" })
+    .min(1, "タグ名を入力してください")
+    .max(TAG_NAME_MAX_LENGTH, `タグ名は${TAG_NAME_MAX_LENGTH}文字以内で入力してください`)
+    .trim(),
+});
+
+/**
+ * 記事タグ更新リクエストのZodスキーマ
+ */
+export const UpdateArticleTagsSchema = z.object({
+  tagIds: z.array(z.string(), { error: "tagIdsは配列で指定してください" }),
+});
+
+/** CreateTagSchemaの型 */
+export type CreateTagInput = z.infer<typeof CreateTagSchema>;
+
+/** UpdateArticleTagsSchemaの型 */
+export type UpdateArticleTagsInput = z.infer<typeof UpdateArticleTagsSchema>;

--- a/apps/api/src/validators/users.ts
+++ b/apps/api/src/validators/users.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+/** 名前最大文字数 */
+const NAME_MAX_LENGTH = 100;
+
+/** ユーザー名最大文字数 */
+const USERNAME_MAX_LENGTH = 30;
+
+/** 自己紹介最大文字数 */
+const BIO_MAX_LENGTH = 500;
+
+/** URL最大文字数 */
+const URL_MAX_LENGTH = 2048;
+
+/** GitHubユーザー名最大文字数 */
+const GITHUB_USERNAME_MAX_LENGTH = 39;
+
+/** Twitterユーザー名最大文字数 */
+const TWITTER_USERNAME_MAX_LENGTH = 15;
+
+/** ユーザー名の正規表現（半角英数字とアンダースコア、ハイフンのみ） */
+const USERNAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * プロフィール更新リクエストのZodスキーマ
+ */
+export const UpdateProfileSchema = z.object({
+  name: z
+    .string()
+    .max(NAME_MAX_LENGTH, `名前は${NAME_MAX_LENGTH}文字以内で入力してください`)
+    .trim()
+    .nullable()
+    .optional(),
+  username: z
+    .string()
+    .max(USERNAME_MAX_LENGTH, `ユーザー名は${USERNAME_MAX_LENGTH}文字以内で入力してください`)
+    .regex(USERNAME_REGEX, "ユーザー名は半角英数字、アンダースコア、ハイフンのみ使用できます")
+    .nullable()
+    .optional(),
+  bio: z
+    .string()
+    .max(BIO_MAX_LENGTH, `自己紹介は${BIO_MAX_LENGTH}文字以内で入力してください`)
+    .nullable()
+    .optional(),
+  websiteUrl: z
+    .string()
+    .max(URL_MAX_LENGTH, `URLは${URL_MAX_LENGTH}文字以内で入力してください`)
+    .url("URLの形式が正しくありません")
+    .nullable()
+    .optional(),
+  githubUsername: z
+    .string()
+    .max(
+      GITHUB_USERNAME_MAX_LENGTH,
+      `GitHubユーザー名は${GITHUB_USERNAME_MAX_LENGTH}文字以内で入力してください`,
+    )
+    .nullable()
+    .optional(),
+  twitterUsername: z
+    .string()
+    .max(
+      TWITTER_USERNAME_MAX_LENGTH,
+      `Twitterユーザー名は${TWITTER_USERNAME_MAX_LENGTH}文字以内で入力してください`,
+    )
+    .nullable()
+    .optional(),
+  isProfilePublic: z.boolean().optional(),
+  preferredLanguage: z.string().optional(),
+});
+
+/**
+ * アバターアップロードリクエストのZodスキーマ
+ */
+export const UploadAvatarSchema = z.object({
+  avatar: z.instanceof(File, { message: "avatarフィールドにファイルを指定してください" }),
+});
+
+/** UpdateProfileSchemaの型 */
+export type UpdateProfileInput = z.infer<typeof UpdateProfileSchema>;
+
+/** UploadAvatarSchemaの型 */
+export type UploadAvatarInput = z.infer<typeof UploadAvatarSchema>;


### PR DESCRIPTION
## Summary

- Extract Zod schemas into dedicated `apps/api/src/validators/` files (`articles.ts`, `users.ts`, `tags.ts`, `ai.ts`)
- Add `apps/api/src/middleware/validate.ts` with `validateJson()` and `validateQuery()` Hono middleware helpers
- Add 59 unit tests in `apps/api/__tests__/validators/` covering all schemas (正常系・異常系・境界値)

## Validators added

| File | Schemas |
|------|---------|
| `validators/articles.ts` | `CreateArticleSchema`, `UpdateArticleSchema`, `SearchArticlesSchema` |
| `validators/users.ts` | `UpdateProfileSchema`, `UploadAvatarSchema` |
| `validators/tags.ts` | `CreateTagSchema`, `UpdateArticleTagsSchema` |
| `validators/ai.ts` | `GenerateTranslationSchema`, `GenerateSummarySchema` |
| `middleware/validate.ts` | `validateJson()`, `validateQuery()` |

## Test plan

- [x] 59 validator unit tests pass (`pnpm exec vitest run __tests__/validators`)
- [x] Full test suite passes (831 tests, 54 files)
- [x] TypeScript typecheck passes with zero errors
- [x] Biome lint/format check passes

Closes #125

🤖 Generated with [Claude Code](https://claude.ai/code)