### PR TITLE
docs: complete CLAUDE.md with full development rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,72 @@
 # TechClip 開発ルール
 
+TechClipは、技術記事・動画をAIで要約・翻訳してモバイルで快適に閲覧できるキュレーションアプリです。
+
+---
+
+## プロジェクト概要
+
+| 項目 | 内容 |
+|------|------|
+| アプリ種別 | モバイルアプリ（iOS / Android） |
+| 主機能 | 技術コンテンツのAI要約・翻訳・キュレーション |
+| ターゲット | 技術者・エンジニア |
+
+---
+
+## Tech Stack（バージョン付き）
+
+| カテゴリ | 技術 | バージョン |
+|----------|------|-----------|
+| パッケージマネージャー | pnpm | 9.x |
+| モノレポ | Turborepo | 2.x |
+| モバイル | React Native + Expo | SDK 52 |
+| スタイリング | Nativewind | v4 |
+| API サーバー | Cloudflare Workers + Hono | Hono 4.x |
+| DB | Turso (libSQL) + Drizzle ORM | Drizzle 0.40.x |
+| 認証 | Better Auth | 1.x |
+| AI 推論 | RunPod + Qwen2.5 9B | - |
+| Lint / Format | Biome | 1.x |
+| テスト | Vitest | 2.x |
+| 開発環境 | Nix (flake.nix) | - |
+| 言語 | TypeScript | 5.x |
+
+> ローカル開発のDBはSQLite（Tursoクライアントがローカルファイルを利用）
+
+---
+
+## 環境セットアップ
+
+```bash
+# 1. Nix 開発環境に入る（Node, pnpm, wrangler など自動で入る）
+nix develop
+
+# 2. 依存パッケージのインストール
+pnpm install
+
+# 3. 環境変数の設定
+cp .env.example .env
+# .env を編集して必要な値を入力
+
+# 4. DBマイグレーション（初回）
+pnpm drizzle-kit migrate
+
+# 5. 開発サーバー起動
+pnpm dev
+```
+
+### パッケージ追加時の注意
+
+```bash
+# ✅ 正しい: workspace指定
+pnpm add <pkg> --filter @tech-clip/api
+
+# ❌ 禁止: ルートに直接追加
+pnpm add <pkg>
+```
+
+---
+
 ## 必須ワークフロー（絶対厳守）
 
 すべての開発作業は以下のフローに従うこと。違反した成果物はすべてやり直し。
@@ -8,26 +75,137 @@
 - 既存のIssueがある場合: `gh issue view <番号>` で内容を確認
 - 既存のIssueがない場合: `gh issue create` でIssueを先に作成してから着手
 - **Issue番号がない状態での作業開始は禁止**
+
 ### 2. Git Worktree を作成する
 - ブランチ名: `issue/<issue番号>/<短い説明>`
 - コマンド: `git worktree add .worktrees/issue-N -b issue/N/short-desc`
+
 ### 3. Worktree 内で TDD 実装
 - **RED**: テストを先に書く（失敗することを確認）
 - **GREEN**: テストを通す最小限のコードを書く
 - **REFACTOR**: テストが通る状態を維持しつつリファクタ
 - カバレッジ目標: 80%以上
+
 ### 4. コミット & プッシュ
-- Conventional Commits: `feat:`, `fix:`, `docs:`, `test:`, `chore:`
-- コミットメッセージに Issue 番号を含める (例: `feat: initialize monorepo #1`)
-### 5. PR を作成し、コードレビュー → マージ
+- Conventional Commits 形式でコミット（詳細は下記参照）
+- コミットメッセージに Issue 番号を含める
+
+### 5. PR を作成し、ユーザーレビューを待つ
 - PR 本文に `Closes #<issue番号>` を含める
-- code-review エージェントでレビューを実施し、問題なければ `gh pr merge` でマージ
-- 重大な問題が検出された場合は修正してから再レビュー → マージ
+- **全PRはユーザーレビュー必須**（セルフマージ禁止）
+
 ### 6. マージ後、Worktree をクリーンアップ
