### PR TITLE
feat: Workers KV namespace setup for rate limit and cache #155

### DIFF
--- a/apps/api/__tests__/middleware/rateLimit.test.ts
+++ b/apps/api/__tests__/middleware/rateLimit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type RateLimitConfig,
   type RateLimitStore,
+  createKvStore,
   createRateLimitMiddleware,
 } from "../../src/middleware/rateLimit";
 
@@ -413,6 +414,68 @@ describe("createRateLimitMiddleware", () => {
 
       // Assert: 同一ユーザーとして扱われ429
       expect(res.status).toBe(429);
+    });
+  });
+
+  describe("KVストア", () => {
+    it("createKvStoreがKVNamespaceを使ったRateLimitStoreを返すこと", async () => {
+      // Arrange
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+      } as unknown as KVNamespace;
+
+      // Act
+      const store = createKvStore(mockKv);
+
+      // Assert: getが呼べること
+      const result = await store.get("test-key");
+      expect(result).toBeNull();
+      expect(mockKv.get).toHaveBeenCalledWith("test-key", "json");
+    });
+
+    it("createKvStoreのsetがKV.putを呼ぶこと", async () => {
+      // Arrange
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+      } as unknown as KVNamespace;
+      const store = createKvStore(mockKv);
+
+      // Act
+      await store.set("test-key", { count: 1, resetAt: Date.now() + 60_000 });
+
+      // Assert
+      expect(mockKv.put).toHaveBeenCalledWith(
+        "test-key",
+        expect.any(String),
+        { expirationTtl: 120 },
+      );
+    });
+
+    it("createKvStoreのgetがエントリを正しく返すこと", async () => {
+      // Arrange
+      const entry = { count: 3, resetAt: 9999999999 };
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(entry),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+      } as unknown as KVNamespace;
+      const store = createKvStore(mockKv);
+
+      // Act
+      const result = await store.get("test-key");
+
+      // Assert
+      expect(result).toEqual(entry);
     });
   });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,10 @@ type Bindings = {
   APPLE_CLIENT_SECRET: string;
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
+  /** レート制限用 Workers KV namespace */
+  RATE_LIMIT: KVNamespace;
+  /** キャッシュ用 Workers KV namespace */
+  CACHE: KVNamespace;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -23,9 +23,9 @@ type RateLimitEntry = {
  * ローカル開発はインメモリMap、本番はCloudflare Workers KVを注入可能
  */
 export type RateLimitStore = {
-  get: (key: string) => RateLimitEntry | null;
-  set: (key: string, value: RateLimitEntry) => void;
-  clear: () => void;
+  get: (key: string) => Promise<RateLimitEntry | null> | RateLimitEntry | null;
+  set: (key: string, value: RateLimitEntry) => Promise<void> | void;
+  clear: () => Promise<void> | void;
 };
 
 /**
@@ -90,6 +90,33 @@ export function createInMemoryStore(): RateLimitStore {
   };
 }
 
+/** KV エントリのTTL（秒）：最大ウィンドウ長より長く保持する */
+const KV_TTL_SECONDS = 120;
+
+/**
+ * Cloudflare Workers KV を使ったレート制限ストアを生成する
+ *
+ * @param kv - Workers KV namespace バインディング
+ * @returns KVNamespace を使ったRateLimitStore
+ */
+export function createKvStore(kv: KVNamespace): RateLimitStore {
+  return {
+    get: async (key: string) => {
+      const raw = await kv.get(key, "json");
+      if (raw === null) {
+        return null;
+      }
+      return raw as RateLimitEntry;
+    },
+    set: async (key: string, value: RateLimitEntry) => {
+      await kv.put(key, JSON.stringify(value), { expirationTtl: KV_TTL_SECONDS });
+    },
+    clear: async () => {
+      // KV には一括削除APIがないため、このメソッドはno-op
+    },
+  };
+}
+
 /** デフォルトのインメモリストア（開発環境用） */
 const defaultStore = createInMemoryStore();
 
@@ -134,10 +161,10 @@ export function createRateLimitMiddleware(
     const key = `${config.keyPrefix}:${identifier}`;
     const now = Date.now();
 
-    const existing = store.get(key);
+    const existing = await store.get(key);
 
     if (!existing || existing.resetAt <= now) {
-      store.set(key, { count: 1, resetAt: now + config.windowMs });
+      await store.set(key, { count: 1, resetAt: now + config.windowMs });
       await next();
       return;
     }
@@ -159,7 +186,7 @@ export function createRateLimitMiddleware(
       );
     }
 
-    store.set(key, { count: existing.count + 1, resetAt: existing.resetAt });
+    await store.set(key, { count: existing.count + 1, resetAt: existing.resetAt });
     await next();
   };
 }

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -6,6 +6,14 @@ compatibility_flags = ["nodejs_compat"]
 [vars]
 ENVIRONMENT = "development"
 
+[[kv_namespaces]]
+binding = "RATE_LIMIT"
+id = "REPLACE_WITH_RATE_LIMIT_KV_ID"
+
+[[kv_namespaces]]
+binding = "CACHE"
+id = "REPLACE_WITH_CACHE_KV_ID"
+
 # [[r2_buckets]]
 # binding = "AVATARS_BUCKET"
 # bucket_name = "tech-clip-avatars"


### PR DESCRIPTION
## Summary

- Add `RATE_LIMIT` and `CACHE` KV namespace bindings to `wrangler.toml` (placeholder IDs to be replaced with real KV IDs before deployment)
- Add `KVNamespace` types to `Bindings` type in `src/index.ts`
- Update `RateLimitStore` interface to support async `get`/`set`/`clear` (returns `Promise<...> | ...`)
- Add `createKvStore(kv: KVNamespace)` factory so the rate limit middleware can be backed by Workers KV in production
- Update `createRateLimitMiddleware` to `await` store operations (backward-compatible with sync in-memory store)
- Add 3 tests for `createKvStore` behavior (null get, put call, entry retrieval)

## Test plan

- [x] All 870 existing tests pass (`pnpm --filter @tech-clip/api test --run`)
- [x] 3 new `createKvStore` tests added and passing
- [x] Biome check clean on all modified files
- [x] TypeScript compiles with `@cloudflare/workers-types` providing `KVNamespace`

Closes #155

🤖 Generated with [Claude Code](https://claude.ai/code)