### PR TITLE
feat: add Cloudflare R2 bucket configuration #133

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,6 +26,8 @@ type Bindings = {
   RATE_LIMIT: KVNamespace;
   /** キャッシュ用 Workers KV namespace */
   CACHE: KVNamespace;
+  /** アバター画像保存用 R2 バケット */
+  AVATARS_BUCKET: R2Bucket;
 };
 
 const app = new Hono<{ Bindings: Bindings }>();

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -14,9 +14,9 @@ id = "REPLACE_WITH_RATE_LIMIT_KV_ID"
 binding = "CACHE"
 id = "REPLACE_WITH_CACHE_KV_ID"
 
-# [[r2_buckets]]
-# binding = "AVATARS_BUCKET"
-# bucket_name = "tech-clip-avatars"
+[[r2_buckets]]
+binding = "AVATARS_BUCKET"
+bucket_name = "tech-clip-avatars"
 
 # [secrets]
 # TURSO_DATABASE_URL


### PR DESCRIPTION
## 概要

Cloudflare R2 バケット（tech-clip-avatars）の設定を追加し、Workers の型定義に R2Bucket バインディングを追加。

## 変更内容

- `apps/api/wrangler.toml`: `[[r2_buckets]]` セクションを有効化（binding: `AVATARS_BUCKET`, bucket_name: `tech-clip-avatars`）
- `apps/api/src/index.ts`: `Bindings` 型に `AVATARS_BUCKET: R2Bucket` を追加

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（インフラ設定のみのため TDD 対象外）
- [x] `biome check` がエラーなしで通ること

## 関連Issue

Closes #133