### PR TITLE
docs: add DB migration rollback strategy #163

### DIFF
--- a/docs/DB_MIGRATION_ROLLBACK.md
+++ b/docs/DB_MIGRATION_ROLLBACK.md
@@ -1,0 +1,251 @@
+# DB マイグレーション ロールバック戦略
+
+## 概要
+
+本ドキュメントは、Drizzle Kit を使用したデータベースマイグレーションの失敗時に、安全かつ迅速にロールバックするための手順を定義します。
+
+---
+
+## 基本方針
+
+| 原則 | 内容 |
+|------|------|
+| バックアップ優先 | マイグレーション前に必ずバックアップを取得する |
+| ステージング検証 | 本番適用前にステージング環境で検証する |
+| 最小変更単位 | 1マイグレーション = 1論理変更（大きな変更は分割する） |
+| 前進優先 | 可能な場合はロールバックより前進修正（fix-forward）を優先する |
+
+---
+
+## Drizzle マイグレーションの仕組み
+
+Drizzle Kit は `drizzle/` ディレクトリにマイグレーションファイルを生成し、`__drizzle_migrations` テーブルで適用済みマイグレーションを追跡します。
+
+```
+drizzle/
+├── meta/
+│   ├── _journal.json        # マイグレーション適用履歴
+│   └── 0000_snapshot.json   # スキーマスナップショット
+├── 0000_initial_schema.sql
+├── 0001_add_users_table.sql
+└── 0002_add_posts_table.sql
+```
+
+**重要**: Drizzle Kit には組み込みのロールバックコマンドがありません。ロールバックは手動 SQL または前進修正で対応します。
+
+---
+
+## マイグレーション前チェックリスト
+
+マイグレーションを実行する前に、以下をすべて完了してください。
+
+### 必須作業
+
+- [ ] **データベースバックアップを取得する**（後述の手順参照）
+- [ ] ステージング環境でマイグレーションを検証済みである
+- [ ] ロールバック SQL を事前に生成・確認済みである（`scripts/generate-rollback.sh` を使用）
+- [ ] マイグレーション実行中のサービスダウンタイムを関係者に通知済みである
+- [ ] DB に接続しているアプリケーションの状態を確認した（接続数、実行中クエリ）
+
+### バックアップ手順（Turso / libSQL）
+
+```bash
+# ローカル開発（SQLite）
+cp local.db local.db.backup-$(date +%Y%m%d-%H%M%S)
+
+# Turso 本番環境
+# Turso は自動バックアップを提供しているが、手動スナップショットも推奨
+turso db shell <DB_NAME> ".dump" > backup-$(date +%Y%m%d-%H%M%S).sql
+```
+
+---
+
+## ロールバック手順
+
+### ステップ 1: 障害の確認
+
+```bash
+# エラーログを確認
+pnpm drizzle-kit migrate 2>&1 | tee migration.log
+
+# 適用済みマイグレーションを確認
+turso db shell <DB_NAME> "SELECT * FROM __drizzle_migrations ORDER BY created_at DESC LIMIT 10;"
+```
+
+### ステップ 2: ロールバック SQL の実行
+
+`scripts/generate-rollback.sh` で生成したロールバック SQL を適用します。
+
+```bash
+# ロールバック SQL の生成（事前に実施しておくことが推奨）
+./scripts/generate-rollback.sh drizzle/0002_add_posts_table.sql
+
+# 生成されたロールバック SQL を確認
+cat drizzle/rollback/0002_add_posts_table.rollback.sql
+
+# ロールバック SQL を適用（ローカル SQLite）
+sqlite3 local.db < drizzle/rollback/0002_add_posts_table.rollback.sql
+
+# ロールバック SQL を適用（Turso 本番環境）
+turso db shell <DB_NAME> < drizzle/rollback/0002_add_posts_table.rollback.sql
+```
+
+### ステップ 3: マイグレーション追跡テーブルの修正
+
+ロールバック SQL 適用後、Drizzle のマイグレーション追跡テーブルからエントリを削除します。
+
+```bash
+# ロールバックしたマイグレーションのエントリを削除
+turso db shell <DB_NAME> \
+  "DELETE FROM __drizzle_migrations WHERE tag = '0002_add_posts_table';"
+```
+
+### ステップ 4: アプリケーションの動作確認
+
+```bash
+# ローカルでアプリを起動して動作確認
+pnpm dev
+
+# ヘルスチェック
+curl http://localhost:8787/health
+```
+
+### ステップ 5: 原因調査と修正
+
+ロールバック完了後、以下を実施します。
+
+1. マイグレーション失敗の原因を特定する
+2. `src/db/schema.ts` を修正する
+3. 新しいマイグレーションファイルを生成する（**既存のマイグレーションファイルは編集しない**）
+4. ステージング環境で再検証する
+
+```bash
+# 修正後、新しいマイグレーションを生成
+pnpm drizzle-kit generate --name fix_posts_table_constraint
+pnpm drizzle-kit migrate
+```
+
+---
+
+## 一般的なロールバックパターン
+
+### カラム追加のロールバック
+
+```sql
+-- 元のマイグレーション（0003_add_bio_to_users.sql）
+ALTER TABLE users ADD COLUMN bio TEXT;
+
+-- ロールバック SQL
+ALTER TABLE users DROP COLUMN bio;
+-- __drizzle_migrations からエントリを削除
+DELETE FROM __drizzle_migrations WHERE tag = '0003_add_bio_to_users';
+```
+
+### テーブル作成のロールバック
+
+```sql
+-- 元のマイグレーション
+CREATE TABLE posts (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  user_id TEXT NOT NULL REFERENCES users(id)
+);
+
+-- ロールバック SQL
+DROP TABLE IF EXISTS posts;
+DELETE FROM __drizzle_migrations WHERE tag = '0002_add_posts_table';
+```
+
+### インデックス追加のロールバック
+
+```sql
+-- 元のマイグレーション
+CREATE INDEX idx_users_email ON users(email);
+
+-- ロールバック SQL
+DROP INDEX IF EXISTS idx_users_email;
+DELETE FROM __drizzle_migrations WHERE tag = '0004_add_email_index';
+```
+
+### カラム名変更のロールバック（非破壊的アプローチ）
+
+SQLite はカラム名変更をサポートしていません。非破壊的な方法を使用します。
+
+```sql
+-- 推奨アプローチ: 新旧カラムを並存させる
+-- 元のマイグレーション（新カラム追加）
+ALTER TABLE users ADD COLUMN display_name TEXT;
+UPDATE users SET display_name = name;
+
+-- ロールバック SQL（新カラムを削除し古いカラムを保持）
+ALTER TABLE users DROP COLUMN display_name;
+DELETE FROM __drizzle_migrations WHERE tag = '0005_rename_name_to_display_name';
+```
+
+---
+
+## ステージング環境でのロールバック検証
+
+本番環境に適用する前に、必ずステージング環境でロールバック手順を検証します。
+
+```bash
+# 1. ステージング DB でマイグレーションを適用
+DATABASE_URL=$STAGING_DATABASE_URL pnpm drizzle-kit migrate
+
+# 2. ロールバック SQL を生成
+./scripts/generate-rollback.sh drizzle/<migration_file>.sql
+
+# 3. ステージング DB でロールバックを実行
+turso db shell $STAGING_DB_NAME < drizzle/rollback/<migration_file>.rollback.sql
+
+# 4. データ整合性を確認
+turso db shell $STAGING_DB_NAME "SELECT COUNT(*) FROM users;"
+
+# 5. アプリケーションを再起動して動作確認
+```
+
+---
+
+## 緊急ロールバック（本番障害時）
+
+本番環境でマイグレーション失敗が発生した場合の緊急手順です。
+
+```bash
+# 1. アプリケーションを停止してトラフィックをブロック（必要に応じて）
+# Cloudflare Workers の場合: ルートを一時的に無効化
+
+# 2. バックアップからリストア（最終手段）
+turso db shell <DB_NAME> < backup-YYYYMMDD-HHMMSS.sql
+
+# 3. または生成済みロールバック SQL を適用
+turso db shell <DB_NAME> < drizzle/rollback/<migration>.rollback.sql
+
+# 4. マイグレーション追跡テーブルを修正
+turso db shell <DB_NAME> "DELETE FROM __drizzle_migrations WHERE tag = '<migration_tag>';"
+
+# 5. アプリケーションを再起動
+# 6. ヘルスチェックで動作確認
+# 7. インシデントレポートを作成
+```
+
+---
+
+## データ損失リスクが高いマイグレーション
+
+以下のマイグレーションは特に注意が必要です。ロールバック SQL を必ず事前準備してください。
+
+| 操作 | リスク | 対策 |
+|------|--------|------|
+| `DROP TABLE` | データ消失 | バックアップ必須、前進修正を検討 |
+| `DROP COLUMN` | データ消失 | バックアップ必須 |
+| `NOT NULL` 制約追加 | 既存データで失敗の可能性 | デフォルト値を先に設定 |
+| 外部キー制約追加 | 既存データで失敗の可能性 | データ整合性を事前確認 |
+| データ型変更 | データ損失の可能性 | 段階的移行（新カラム追加 → データコピー → 旧カラム削除） |
+
+---
+
+## 関連ドキュメント
+
+- [ROADMAP.md](./ROADMAP.md) - 実装ロードマップ
+- [Drizzle Kit 公式ドキュメント](https://orm.drizzle.team/kit-docs/overview)
+- `scripts/generate-rollback.sh` - ロールバック SQL 生成スクリプト

--- a/scripts/generate-rollback.sh
+++ b/scripts/generate-rollback.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+#
+# generate-rollback.sh
+# Drizzle マイグレーションファイルからロールバック SQL を生成するスクリプト
+#
+# 使用方法:
+#   ./scripts/generate-rollback.sh <migration_file>
+#   ./scripts/generate-rollback.sh drizzle/0002_add_posts_table.sql
+#
+# 出力:
+#   drizzle/rollback/<migration_name>.rollback.sql
+#
+# 注意:
+#   - このスクリプトはヒューリスティックなパターンマッチングを使用します
+#   - 生成されたロールバック SQL は必ず手動で確認・修正してください
+#   - 複雑なマイグレーション（データ変換等）は手動でロールバック SQL を作成してください
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 定数
+# ---------------------------------------------------------------------------
+
+## ロールバック SQL の出力ディレクトリ
+ROLLBACK_DIR="drizzle/rollback"
+
+# ---------------------------------------------------------------------------
+# 関数定義
+# ---------------------------------------------------------------------------
+
+print_usage() {
+  echo "使用方法: $0 <migration_file>"
+  echo ""
+  echo "例:"
+  echo "  $0 drizzle/0002_add_posts_table.sql"
+  echo "  $0 drizzle/0003_add_bio_to_users.sql"
+  echo ""
+  echo "出力: ${ROLLBACK_DIR}/<migration_name>.rollback.sql"
+}
+
+print_error() {
+  echo "[ERROR] $1" >&2
+}
+
+print_info() {
+  echo "[INFO] $1"
+}
+
+print_warn() {
+  echo "[WARN] $1"
+}
+
+# CREATE TABLE -> DROP TABLE
+generate_drop_table() {
+  local table_name="$1"
+  echo "DROP TABLE IF EXISTS ${table_name};"
+}
+
+# ALTER TABLE ADD COLUMN -> ALTER TABLE DROP COLUMN
+generate_drop_column() {
+  local table_name="$1"
+  local column_name="$2"
+  echo "ALTER TABLE ${table_name} DROP COLUMN IF EXISTS ${column_name};"
+}
+
+# CREATE INDEX -> DROP INDEX
+generate_drop_index() {
+  local index_name="$1"
+  echo "DROP INDEX IF EXISTS ${index_name};"
+}
+
+# CREATE UNIQUE INDEX -> DROP INDEX
+generate_drop_unique_index() {
+  local index_name="$1"
+  echo "DROP INDEX IF EXISTS ${index_name};"
+}
+
+# マイグレーションタグを __drizzle_migrations から削除
+generate_delete_migration_record() {
+  local migration_tag="$1"
+  echo ""
+  echo "-- マイグレーション追跡テーブルからエントリを削除"
+  echo "DELETE FROM __drizzle_migrations WHERE tag = '${migration_tag}';"
+}
+
+# ---------------------------------------------------------------------------
+# メイン処理
+# ---------------------------------------------------------------------------
+
+# 引数チェック
+if [ $# -eq 0 ]; then
+  print_usage
+  exit 1
+fi
+
+MIGRATION_FILE="$1"
+
+# ファイル存在チェック
+if [ ! -f "${MIGRATION_FILE}" ]; then
+  print_error "マイグレーションファイルが見つかりません: ${MIGRATION_FILE}"
+  exit 1
+fi
+
+# ファイル名からマイグレーション名を抽出（拡張子なし）
+MIGRATION_BASENAME=$(basename "${MIGRATION_FILE}" .sql)
+
+# ロールバック出力ファイルのパス
+ROLLBACK_FILE="${ROLLBACK_DIR}/${MIGRATION_BASENAME}.rollback.sql"
+
+# 出力ディレクトリを作成
+mkdir -p "${ROLLBACK_DIR}"
+
+print_info "マイグレーションファイルを解析中: ${MIGRATION_FILE}"
+
+# ロールバック SQL ファイルのヘッダーを生成
+cat > "${ROLLBACK_FILE}" << EOF
+-- ============================================================
+-- ロールバック SQL: ${MIGRATION_BASENAME}
+-- 生成日時: $(date '+%Y-%m-%d %H:%M:%S')
+-- 元ファイル: ${MIGRATION_FILE}
+--
+-- 警告: このファイルはヒューリスティックにより自動生成されました。
+--       実行前に必ず内容を確認・修正してください。
+--       特に以下の点に注意:
+--         - DROP 操作はデータを削除します（バックアップを確認してください）
+--         - 複雑な変換ロジックは手動で追記が必要な場合があります
+-- ============================================================
+
+BEGIN;
+
+EOF
+
+GENERATED_STATEMENTS=0
+
+# マイグレーション SQL を行ごとに解析
+while IFS= read -r line; do
+  # 空行・コメント行はスキップ
+  trimmed_line=$(echo "${line}" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+  if [ -z "${trimmed_line}" ] || [[ "${trimmed_line}" == --* ]]; then
+    continue
+  fi
+
+  # CREATE TABLE の検出
+  if echo "${trimmed_line}" | grep -qiE "^CREATE[[:space:]]+(TABLE|TABLE[[:space:]]+IF[[:space:]]+NOT[[:space:]]+EXISTS)"; then
+    table_name=$(echo "${trimmed_line}" | grep -oiE "(TABLE[[:space:]]+(IF[[:space:]]+NOT[[:space:]]+EXISTS[[:space:]]+)?)\`?\"?([a-zA-Z_][a-zA-Z0-9_]*)\`?\"?" | awk '{print $NF}' | tr -d '`"')
+    if [ -n "${table_name}" ]; then
+      echo "-- ロールバック: CREATE TABLE ${table_name}" >> "${ROLLBACK_FILE}"
+      generate_drop_table "${table_name}" >> "${ROLLBACK_FILE}"
+      echo "" >> "${ROLLBACK_FILE}"
+      GENERATED_STATEMENTS=$((GENERATED_STATEMENTS + 1))
+      print_info "  検出: CREATE TABLE ${table_name} -> DROP TABLE ${table_name}"
+    fi
+  fi
+
+  # ALTER TABLE ADD COLUMN の検出
+  if echo "${trimmed_line}" | grep -qiE "^ALTER[[:space:]]+TABLE.+ADD[[:space:]]+COLUMN"; then
+    table_name=$(echo "${trimmed_line}" | grep -oiE "TABLE[[:space:]]+\`?\"?([a-zA-Z_][a-zA-Z0-9_]*)\`?\"?" | awk '{print $NF}' | tr -d '`"')
+    column_name=$(echo "${trimmed_line}" | grep -oiE "ADD[[:space:]]+COLUMN[[:space:]]+\`?\"?([a-zA-Z_][a-zA-Z0-9_]*)\`?\"?" | awk '{print $NF}' | tr -d '`"')
+    if [ -n "${table_name}" ] && [ -n "${column_name}" ]; then
+      echo "-- ロールバック: ALTER TABLE ${table_name} ADD COLUMN ${column_name}" >> "${ROLLBACK_FILE}"
+      generate_drop_column "${table_name}" "${column_name}" >> "${ROLLBACK_FILE}"
+      echo "" >> "${ROLLBACK_FILE}"
+      GENERATED_STATEMENTS=$((GENERATED_STATEMENTS + 1))
+      print_info "  検出: ADD COLUMN ${column_name} on ${table_name} -> DROP COLUMN ${column_name}"
+    fi
+  fi
+
+  # CREATE INDEX の検出
+  if echo "${trimmed_line}" | grep -qiE "^CREATE[[:space:]]+INDEX"; then
+    index_name=$(echo "${trimmed_line}" | grep -oiE "INDEX[[:space:]]+(IF[[:space:]]+NOT[[:space:]]+EXISTS[[:space:]]+)?\`?\"?([a-zA-Z_][a-zA-Z0-9_]*)\`?\"?" | awk '{print $NF}' | tr -d '`"')
+    if [ -n "${index_name}" ]; then
+      echo "-- ロールバック: CREATE INDEX ${index_name}" >> "${ROLLBACK_FILE}"
+      generate_drop_index "${index_name}" >> "${ROLLBACK_FILE}"
+      echo "" >> "${ROLLBACK_FILE}"
+      GENERATED_STATEMENTS=$((GENERATED_STATEMENTS + 1))
+      print_info "  検出: CREATE INDEX ${index_name} -> DROP INDEX ${index_name}"
+    fi
+  fi
+
+  # CREATE UNIQUE INDEX の検出
+  if echo "${trimmed_line}" | grep -qiE "^CREATE[[:space:]]+UNIQUE[[:space:]]+INDEX"; then
+    index_name=$(echo "${trimmed_line}" | grep -oiE "INDEX[[:space:]]+(IF[[:space:]]+NOT[[:space:]]+EXISTS[[:space:]]+)?\`?\"?([a-zA-Z_][a-zA-Z0-9_]*)\`?\"?" | awk '{print $NF}' | tr -d '`"')
+    if [ -n "${index_name}" ]; then
+      echo "-- ロールバック: CREATE UNIQUE INDEX ${index_name}" >> "${ROLLBACK_FILE}"
+      generate_drop_unique_index "${index_name}" >> "${ROLLBACK_FILE}"
+      echo "" >> "${ROLLBACK_FILE}"
+      GENERATED_STATEMENTS=$((GENERATED_STATEMENTS + 1))
+      print_info "  検出: CREATE UNIQUE INDEX ${index_name} -> DROP INDEX ${index_name}"
+    fi
+  fi
+
+  # DROP TABLE の警告（ロールバックには元のデータが必要）
+  if echo "${trimmed_line}" | grep -qiE "^DROP[[:space:]]+TABLE"; then
+    print_warn "  DROP TABLE を検出しました。ロールバックにはバックアップからのデータリストアが必要です。"
+    echo "-- 警告: DROP TABLE のロールバックにはバックアップからのデータリストアが必要です" >> "${ROLLBACK_FILE}"
+    echo "-- 元のテーブル定義と全データを手動でリストアしてください" >> "${ROLLBACK_FILE}"
+    echo "" >> "${ROLLBACK_FILE}"
+  fi
+
+done < "${MIGRATION_FILE}"
+
+# マイグレーション追跡テーブルのエントリ削除を追加
+generate_delete_migration_record "${MIGRATION_BASENAME}" >> "${ROLLBACK_FILE}"
+
+# トランザクション終了
+cat >> "${ROLLBACK_FILE}" << EOF
+
+COMMIT;
+EOF
+
+# 結果の報告
+echo ""
+if [ "${GENERATED_STATEMENTS}" -eq 0 ]; then
+  print_warn "自動生成されたロールバック文がありません。"
+  print_warn "マイグレーションに手動ロールバック SQL の追記が必要な可能性があります。"
+  print_warn "出力ファイルを確認してください: ${ROLLBACK_FILE}"
+else
+  print_info "ロールバック SQL を生成しました: ${ROLLBACK_FILE}"
+  print_info "生成されたロールバック文: ${GENERATED_STATEMENTS} 件"
+fi
+
+echo ""
+print_warn "============================================================"
+print_warn "重要: 実行前に ${ROLLBACK_FILE} の内容を必ず確認してください。"
+print_warn "特に DROP 操作はデータを削除します。バックアップを確認してください。"
+print_warn "============================================================"


### PR DESCRIPTION
## 概要

Drizzle Kit マイグレーションの失敗時に安全かつ迅速にロールバックするための戦略ドキュメントとスクリプトを追加しました。

## 変更内容

- `docs/DB_MIGRATION_ROLLBACK.md`: ロールバック戦略の全体ドキュメント
  - ロールバック戦略の基本方針
  - Drizzle マイグレーションの仕組みの説明
  - マイグレーション前チェックリスト（バックアップ手順含む）
  - ステップバイステップのロールバック手順
  - 一般的なロールバックパターン（CREATE TABLE, ADD COLUMN, CREATE INDEX 等）
  - ステージング環境での検証手順
  - 本番障害時の緊急ロールバック手順
  - データ損失リスクが高いマイグレーションの注意事項

- `scripts/generate-rollback.sh`: ロールバック SQL 自動生成スクリプト
  - マイグレーション SQL を解析してロールバック SQL を自動生成
  - CREATE TABLE → DROP TABLE
  - ALTER TABLE ADD COLUMN → DROP COLUMN
  - CREATE INDEX / CREATE UNIQUE INDEX → DROP INDEX
  - DROP TABLE の警告出力
  - __drizzle_migrations テーブルのエントリ削除 SQL も自動生成
  - bash -n で構文チェック済み

## テスト

- TDD対象外（ドキュメント・スクリプトのみ）
- bash -n scripts/generate-rollback.sh で構文チェック通過済み

## 関連Issue

Closes #163