### PR TITLE
docs: Turso DB バックアップ戦略とリストア手順の追加 #150

### DIFF
--- a/docs/DB_BACKUP.md
+++ b/docs/DB_BACKUP.md
@@ -1,0 +1,191 @@
+# Turso DB バックアップ戦略
+
+## 概要
+
+TechClip は Turso (libSQL) をデータベースとして使用しています。本ドキュメントでは、バックアップ戦略・実行手順・リストア手順を定義します。
+
+---
+
+## バックアップ戦略
+
+### バックアップ種別
+
+| 種別 | 頻度 | 保持期間 | 用途 |
+|------|------|----------|------|
+| 定期バックアップ | 毎日 02:00 UTC | 30日間 | 障害時の復旧 |
+| リリース前バックアップ | デプロイ前手動実行 | 90日間 | ロールバック用 |
+| 週次フルバックアップ | 毎週日曜 00:00 UTC | 1年間 | 長期保管 |
+
+### バックアップ先
+
+- **ローカル**: `backups/` ディレクトリ（開発用）
+- **本番**: Cloudflare R2 または AWS S3（環境変数 `BACKUP_STORAGE_URL` で指定）
+
+---
+
+## 必要なツール・環境変数
+
+### Turso CLI のインストール
+
+```bash
+# macOS / Linux
+curl -sSfL https://get.tur.so/install.sh | bash
+
+# バージョン確認
+turso --version
+```
+
+### 必要な環境変数
+
+```bash
+# .env または CI/CD シークレットに設定
+TURSO_ORG_NAME=your-org-name          # Turso 組織名
+TURSO_DB_NAME=techclip-prod           # データベース名
+TURSO_AUTH_TOKEN=your-auth-token      # 認証トークン（turso auth token で取得）
+BACKUP_DIR=./backups                  # バックアップ保存先ディレクトリ
+BACKUP_STORAGE_URL=                   # (省略可) リモートストレージ URL
+```
+
+### 認証トークンの取得
+
+```bash
+# Turso にログイン
+turso auth login
+
+# トークン取得
+turso auth token
+```
+
+---
+
+## バックアップ手順
+
+### 手動バックアップ
+
+```bash
+# バックアップスクリプトを実行
+./scripts/db-backup.sh
+
+# 特定のデータベースを指定してバックアップ
+TURSO_DB_NAME=techclip-staging ./scripts/db-backup.sh
+```
+
+### バックアップ内容
+
+`db-backup.sh` は以下を実行します。
+
+1. Turso CLI で対象 DB に接続
+2. `.dump` コマンドで SQL ダンプを取得
+3. タイムスタンプ付きファイル名で保存（例: `techclip-prod_20240101_120000.sql`）
+4. gzip 圧縮（`.sql.gz`）
+5. （設定済みの場合）リモートストレージへアップロード
+
+### バックアップファイルの確認
+
+```bash
+ls -lh backups/
+# 出力例:
+# techclip-prod_20240101_020000.sql.gz  1.2M
+# techclip-prod_20231231_020000.sql.gz  1.1M
+```
+
+---
+
+## リストア手順
+
+### リストアスクリプトを使用する場合
+
+```bash
+# 最新バックアップからリストア
+./scripts/db-restore.sh backups/techclip-prod_20240101_020000.sql.gz
+
+# 解凍済み SQL ファイルからリストア
+./scripts/db-restore.sh backups/techclip-prod_20240101_020000.sql
+```
+
+### 手動リストア手順
+
+```bash
+# 1. バックアップファイルを解凍
+gunzip backups/techclip-prod_20240101_020000.sql.gz
+
+# 2. Turso CLI でリストア
+turso db shell $TURSO_DB_NAME < backups/techclip-prod_20240101_020000.sql
+
+# 3. データ確認
+turso db shell $TURSO_DB_NAME "SELECT count(*) FROM users;"
+```
+
+---
+
+## 定期バックアップの設定
+
+### Cron（サーバー運用の場合）
+
+```bash
+# crontab -e で以下を追加
+# 毎日 02:00 UTC にバックアップ
+0 2 * * * /path/to/tech_clip/scripts/db-backup.sh >> /var/log/db-backup.log 2>&1
+
+# 毎週日曜 00:00 UTC にフルバックアップ
+0 0 * * 0 BACKUP_RETENTION_DAYS=365 /path/to/tech_clip/scripts/db-backup.sh >> /var/log/db-backup-weekly.log 2>&1
+```
+
+### GitHub Actions（推奨）
+
+```yaml
+# .github/workflows/db-backup.yml
+name: DB Backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 毎日 02:00 UTC
+  workflow_dispatch:        # 手動実行も可能
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Turso CLI
+        run: curl -sSfL https://get.tur.so/install.sh | bash
+
+      - name: Run backup
+        env:
+          TURSO_ORG_NAME: ${{ secrets.TURSO_ORG_NAME }}
+          TURSO_DB_NAME: ${{ secrets.TURSO_DB_NAME }}
+          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+          BACKUP_STORAGE_URL: ${{ secrets.BACKUP_STORAGE_URL }}
+        run: ./scripts/db-backup.sh
+```
+
+---
+
+## 障害対応フロー
+
+```
+障害発生
+  │
+  ├─ 影響範囲の確認
+  │    └─ turso db shell $TURSO_DB_NAME "SELECT 1;"
+  │
+  ├─ 最新バックアップの特定
+  │    └─ ls -lt backups/ | head -5
+  │
+  ├─ リストア実行
+  │    └─ ./scripts/db-restore.sh <backup-file>
+  │
+  └─ データ整合性の確認
+       └─ 主要テーブルのレコード数を確認
+```
+
+---
+
+## 重要な注意事項
+
+- **本番リストア前に必ず現在の状態をバックアップすること**
+- **リストアは本番データを上書きするため、必ず2名以上で確認してから実行**
+- `TURSO_AUTH_TOKEN` は絶対にコードにハードコードしないこと（環境変数必須）
+- バックアップファイルには機密データが含まれるため、アクセス権限を制限すること
+- リストア後は必ずアプリケーションの動作確認を行うこと

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Turso DB バックアップスクリプト
+#
+# 使用方法:
+#   ./scripts/db-backup.sh
+#
+# 必要な環境変数:
+#   TURSO_ORG_NAME    - Turso 組織名
+#   TURSO_DB_NAME     - データベース名
+#   TURSO_AUTH_TOKEN  - 認証トークン（turso auth token で取得）
+#   BACKUP_DIR        - バックアップ保存先ディレクトリ（省略時: ./backups）
+#   BACKUP_STORAGE_URL - (省略可) リモートストレージ URL
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 設定
+# ---------------------------------------------------------------------------
+
+# バックアップ保存先ディレクトリ
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+
+# バックアップ保持日数（この日数より古いファイルを削除）
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+
+# タイムスタンプ（ファイル名に使用）
+TIMESTAMP="$(date -u '+%Y%m%d_%H%M%S')"
+
+# ---------------------------------------------------------------------------
+# 必須環境変数チェック
+# ---------------------------------------------------------------------------
+
+check_required_env() {
+  local missing=0
+
+  if [[ -z "${TURSO_ORG_NAME:-}" ]]; then
+    echo "[ERROR] 環境変数 TURSO_ORG_NAME が設定されていません" >&2
+    missing=1
+  fi
+
+  if [[ -z "${TURSO_DB_NAME:-}" ]]; then
+    echo "[ERROR] 環境変数 TURSO_DB_NAME が設定されていません" >&2
+    missing=1
+  fi
+
+  if [[ -z "${TURSO_AUTH_TOKEN:-}" ]]; then
+    echo "[ERROR] 環境変数 TURSO_AUTH_TOKEN が設定されていません" >&2
+    missing=1
+  fi
+
+  if [[ "$missing" -eq 1 ]]; then
+    echo "[ERROR] 必須環境変数が不足しています。.env ファイルまたは CI/CD シークレットを確認してください" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Turso CLI の存在確認
+# ---------------------------------------------------------------------------
+
+check_turso_cli() {
+  if ! command -v turso &>/dev/null; then
+    echo "[ERROR] turso CLI が見つかりません" >&2
+    echo "[INFO]  インストール: curl -sSfL https://get.tur.so/install.sh | bash" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# バックアップ実行
+# ---------------------------------------------------------------------------
+
+run_backup() {
+  local db_url="libsql://${TURSO_DB_NAME}-${TURSO_ORG_NAME}.turso.io"
+  local backup_file="${BACKUP_DIR}/${TURSO_DB_NAME}_${TIMESTAMP}.sql"
+  local compressed_file="${backup_file}.gz"
+
+  echo "[INFO] バックアップ開始: ${TURSO_DB_NAME} (${TIMESTAMP})"
+  echo "[INFO] 接続先: ${db_url}"
+
+  # バックアップディレクトリを作成
+  mkdir -p "$BACKUP_DIR"
+
+  # Turso DB から SQL ダンプを取得
+  # TURSO_AUTH_TOKEN を環境変数として渡す
+  if ! TURSO_TOKEN="$TURSO_AUTH_TOKEN" turso db shell "$db_url" .dump > "$backup_file" 2>/dev/null; then
+    # turso db shell は db 名でも接続できる
+    if ! turso db shell "$TURSO_DB_NAME" .dump > "$backup_file"; then
+      echo "[ERROR] バックアップの取得に失敗しました" >&2
+      rm -f "$backup_file"
+      exit 1
+    fi
+  fi
+
+  # ダンプファイルが空でないことを確認
+  if [[ ! -s "$backup_file" ]]; then
+    echo "[ERROR] バックアップファイルが空です" >&2
+    rm -f "$backup_file"
+    exit 1
+  fi
+
+  echo "[INFO] SQL ダンプ取得完了: ${backup_file}"
+
+  # gzip 圧縮
+  gzip "$backup_file"
+  echo "[INFO] 圧縮完了: ${compressed_file}"
+
+  # ファイルサイズを表示
+  local size
+  size="$(du -sh "$compressed_file" | cut -f1)"
+  echo "[INFO] バックアップサイズ: ${size}"
+
+  # リモートストレージへアップロード（設定済みの場合）
+  if [[ -n "${BACKUP_STORAGE_URL:-}" ]]; then
+    upload_to_remote "$compressed_file"
+  fi
+
+  echo "[INFO] バックアップ完了: ${compressed_file}"
+}
+
+# ---------------------------------------------------------------------------
+# リモートストレージへアップロード
+# ---------------------------------------------------------------------------
+
+upload_to_remote() {
+  local file="$1"
+  local filename
+  filename="$(basename "$file")"
+
+  echo "[INFO] リモートストレージへアップロード中: ${BACKUP_STORAGE_URL}/${filename}"
+
+  # rclone が利用可能な場合
+  if command -v rclone &>/dev/null; then
+    rclone copy "$file" "${BACKUP_STORAGE_URL}/"
+    echo "[INFO] rclone アップロード完了"
+    return
+  fi
+
+  # aws CLI が利用可能な場合（S3 互換）
+  if command -v aws &>/dev/null; then
+    aws s3 cp "$file" "${BACKUP_STORAGE_URL}/${filename}"
+    echo "[INFO] S3 アップロード完了"
+    return
+  fi
+
+  echo "[WARN] リモートアップロードツールが見つかりません（rclone または aws CLI が必要）" >&2
+}
+
+# ---------------------------------------------------------------------------
+# 古いバックアップの削除
+# ---------------------------------------------------------------------------
+
+cleanup_old_backups() {
+  echo "[INFO] ${BACKUP_RETENTION_DAYS} 日以上前のバックアップを削除中..."
+
+  local deleted_count=0
+  while IFS= read -r -d '' file; do
+    rm -f "$file"
+    echo "[INFO] 削除: ${file}"
+    ((deleted_count++)) || true
+  done < <(find "$BACKUP_DIR" -name "*.sql.gz" -mtime +"$BACKUP_RETENTION_DAYS" -print0 2>/dev/null)
+
+  if [[ "$deleted_count" -eq 0 ]]; then
+    echo "[INFO] 削除対象のバックアップはありません"
+  else
+    echo "[INFO] ${deleted_count} 件のバックアップを削除しました"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# メイン処理
+# ---------------------------------------------------------------------------
+
+main() {
+  check_required_env
+  check_turso_cli
+  run_backup
+  cleanup_old_backups
+  echo "[INFO] すべての処理が完了しました"
+}
+
+main "$@"

--- a/scripts/db-restore.sh
+++ b/scripts/db-restore.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Turso DB リストアスクリプト
+#
+# 使用方法:
+#   ./scripts/db-restore.sh <backup-file>
+#
+#   例:
+#     ./scripts/db-restore.sh backups/techclip-prod_20240101_020000.sql.gz
+#     ./scripts/db-restore.sh backups/techclip-prod_20240101_020000.sql
+#
+# 必要な環境変数:
+#   TURSO_ORG_NAME    - Turso 組織名
+#   TURSO_DB_NAME     - データベース名
+#   TURSO_AUTH_TOKEN  - 認証トークン（turso auth token で取得）
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 引数チェック
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  echo "使用方法: $0 <backup-file>" >&2
+  echo "" >&2
+  echo "例:" >&2
+  echo "  $0 backups/techclip-prod_20240101_020000.sql.gz" >&2
+  echo "  $0 backups/techclip-prod_20240101_020000.sql" >&2
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+
+# ---------------------------------------------------------------------------
+# 必須環境変数チェック
+# ---------------------------------------------------------------------------
+
+check_required_env() {
+  local missing=0
+
+  if [[ -z "${TURSO_ORG_NAME:-}" ]]; then
+    echo "[ERROR] 環境変数 TURSO_ORG_NAME が設定されていません" >&2
+    missing=1
+  fi
+
+  if [[ -z "${TURSO_DB_NAME:-}" ]]; then
+    echo "[ERROR] 環境変数 TURSO_DB_NAME が設定されていません" >&2
+    missing=1
+  fi
+
+  if [[ -z "${TURSO_AUTH_TOKEN:-}" ]]; then
+    echo "[ERROR] 環境変数 TURSO_AUTH_TOKEN が設定されていません" >&2
+    missing=1
+  fi
+
+  if [[ "$missing" -eq 1 ]]; then
+    echo "[ERROR] 必須環境変数が不足しています。.env ファイルまたは CI/CD シークレットを確認してください" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Turso CLI の存在確認
+# ---------------------------------------------------------------------------
+
+check_turso_cli() {
+  if ! command -v turso &>/dev/null; then
+    echo "[ERROR] turso CLI が見つかりません" >&2
+    echo "[INFO]  インストール: curl -sSfL https://get.tur.so/install.sh | bash" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# バックアップファイルの確認
+# ---------------------------------------------------------------------------
+
+check_backup_file() {
+  if [[ ! -f "$BACKUP_FILE" ]]; then
+    echo "[ERROR] バックアップファイルが見つかりません: ${BACKUP_FILE}" >&2
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 確認プロンプト
+# ---------------------------------------------------------------------------
+
+confirm_restore() {
+  local db_url="libsql://${TURSO_DB_NAME}-${TURSO_ORG_NAME}.turso.io"
+
+  echo ""
+  echo "=================================================================="
+  echo "  警告: データベースリストアを実行します"
+  echo "=================================================================="
+  echo "  対象DB : ${TURSO_DB_NAME}"
+  echo "  接続先 : ${db_url}"
+  echo "  ファイル: ${BACKUP_FILE}"
+  echo "=================================================================="
+  echo ""
+  echo "この操作は現在のデータベースの内容を上書きします。"
+  echo "実行前に現在のデータをバックアップしてください。"
+  echo ""
+  read -r -p "続行しますか？ (yes/no): " answer
+
+  if [[ "$answer" != "yes" ]]; then
+    echo "[INFO] リストアをキャンセルしました"
+    exit 0
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# リストア前に現在の状態をバックアップ
+# ---------------------------------------------------------------------------
+
+backup_current_state() {
+  echo "[INFO] リストア前に現在の状態をバックアップ中..."
+
+  local pre_restore_dir="./backups/pre-restore"
+  mkdir -p "$pre_restore_dir"
+
+  local timestamp
+  timestamp="$(date -u '+%Y%m%d_%H%M%S')"
+  local pre_restore_file="${pre_restore_dir}/${TURSO_DB_NAME}_pre-restore_${timestamp}.sql"
+
+  if turso db shell "$TURSO_DB_NAME" .dump > "$pre_restore_file" 2>/dev/null; then
+    gzip "$pre_restore_file"
+    echo "[INFO] 現在の状態をバックアップしました: ${pre_restore_file}.gz"
+  else
+    echo "[WARN] 現在の状態のバックアップに失敗しました（DB が空の可能性があります）" >&2
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# SQL ファイルの準備（解凍が必要な場合）
+# ---------------------------------------------------------------------------
+
+prepare_sql_file() {
+  if [[ "$BACKUP_FILE" == *.gz ]]; then
+    echo "[INFO] バックアップファイルを解凍中..."
+
+    # 一時ファイルに解凍（元ファイルを保持するため -k オプション）
+    TEMP_SQL_FILE="${BACKUP_FILE%.gz}"
+
+    # 解凍先が既に存在する場合は削除
+    if [[ -f "$TEMP_SQL_FILE" ]]; then
+      rm -f "$TEMP_SQL_FILE"
+    fi
+
+    gunzip -k "$BACKUP_FILE"
+    SQL_FILE="$TEMP_SQL_FILE"
+    CLEANUP_TEMP=true
+    echo "[INFO] 解凍完了: ${SQL_FILE}"
+  else
+    SQL_FILE="$BACKUP_FILE"
+    CLEANUP_TEMP=false
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# リストア実行
+# ---------------------------------------------------------------------------
+
+run_restore() {
+  local db_url="libsql://${TURSO_DB_NAME}-${TURSO_ORG_NAME}.turso.io"
+
+  echo "[INFO] リストア開始: ${TURSO_DB_NAME}"
+  echo "[INFO] 接続先: ${db_url}"
+
+  if ! turso db shell "$TURSO_DB_NAME" < "$SQL_FILE"; then
+    echo "[ERROR] リストアに失敗しました" >&2
+
+    # 一時ファイルのクリーンアップ
+    if [[ "${CLEANUP_TEMP:-false}" == "true" && -f "${SQL_FILE:-}" ]]; then
+      rm -f "$SQL_FILE"
+    fi
+
+    exit 1
+  fi
+
+  echo "[INFO] リストア完了"
+}
+
+# ---------------------------------------------------------------------------
+# 一時ファイルのクリーンアップ
+# ---------------------------------------------------------------------------
+
+cleanup_temp_files() {
+  if [[ "${CLEANUP_TEMP:-false}" == "true" && -f "${SQL_FILE:-}" ]]; then
+    rm -f "$SQL_FILE"
+    echo "[INFO] 一時ファイルを削除しました: ${SQL_FILE}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# リストア後の確認
+# ---------------------------------------------------------------------------
+
+verify_restore() {
+  echo "[INFO] リストア結果を確認中..."
+
+  local tables
+  tables="$(turso db shell "$TURSO_DB_NAME" ".tables" 2>/dev/null || echo "")"
+
+  if [[ -z "$tables" ]]; then
+    echo "[WARN] テーブルが見つかりません。リストア内容を確認してください" >&2
+    return
+  fi
+
+  echo "[INFO] 復元されたテーブル:"
+  echo "$tables" | while read -r table; do
+    if [[ -n "$table" ]]; then
+      local count
+      count="$(turso db shell "$TURSO_DB_NAME" "SELECT count(*) FROM ${table};" 2>/dev/null | tail -1 || echo "?")"
+      echo "  - ${table}: ${count} 件"
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# メイン処理
+# ---------------------------------------------------------------------------
+
+main() {
+  check_required_env
+  check_turso_cli
+  check_backup_file
+  confirm_restore
+  backup_current_state
+  prepare_sql_file
+  run_restore
+  cleanup_temp_files
+  verify_restore
+  echo "[INFO] すべての処理が完了しました"
+  echo "[INFO] アプリケーションの動作確認を行ってください"
+}
+
+main "$@"


### PR DESCRIPTION
## 概要

Turso DB のバックアップ戦略を文書化し、バックアップ・リストアの実行スクリプトを追加しました。

## 変更内容

- `docs/DB_BACKUP.md`: バックアップ戦略、スケジュール、実行手順、障害対応フローを記載
- `scripts/db-backup.sh`: Turso CLI を使用した SQL ダンプ取得・gzip 圧縮・古いファイル自動削除
- `scripts/db-restore.sh`: バックアップファイルからのリストア（確認プロンプト・リストア前自動バックアップ付き）

## テスト

- `bash -n` による構文チェック: 両スクリプトとも SYNTAX OK
- TDD 対象外（ドキュメント・スクリプトのみの Issue）

## 関連Issue

Closes #150