+
+```bash
+git worktree remove .worktrees/issue-N
+git branch -d issue/N/short-desc
+```
+
+---
+
+## ブランチ命名規則
+
+```
+issue/<issue番号>/<短い説明（kebab-case）>
+
+例:
+  issue/17/init-monorepo
+  issue/49/nix-flake-setup
+  issue/86/better-auth-integration
+```
+
+- メインブランチ: `main`
+- 作業ブランチはすべて上記形式
+- `main` への直接コミット禁止
+
+---
+
+## Conventional Commits
+
+```
+<type>: <summary> #<issue番号>
+
+types:
+  feat     新機能
+  fix      バグ修正
+  docs     ドキュメントのみの変更
+  test     テストの追加・修正
+  refactor リファクタリング（機能変更なし）
+  chore    ビルド・ツール・設定の変更
+  perf     パフォーマンス改善
+  style    フォーマットのみの変更（ロジック変更なし）
+  ci       CIの変更
+
+例:
+  feat: add user authentication with Better Auth #86
+  fix: resolve SQLite connection leak on worker restart #92
+  docs: complete CLAUDE.md with full development rules #118
+  test: add integration tests for article parser #103
+```
+
+### コミットの粒度
+
+- 1コミット = 1つの論理的変更
+- テストと実装は同一コミットに含めてよい
+- 大きな変更は複数コミットに分割する
+
+---
+
+## PR テンプレート
+
+PRを作成する際は以下の形式を使用する:
+
+```markdown
+## 概要
+
+<!-- このPRで何をしたか1〜3行で説明 -->
+
+## 変更内容
+
+-
+-
+
+## テスト
+
+- [ ] Unit テスト追加・更新済み
+- [ ] Integration テスト追加・更新済み
+- [ ] カバレッジ 80% 以上を確認済み
+- [ ] `pnpm test` がすべてパスすること
+- [ ] `pnpm lint` がエラーなしで通ること
+
+## 関連Issue
+
+Closes #<issue番号>
+```
+
+---
+
+## コーディング規約
+
+詳細は `.claude/rules/` を参照:
+
+| ファイル | 内容 |
+|---------|------|
+| `.claude/rules/coding-standards.md` | TypeScript規約（any禁止、早期リターン、JSDoc等） |
+| `.claude/rules/testing.md` | テスト規約（AAAパターン、命名規則等） |
+| `.claude/rules/api-design.md` | RESTful API設計、レスポンス形式 |
+| `.claude/rules/database.md` | Drizzle ORM、マイグレーション規則 |
+| `.claude/rules/security.md` | セキュリティ要件（認証、XSS、SQLi等） |
+| `.claude/rules/frontend-design.md` | UIデザイン規約（Lucide Icons、カラーシステム等） |
+
+### 重要ルールの要約
+
+- `any` 型禁止 → `unknown` + 型ガード
+- `else` 文禁止 → 早期リターン
+- `console.log` 禁止 → logger 使用
+- Biome のみ使用（ESLint / Prettier 禁止）
+- エラーメッセージは日本語
+- ハードコード禁止（環境変数 or 定数化）
 
 ---
 
 ## .gitignore 管理ルール
+
 - 新しいツール・フレームワーク・依存を追加した場合、必ず `.gitignore` も更新すること
 - 対象: ビルド成果物、キャッシュ、環境変数ファイル、IDE設定、OS固有ファイル等
 - `.gitignore` の更新は、そのツール導入issueに含めて対応する（別issueは不要）
@@ -35,17 +213,21 @@
 ---
 
 ## 禁止事項
+
 - Issue なしでの作業開始
 - Worktree を使わずにメインブランチで直接コード変更
-- レビューなしでのマージ（code-review エージェントによるレビュー必須）
+- セルフマージ（ユーザーレビュー前のマージ）
 - ESLint / Prettier の使用（Biome を使用すること）
 - `drizzle-kit push` の使用（**`drizzle-kit migrate` のみ許可**。push はスキーマ差分を直接適用し、マイグレーション履歴が残らないため本番運用で危険）
 - テストを書かずに実装コードを書くこと（TDDサイクル厳守）
 - テストカバレッジ80%未満でのPR作成
 
+---
+
 ## TDD ルール
 
 ### TDDサイクル
+
 1. **RED** - 失敗するテストを書く。実装より先にテストを作成し、テストが意図通りに失敗することを確認する
 2. **GREEN** - テストを通す最小限のコードを書く。動作すれば十分。綺麗さより動作優先
 3. **REFACTOR** - テストが通った状態を維持しつつ、コードの品質を向上させる
@@ -59,14 +241,49 @@
 | E2E | ユーザー操作を模したシナリオ | （別途定義） |
 
 ### カバレッジ目標
+
 - **80%以上**を目標とする（line / statement カバレッジ）
 - PRレビュー時にカバレッジレポートを添付すること
 
 ### TDD対象外
+
 以下のissueはコード実装を伴わないため、TDD対象外とする。
 - デザインモックアップ・UI仕様の作成
 - ドキュメント更新のみのissue
 - 環境設定・インフラ構成のみの変更
+
+---
+
+## 実装順序（必読）
+
+**実装順序の違反は禁止。依存Issueが未完了の状態で着手しないこと。**
+
+詳細は `docs/ROADMAP.md` を参照。
+
+### Phase 順序
+
+1. **Phase 0**: セットアップ → 現在着手中
+2. **Phase 1**: DB + 認証 → Phase 0 完了後
+3. **Phase 2**: パーサー → Phase 1 完了後
+4. **Phase 3**: API → Phase 1, 2 完了後
+5. **Phase 4**: モバイル → Phase 3 完了後
+6. **Phase 5-9**: 課金、ソーシャル、オフライン、テスト、リリース
+
+### 依存関係チェック
+
+- セッション開始時に `implementation-order-guard.sh` が自動実行
+- 依存Issueが未完了の場合、警告が表示される
+- 詳細な依存関係は `docs/ROADMAP.md` を参照
+- ROADMAP更新時は `scripts/sync-roadmap.sh` で GitHub Issue との整合性を検証すること
+
+### 次に着手すべきIssue（Phase 0）
+
+| Issue | タイトル | 依存 |
+|-------|---------|------|
+| #17 | pnpm workspace + Turborepo 初期化 | - |
+| #49 | Nix 開発環境 (flake.nix) セットアップ | - |
+
+これら2つは並行作業可能。#17 完了後に #19, #18, #36 へ進める。
 
 ---
 
