### PR TITLE
feat: add test data seed script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:seed": "tsx src/db/seed.ts"
   },
   "dependencies": {
     "@libsql/client": "^0.14.0",

--- a/apps/api/src/db/seed.test.ts
+++ b/apps/api/src/db/seed.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildArticleData,
+  buildFollowData,
+  buildNotificationData,
+  buildSummaryData,
+  buildTagData,
+  buildTranslationData,
+  buildUserData,
+} from "./seed";
+
+describe("seed", () => {
+  describe("buildUserData", () => {
+    it("有効なユーザーデータを返すこと", () => {
+      // Arrange
+      const index = 0;
+
+      // Act
+      const user = buildUserData(index);
+
+      // Assert
+      expect(user.id).toBeDefined();
+      expect(user.email).toBe("seed-user-0@example.com");
+      expect(user.name).toBe("シードユーザー0");
+      expect(user.username).toBe("seed_user_0");
+      expect(user.emailVerified).toBe(true);
+    });
+
+    it("インデックスに応じて異なるメールアドレスを返すこと", () => {
+      // Arrange & Act
+      const user1 = buildUserData(1);
+      const user2 = buildUserData(2);
+
+      // Assert
+      expect(user1.email).toBe("seed-user-1@example.com");
+      expect(user2.email).toBe("seed-user-2@example.com");
+      expect(user1.id).not.toBe(user2.id);
+    });
+  });
+
+  describe("buildArticleData", () => {
+    it("有効な記事データを返すこと", () => {
+      // Arrange
+      const userId = "test-user-id";
+      const index = 0;
+
+      // Act
+      const article = buildArticleData(userId, index);
+
+      // Assert
+      expect(article.id).toBeDefined();
+      expect(article.userId).toBe(userId);
+      expect(article.url).toContain("https://");
+      expect(article.title).toBeDefined();
+      expect(article.source).toBeDefined();
+      expect(article.createdAt).toBeInstanceOf(Date);
+      expect(article.updatedAt).toBeInstanceOf(Date);
+    });
+
+    it("インデックスに応じて異なるURLを返すこと", () => {
+      // Arrange
+      const userId = "test-user-id";
+
+      // Act
+      const article1 = buildArticleData(userId, 0);
+      const article2 = buildArticleData(userId, 1);
+
+      // Assert
+      expect(article1.url).not.toBe(article2.url);
+    });
+  });
+
+  describe("buildTagData", () => {
+    it("有効なタグデータを返すこと", () => {
+      // Arrange
+      const userId = "test-user-id";
+      const index = 0;
+
+      // Act
+      const tag = buildTagData(userId, index);
+
+      // Assert
+      expect(tag.id).toBeDefined();
+      expect(tag.userId).toBe(userId);
+      expect(tag.name).toBeDefined();
+      expect(tag.createdAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("buildSummaryData", () => {
+    it("有効なサマリーデータを返すこと", () => {
+      // Arrange
+      const articleId = "test-article-id";
+
+      // Act
+      const summary = buildSummaryData(articleId);
+
+      // Assert
+      expect(summary.id).toBeDefined();
+      expect(summary.articleId).toBe(articleId);
+      expect(summary.language).toBe("ja");
+      expect(summary.summary).toBeDefined();
+      expect(summary.model).toBeDefined();
+      expect(summary.createdAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("buildTranslationData", () => {
+    it("有効な翻訳データを返すこと", () => {
+      // Arrange
+      const articleId = "test-article-id";
+
+      // Act
+      const translation = buildTranslationData(articleId);
+
+      // Assert
+      expect(translation.id).toBeDefined();
+      expect(translation.articleId).toBe(articleId);
+      expect(translation.targetLanguage).toBe("en");
+      expect(translation.translatedTitle).toBeDefined();
+      expect(translation.translatedContent).toBeDefined();
+      expect(translation.model).toBeDefined();
+      expect(translation.createdAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("buildFollowData", () => {
+    it("有効なフォローデータを返すこと", () => {
+      // Arrange
+      const followerId = "follower-id";
+      const followingId = "following-id";
+
+      // Act
+      const follow = buildFollowData(followerId, followingId);
+
+      // Assert
+      expect(follow.followerId).toBe(followerId);
+      expect(follow.followingId).toBe(followingId);
+    });
+  });
+
+  describe("buildNotificationData", () => {
+    it("有効な通知データを返すこと", () => {
+      // Arrange
+      const userId = "test-user-id";
+      const index = 0;
+
+      // Act
+      const notification = buildNotificationData(userId, index);
+
+      // Assert
+      expect(notification.id).toBeDefined();
+      expect(notification.userId).toBe(userId);
+      expect(notification.type).toBeDefined();
+      expect(notification.title).toBeDefined();
+      expect(notification.body).toBeDefined();
+    });
+  });
+});

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,0 +1,299 @@
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import {
+  articleTags,
+  articles,
+  follows,
+  notifications,
+  summaries,
+  tags,
+  translations,
+  users,
+} from "./schema";
+
+/** シードで作成するユーザー数 */
+const SEED_USER_COUNT = 5;
+
+/** ユーザーあたりの記事数（最小） */
+const ARTICLES_PER_USER_MIN = 10;
+
+/** ユーザーあたりの記事数（最大） */
+const ARTICLES_PER_USER_MAX = 30;
+
+/** ユーザーあたりのタグ数 */
+const TAGS_PER_USER = 5;
+
+/** AIモデル名（seedデータ用） */
+const SEED_AI_MODEL = "qwen-3.5-9b";
+
+/** 記事ソース一覧 */
+const ARTICLE_SOURCES = [
+  "zenn.dev",
+  "qiita.com",
+  "note.com",
+  "medium.com",
+  "dev.to",
+  "github.com",
+  "tech.example.com",
+] as const;
+
+/** タグ名一覧 */
+const TAG_NAMES = [
+  "TypeScript",
+  "React",
+  "Node.js",
+  "Python",
+  "Go",
+  "Rust",
+  "Docker",
+  "Kubernetes",
+  "AWS",
+  "GCP",
+  "機械学習",
+  "デザイン",
+  "セキュリティ",
+  "パフォーマンス",
+  "テスト",
+] as const;
+
+/** 通知タイプ一覧 */
+const NOTIFICATION_TYPES = ["new_follower", "article_liked", "system_update"] as const;
+
+/**
+ * テスト用ユーザーデータを生成する
+ *
+ * @param index - ユーザーインデックス（0始まり）
+ * @returns 挿入用ユーザーデータ
+ */
+export function buildUserData(index: number) {
+  return {
+    id: crypto.randomUUID(),
+    email: `seed-user-${index}@example.com`,
+    name: `シードユーザー${index}`,
+    username: `seed_user_${index}`,
+    bio: `これはシードデータのユーザー${index}です。`,
+    emailVerified: true,
+    isProfilePublic: true,
+    preferredLanguage: "ja",
+    isPremium: index === 0,
+    freeAiUsesRemaining: 5,
+  };
+}
+
+/**
+ * テスト用記事データを生成する
+ *
+ * @param userId - 記事の所有者ユーザーID
+ * @param index - 記事インデックス（0始まり）
+ * @returns 挿入用記事データ
+ */
+export function buildArticleData(userId: string, index: number) {
+  const source = ARTICLE_SOURCES[index % ARTICLE_SOURCES.length];
+  const now = new Date();
+  const createdAt = new Date(now.getTime() - index * 24 * 60 * 60 * 1000);
+
+  return {
+    id: crypto.randomUUID(),
+    userId,
+    url: `https://${source}/articles/seed-article-${userId.slice(0, 8)}-${index}`,
+    source,
+    title: `シード記事 ${index}: ${source}の技術記事`,
+    author: `著者${index}`,
+    excerpt: `これはシードデータの記事${index}の概要です。テスト用のデータです。`,
+    content: `# シード記事 ${index}\n\nこれはシードデータの記事本文です。\n\n## セクション1\n\nコンテンツがここに入ります。`,
+    readingTimeMinutes: (index % 15) + 3,
+    isRead: index % 3 === 0,
+    isFavorite: index % 5 === 0,
+    isPublic: index % 2 === 0,
+    publishedAt: createdAt,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+/**
+ * テスト用タグデータを生成する
+ *
+ * @param userId - タグの所有者ユーザーID
+ * @param index - タグインデックス（0始まり）
+ * @returns 挿入用タグデータ
+ */
+export function buildTagData(userId: string, index: number) {
+  return {
+    id: crypto.randomUUID(),
+    userId,
+    name: TAG_NAMES[index % TAG_NAMES.length],
+    createdAt: new Date(),
+  };
+}
+
+/**
+ * テスト用サマリーデータを生成する
+ *
+ * @param articleId - 対象記事ID
+ * @returns 挿入用サマリーデータ
+ */
+export function buildSummaryData(articleId: string) {
+  return {
+    id: crypto.randomUUID(),
+    articleId,
+    language: "ja",
+    summary:
+      "これはAIが生成したシードデータの要約です。記事の主要なポイントをまとめています。技術的な内容を分かりやすく説明しています。",
+    model: SEED_AI_MODEL,
+    createdAt: new Date(),
+  };
+}
+
+/**
+ * テスト用翻訳データを生成する
+ *
+ * @param articleId - 対象記事ID
+ * @returns 挿入用翻訳データ
+ */
+export function buildTranslationData(articleId: string) {
+  return {
+    id: crypto.randomUUID(),
+    articleId,
+    targetLanguage: "en",
+    translatedTitle: "Seed Article: Technical Content",
+    translatedContent:
+      "This is an AI-generated translation for seed data. The article covers technical topics in an easy-to-understand manner.",
+    model: SEED_AI_MODEL,
+    createdAt: new Date(),
+  };
+}
+
+/**
+ * テスト用フォローデータを生成する
+ *
+ * @param followerId - フォロワーのユーザーID
+ * @param followingId - フォロー対象のユーザーID
+ * @returns 挿入用フォローデータ
+ */
+export function buildFollowData(followerId: string, followingId: string) {
+  return {
+    followerId,
+    followingId,
+  };
+}
+
+/**
+ * テスト用通知データを生成する
+ *
+ * @param userId - 通知先ユーザーID
+ * @param index - 通知インデックス（0始まり）
+ * @returns 挿入用通知データ
+ */
+export function buildNotificationData(userId: string, index: number) {
+  const type = NOTIFICATION_TYPES[index % NOTIFICATION_TYPES.length];
+  const titles: Record<string, string> = {
+    new_follower: "新しいフォロワーがいます",
+    article_liked: "記事にいいねがつきました",
+    system_update: "システムのお知らせ",
+  };
+  const bodies: Record<string, string> = {
+    new_follower: "シードユーザーがあなたをフォローしました。",
+    article_liked: "あなたの記事が高評価を受けました。",
+    system_update: "TechClipがアップデートされました。新機能をお試しください。",
+  };
+
+  return {
+    id: crypto.randomUUID(),
+    userId,
+    type,
+    title: titles[type],
+    body: bodies[type],
+    isRead: index % 2 === 0,
+  };
+}
+
+/**
+ * DBをシードデータで初期化する（冪等）
+ *
+ * 既存のシードユーザーが存在する場合はスキップする。
+ * TURSO_DATABASE_URL と TURSO_AUTH_TOKEN 環境変数が必要。
+ */
+async function seed() {
+  const databaseUrl = process.env.TURSO_DATABASE_URL;
+  const authToken = process.env.TURSO_AUTH_TOKEN;
+
+  if (!databaseUrl) {
+    throw new Error("環境変数 TURSO_DATABASE_URL が設定されていません");
+  }
+
+  const client = createClient({
+    url: databaseUrl,
+    authToken: authToken ?? "",
+  });
+  const db = drizzle(client);
+
+  const existingUsers = await db.select().from(users).limit(1);
+  if (existingUsers.length > 0) {
+    process.stdout.write("シードユーザーが既に存在します。スキップします。\n");
+    client.close();
+    return;
+  }
+
+  process.stdout.write("シードデータの挿入を開始します...\n");
+
+  const seedUsers = Array.from({ length: SEED_USER_COUNT }, (_, i) => buildUserData(i));
+  await db.insert(users).values(seedUsers);
+  process.stdout.write(`ユーザー ${SEED_USER_COUNT} 件を挿入しました\n`);
+
+  for (const user of seedUsers) {
+    const articleCount =
+      ARTICLES_PER_USER_MIN +
+      Math.floor(Math.random() * (ARTICLES_PER_USER_MAX - ARTICLES_PER_USER_MIN + 1));
+    const seedArticles = Array.from({ length: articleCount }, (_, i) =>
+      buildArticleData(user.id, i),
+    );
+    await db.insert(articles).values(seedArticles);
+
+    const seedTags = Array.from({ length: TAGS_PER_USER }, (_, i) => buildTagData(user.id, i));
+    await db.insert(tags).values(seedTags);
+
+    for (const article of seedArticles) {
+      await db.insert(summaries).values(buildSummaryData(article.id));
+      await db.insert(translations).values(buildTranslationData(article.id));
+
+      const tagForArticle = seedTags[0];
+      await db.insert(articleTags).values({
+        articleId: article.id,
+        tagId: tagForArticle.id,
+      });
+    }
+
+    const seedNotifications = Array.from({ length: 3 }, (_, i) =>
+      buildNotificationData(user.id, i),
+    );
+    await db.insert(notifications).values(seedNotifications);
+
+    process.stdout.write(`ユーザー ${user.username} のデータを挿入しました\n`);
+  }
+
+  for (let i = 0; i < seedUsers.length; i++) {
+    for (let j = 0; j < seedUsers.length; j++) {
+      if (i === j) continue;
+      if (i === 0 || j === 0) {
+        await db.insert(follows).values(buildFollowData(seedUsers[i].id, seedUsers[j].id));
+      }
+    }
+  }
+  process.stdout.write("フォロー関係を挿入しました\n");
+
+  process.stdout.write("シードデータの挿入が完了しました\n");
+  client.close();
+}
+
+const isMain =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith("seed.ts") || process.argv[1].endsWith("seed.js"));
+
+if (isMain) {
+  seed().catch((error: unknown) => {
+    process.stderr.write(`シードエラー: ${String(error)}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- テスト用シードスクリプト (`apps/api/src/db/seed.ts`) を追加
- シードスクリプトのテスト (`apps/api/src/db/seed.test.ts`) を追加
- `apps/api/package.json` にシード実行コマンドを追加

## Test plan

- [ ] `pnpm seed` でシードデータが正常に投入されることを確認
- [ ] `pnpm test` でシードテストがパスすることを確認

Closes #143

🤖 Generated with [Claude Code](https://claude.ai/code)