@@ -82,57 +299,20 @@
 
 ---
 
-## Tech Stack
-- pnpm (パッケージマネージャー)
-- Turborepo (monorepo)
-- React Native + Expo (モバイル)
-- Cloudflare Workers + Hono (API)
-- Turso + Drizzle ORM (DB) ※ローカル開発は SQLite
-- Better Auth (認証)
-- RunPod + Qwen3.5 9B (AI要約・翻訳)
-- Nativewind v4 (スタイリング)
-- Biome (lint + formatter)
-- Nix (開発環境)
-
-## 実装順序（必読）
-
-**実装順序の違反は禁止。依存Issueが未完了の状態で着手しないこと。**
-
-### Phase 順序
-1. **Phase 0**: セットアップ → 現在着手中
-2. **Phase 1**: DB + 認証 → Phase 0 完了後
-3. **Phase 2**: パーサー → Phase 1 完了後
-4. **Phase 3**: API → Phase 1, 2 完了後
-5. **Phase 4**: モバイル → Phase 3 完了後
-6. **Phase 5-9**: 課金、ソーシャル、オフライン、テスト、リリース
-
-### 依存関係チェック
-- セッション開始時に `implementation-order-guard.sh` が自動実行
-- 依存Issueが未完了の場合、警告が表示される
-- 詳細な依存関係は `docs/ROADMAP.md` を参照
-- ROADMAP更新時は `scripts/sync-roadmap.sh` で GitHub Issue との整合性を検証すること
-
-### 次に着手すべきIssue（Phase 0）
-| Issue | タイトル | 依存 |
-|-------|---------|------|
-| #17 | pnpm workspace + Turborepo 初期化 | - |
-| #49 | Nix 開発環境 (flake.nix) セットアップ | - |
-
-これら2つは並行作業可能。#17 完了後に #19, #18, #36 へ進める。
-
----
-
 ## Agent Teams 構成
 
 ### 有効化
+
 settings.jsonで `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` を設定済み。
 
 ### チーム構成
 
 #### 1. TDDチーム（新機能開発）
+
 ```
 Test Agent ──→ Impl Agent
 ```
+
 | Agent | 担当 | Worktree |
 |-------|------|----------|
 | Test | テスト作成 → コミット（RED確定） | .worktrees/test |
@@ -143,9 +323,11 @@ Test Agent ──→ Impl Agent
 - Implは独立検証で過適合を防ぐ
 
 #### 2. コードレビューチーム
+
 ```
 Bug Hunter + Verifier + Ranker → 統合レポート
 ```
+
 | Agent | 担当 |
 |-------|------|
 | Bug Hunter | バグ・問題検出（並列） |
@@ -155,9 +337,11 @@ Bug Hunter + Verifier + Ranker → 統合レポート
 **出力**: PRに1つのサマリーコメント + インラインコメント
 
 #### 3. セキュリティ監査チーム
+
 ```
 Security + Performance + Coverage → 統合レポート
 ```
+
 | Agent | 担当 |
 |-------|------|
 | Security | 脆弱性検出（OWASP Top 10） |
@@ -167,6 +351,7 @@ Security + Performance + Coverage → 統合レポート
 **出力**: 単一セキュリティレポート
 
 ### チーム運用ルール
+
 - **小さく保つ**: 2-3エージェントで狭いスコープが最適
 - **Plan-first**: 計画なしでコードに飛び込まない
 - **コンテキスト共有**: チームメイトは会話履歴を継承しないため、spawn時に必要な情報を渡す


### PR DESCRIPTION
## Summary

- プロジェクト概要（1行説明）を追加
- Tech Stack にバージョン情報を追加
- 環境セットアップ手順（nix develop → pnpm install）を追加
- ブランチ命名規則を追加
- Conventional Commits ルールを追加
- PR テンプレートを追加
- コーディング規約のサマリー（`.claude/rules/` への参照付き）を追加
- `docs/ROADMAP.md` への参照を強化
- 既存コンテンツをすべて保持しつつ整理

## Test plan

- [ ] ドキュメントの内容を通読し、情報の正確性を確認
- [ ] 既存セクションが失われていないことを確認
- [ ] 新規セクションが Issue #118 の要件をすべて満たすことを確認

Closes #118