### PR TITLE
feat: apply confirmation dialogs and success feedback to all screens

### DIFF
--- a/apps/mobile/__tests__/screens/profile-edit.test.tsx
+++ b/apps/mobile/__tests__/screens/profile-edit.test.tsx
@@ -1,0 +1,75 @@
+import { Alert } from "react-native";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+
+import ProfileEditScreen from "../../app/profile/edit";
+
+const mockBack = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+jest.mock("../../src/stores/auth-store", () => ({
+  useAuthStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ user: { name: "テストユーザー", image: null } }),
+  ),
+}));
+
+jest.mock("expo-image-picker", () => ({
+  requestMediaLibraryPermissionsAsync: jest.fn().mockResolvedValue({ granted: false }),
+  launchImageLibraryAsync: jest.fn(),
+  MediaTypeOptions: { Images: "Images" },
+}));
+
+jest.spyOn(Alert, "alert");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProfileEditScreen", () => {
+  describe("保存成功時のフィードバック", () => {
+    it("保存ボタンを押すと保存処理が実行されること", async () => {
+      // Arrange
+      render(<ProfileEditScreen />);
+
+      // Act
+      fireEvent.press(screen.getByText("保存する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockBack).toHaveBeenCalled();
+      });
+    });
+
+    it("保存成功後にトーストメッセージが表示されること", async () => {
+      // Arrange
+      render(<ProfileEditScreen />);
+
+      // Act
+      fireEvent.press(screen.getByText("保存する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("プロフィールを更新しました")).toBeTruthy();
+      });
+    });
+  });
+
+  describe("バリデーションエラー", () => {
+    it("名前が空の場合エラーメッセージが表示されること", async () => {
+      // Arrange
+      render(<ProfileEditScreen />);
+      const nameInput = screen.getByPlaceholderText("名前を入力");
+      fireEvent.changeText(nameInput, "");
+
+      // Act
+      fireEvent.press(screen.getByText("保存する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("名前を入力してください")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/apps/mobile/__tests__/screens/settings.test.tsx
+++ b/apps/mobile/__tests__/screens/settings.test.tsx
@@ -1,0 +1,79 @@
+import { Alert } from "react-native";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import SettingsScreen from "../../app/(tabs)/settings";
+
+const mockSignOut = jest.fn();
+
+jest.mock("../../src/stores/auth-store", () => ({
+  useAuthStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ signOut: mockSignOut, user: { name: "テストユーザー", email: "test@example.com" } }),
+  ),
+}));
+
+jest.spyOn(Alert, "alert");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SettingsScreen", () => {
+  describe("ログアウト", () => {
+    it("ログアウトボタンを押すと確認ダイアログが表示されること", () => {
+      // Arrange
+      render(<SettingsScreen />);
+
+      // Act
+      fireEvent.press(screen.getByText("ログアウト"));
+
+      // Assert
+      expect(Alert.alert).toHaveBeenCalledTimes(1);
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "ログアウト",
+        expect.any(String),
+        expect.any(Array),
+      );
+    });
+
+    it("確認ダイアログのキャンセルボタンを押してもサインアウトが実行されないこと", () => {
+      // Arrange
+      render(<SettingsScreen />);
+      fireEvent.press(screen.getByText("ログアウト"));
+
+      // Act
+      const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+      const cancelButton = buttons.find((b: { style: string }) => b.style === "cancel");
+      cancelButton.onPress?.();
+
+      // Assert
+      expect(mockSignOut).not.toHaveBeenCalled();
+    });
+
+    it("確認ダイアログの確認ボタンを押すとサインアウトが実行されること", () => {
+      // Arrange
+      render(<SettingsScreen />);
+      fireEvent.press(screen.getByText("ログアウト"));
+
+      // Act
+      const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+      const confirmButton = buttons.find((b: { style: string }) => b.style === "destructive");
+      confirmButton.onPress();
+
+      // Assert
+      expect(mockSignOut).toHaveBeenCalledTimes(1);
+    });
+
+    it("確認ダイアログのボタンがdestructiveスタイルであること", () => {
+      // Arrange
+      render(<SettingsScreen />);
+
+      // Act
+      fireEvent.press(screen.getByText("ログアウト"));
+
+      // Assert
+      const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+      const confirmButton = buttons.find((b: { style: string }) => b.style === "destructive");
+      expect(confirmButton).toBeDefined();
+    });
+  });
+});

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,8 +1,9 @@
 import { Bell, ChevronRight, CreditCard, Globe, LogOut, User } from "lucide-react-native";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
+import { Pressable, ScrollView, Switch, Text, View } from "react-native";
 
+import { confirm } from "@/components/ConfirmDialog";
 import { useAuthStore } from "../../src/stores/auth-store";
 
 /** 設定セクションの区切り線コンポーネント */
@@ -86,16 +87,16 @@ export default function SettingsScreen() {
    * ログアウト確認ダイアログを表示し、確認後にサインアウトを実行する
    */
   function handleLogout() {
-    Alert.alert("ログアウト", "ログアウトしますか？", [
-      { text: "キャンセル", style: "cancel" },
-      {
-        text: "ログアウト",
-        style: "destructive",
-        onPress: () => {
-          signOut();
-        },
+    confirm({
+      title: "ログアウト",
+      message: "ログアウトしますか？",
+      variant: "danger",
+      confirmLabel: "ログアウト",
+      cancelLabel: "キャンセル",
+      onConfirm: () => {
+        signOut();
       },
-    ]);
+    });
   }
 
   /**

--- a/apps/mobile/app/article/save.tsx
+++ b/apps/mobile/app/article/save.tsx
@@ -1,13 +1,14 @@
 import * as Haptics from "expo-haptics";
 import { router, useLocalSearchParams } from "expo-router";
-import { AlertCircle, ArrowLeft, Check, ExternalLink, Loader2 } from "lucide-react-native";
-import { useCallback, useEffect, useState } from "react";
+import { AlertCircle, ArrowLeft, ExternalLink, Loader2 } from "lucide-react-native";
+import { useCallback, useState } from "react";
 import { Image, Pressable, ScrollView, Text, View } from "react-native";
 
 import { apiFetch } from "@/lib/api";
 import type { ArticlePreview, ParseArticleResponse, SaveArticleResponse } from "@/types/article";
 
-import { Badge, Button, Card, Input, Skeleton } from "@/components/ui";
+import { Badge, Button, Card, Input, Toast } from "@/components/ui";
+import { useToast } from "@/hooks/use-toast";
 
 /** URL正規表現パターン */
 const URL_PATTERN = /^https?:\/\/.+/;
@@ -18,17 +19,11 @@ const THUMBNAIL_HEIGHT = 160;
 /** ソースバッジのアイコンサイズ */
 const ICON_SIZE_SM = 14;
 
-/** 成功アイコンのサイズ */
-const ICON_SIZE_MD = 20;
-
 /** 戻るボタンのアイコンサイズ */
 const ICON_SIZE_LG = 24;
 
 /** エラーアイコンのサイズ */
 const ERROR_ICON_SIZE = 16;
-
-/** 成功メッセージの表示色 */
-const SUCCESS_COLOR = "#22c55e";
 
 /** エラーメッセージの表示色 */
 const ERROR_COLOR = "#ef4444";
@@ -65,15 +60,14 @@ export default function SaveScreen() {
   const [isFetching, setIsFetching] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [urlError, setUrlError] = useState<string | null>(null);
+  const { toast, show: showToast, dismiss: dismissToast } = useToast();
 
   /**
    * URLから記事をパースしてプレビュー表示する
    */
   const handleFetch = useCallback(async () => {
     setErrorMessage(null);
-    setSuccessMessage(null);
     setPreview(null);
 
     const validationError = validateUrl(url);
@@ -114,7 +108,6 @@ export default function SaveScreen() {
     }
 
     setErrorMessage(null);
-    setSuccessMessage(null);
     setIsSaving(true);
 
     try {
@@ -128,132 +121,132 @@ export default function SaveScreen() {
         return;
       }
 
-      setSuccessMessage("記事を保存しました");
+      showToast("記事を保存しました", "success");
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     } catch {
       setErrorMessage("記事の保存に失敗しました");
     } finally {
       setIsSaving(false);
     }
-  }, [preview, url]);
+  }, [preview, url, showToast]);
 
   return (
-    <ScrollView className="flex-1 bg-background" keyboardShouldPersistTaps="handled">
-      <View className="px-4 pt-4 pb-8">
-        {/* ヘッダー */}
-        <View className="flex-row items-center mb-6">
-          <Pressable onPress={() => router.back()} accessibilityLabel="戻る" className="mr-3 p-1">
-            <ArrowLeft size={ICON_SIZE_LG} color="#e2e8f0" />
-          </Pressable>
-          <Text className="text-xl font-bold text-text">記事を保存</Text>
-        </View>
-
-        {/* URL入力 */}
-        <View className="mb-4">
-          <Input
-            label="URL"
-            placeholder="https://"
-            value={url}
-            onChangeText={(text) => {
-              setUrl(text);
-              setUrlError(null);
-            }}
-            error={urlError ?? undefined}
-            keyboardType="url"
-            autoCapitalize="none"
-          />
-        </View>
-
-        {/* 取得ボタン */}
-        <View className="mb-6">
-          <Button onPress={handleFetch} disabled={isFetching} loading={isFetching}>
-            取得
-          </Button>
-        </View>
-
-        {/* ローディング */}
-        {isFetching && (
-          <View testID="fetch-loading" className="items-center py-8">
-            <Loader2 size={ICON_SIZE_LG} color={SPINNER_COLOR} />
-            <Text className="mt-2 text-text-muted text-sm">記事を取得中...</Text>
+    <View className="flex-1">
+      <Toast
+        message={toast.message}
+        variant={toast.variant}
+        visible={toast.visible}
+        onDismiss={dismissToast}
+      />
+      <ScrollView className="flex-1 bg-background" keyboardShouldPersistTaps="handled">
+        <View className="px-4 pt-4 pb-8">
+          {/* ヘッダー */}
+          <View className="flex-row items-center mb-6">
+            <Pressable onPress={() => router.back()} accessibilityLabel="戻る" className="mr-3 p-1">
+              <ArrowLeft size={ICON_SIZE_LG} color="#e2e8f0" />
+            </Pressable>
+            <Text className="text-xl font-bold text-text">記事を保存</Text>
           </View>
-        )}
 
-        {/* エラーメッセージ */}
-        {errorMessage && (
-          <View className="flex-row items-center gap-2 rounded-lg bg-error/10 border border-error/30 p-3 mb-4">
-            <AlertCircle size={ERROR_ICON_SIZE} color={ERROR_COLOR} />
-            <Text className="text-error text-sm flex-1">{errorMessage}</Text>
+          {/* URL入力 */}
+          <View className="mb-4">
+            <Input
+              label="URL"
+              placeholder="https://"
+              value={url}
+              onChangeText={(text) => {
+                setUrl(text);
+                setUrlError(null);
+              }}
+              error={urlError ?? undefined}
+              keyboardType="url"
+              autoCapitalize="none"
+            />
           </View>
-        )}
 
-        {/* 成功メッセージ */}
-        {successMessage && (
-          <View className="flex-row items-center gap-2 rounded-lg bg-success/10 border border-success/30 p-3 mb-4">
-            <Check size={ICON_SIZE_MD} color={SUCCESS_COLOR} />
-            <Text className="text-success text-sm flex-1">{successMessage}</Text>
+          {/* 取得ボタン */}
+          <View className="mb-6">
+            <Button onPress={handleFetch} disabled={isFetching} loading={isFetching}>
+              取得
+            </Button>
           </View>
-        )}
 
-        {/* プレビュー */}
-        {preview && !isFetching && (
-          <View testID="article-preview">
-            <Text className="text-text-muted text-sm font-medium mb-3">プレビュー</Text>
-            <Card>
-              {/* サムネイル */}
-              {preview.thumbnailUrl && (
-                <Image
-                  source={{ uri: preview.thumbnailUrl }}
-                  className="w-full rounded-lg mb-3"
-                  style={{ height: THUMBNAIL_HEIGHT }}
-                  resizeMode="cover"
-                  accessibilityLabel="記事のサムネイル"
-                />
-              )}
+          {/* ローディング */}
+          {isFetching && (
+            <View testID="fetch-loading" className="items-center py-8">
+              <Loader2 size={ICON_SIZE_LG} color={SPINNER_COLOR} />
+              <Text className="mt-2 text-text-muted text-sm">記事を取得中...</Text>
+            </View>
+          )}
 
-              {/* ソースバッジ + 読了時間 */}
-              <View className="flex-row items-center gap-2 mb-2">
-                <Badge>{preview.source}</Badge>
-                {preview.readingTimeMinutes && (
-                  <Text className="text-text-dim text-xs">
-                    {preview.readingTimeMinutes}分で読了
+          {/* エラーメッセージ */}
+          {errorMessage && (
+            <View className="flex-row items-center gap-2 rounded-lg bg-error/10 border border-error/30 p-3 mb-4">
+              <AlertCircle size={ERROR_ICON_SIZE} color={ERROR_COLOR} />
+              <Text className="text-error text-sm flex-1">{errorMessage}</Text>
+            </View>
+          )}
+
+          {/* プレビュー */}
+          {preview && !isFetching && (
+            <View testID="article-preview">
+              <Text className="text-text-muted text-sm font-medium mb-3">プレビュー</Text>
+              <Card>
+                {/* サムネイル */}
+                {preview.thumbnailUrl && (
+                  <Image
+                    source={{ uri: preview.thumbnailUrl }}
+                    className="w-full rounded-lg mb-3"
+                    style={{ height: THUMBNAIL_HEIGHT }}
+                    resizeMode="cover"
+                    accessibilityLabel="記事のサムネイル"
+                  />
+                )}
+
+                {/* ソースバッジ + 読了時間 */}
+                <View className="flex-row items-center gap-2 mb-2">
+                  <Badge>{preview.source}</Badge>
+                  {preview.readingTimeMinutes && (
+                    <Text className="text-text-dim text-xs">
+                      {preview.readingTimeMinutes}分で読了
+                    </Text>
+                  )}
+                </View>
+
+                {/* タイトル */}
+                <Text className="text-text text-lg font-bold mb-2">{preview.title}</Text>
+
+                {/* 著者 */}
+                {preview.author && (
+                  <Text className="text-text-muted text-sm mb-2">{preview.author}</Text>
+                )}
+
+                {/* 概要 */}
+                {preview.excerpt && (
+                  <Text className="text-text-muted text-sm leading-relaxed mb-3">
+                    {preview.excerpt}
                   </Text>
                 )}
+
+                {/* URL表示 */}
+                <View className="flex-row items-center gap-1">
+                  <ExternalLink size={ICON_SIZE_SM} color="#64748b" />
+                  <Text className="text-text-dim text-xs flex-1" numberOfLines={1}>
+                    {url.trim()}
+                  </Text>
+                </View>
+              </Card>
+
+              {/* 保存ボタン */}
+              <View className="mt-4">
+                <Button onPress={handleSave} disabled={isSaving} loading={isSaving}>
+                  保存する
+                </Button>
               </View>
-
-              {/* タイトル */}
-              <Text className="text-text text-lg font-bold mb-2">{preview.title}</Text>
-
-              {/* 著者 */}
-              {preview.author && (
-                <Text className="text-text-muted text-sm mb-2">{preview.author}</Text>
-              )}
-
-              {/* 概要 */}
-              {preview.excerpt && (
-                <Text className="text-text-muted text-sm leading-relaxed mb-3">
-                  {preview.excerpt}
-                </Text>
-              )}
-
-              {/* URL表示 */}
-              <View className="flex-row items-center gap-1">
-                <ExternalLink size={ICON_SIZE_SM} color="#64748b" />
-                <Text className="text-text-dim text-xs flex-1" numberOfLines={1}>
-                  {url.trim()}
-                </Text>
-              </View>
-            </Card>
-
-            {/* 保存ボタン */}
-            <View className="mt-4">
-              <Button onPress={handleSave} disabled={isSaving} loading={isSaving}>
-                保存する
-              </Button>
             </View>
-          </View>
-        )}
-      </View>
-    </ScrollView>
+          )}
+        </View>
+      </ScrollView>
+    </View>
   );
 }

--- a/apps/mobile/app/profile/edit.tsx
+++ b/apps/mobile/app/profile/edit.tsx
@@ -7,6 +7,8 @@ import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from "rea
 
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { Toast } from "@/components/ui/Toast";
+import { useToast } from "@/hooks/use-toast";
 import { useAuthStore } from "@/stores/auth-store";
 
 /** アバター画像のサイズ（px） */
@@ -123,6 +125,7 @@ export function validateProfileForm(data: ProfileFormData): FormErrors {
 export default function ProfileEditScreen() {
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
+  const { toast, show: showToast, dismiss: dismissToast } = useToast();
 
   const [formData, setFormData] = useState<ProfileFormData>({
     name: user?.name ?? "",
@@ -188,18 +191,25 @@ export default function ProfileEditScreen() {
 
     try {
       await new Promise((resolve) => setTimeout(resolve, 500));
+      showToast("プロフィールを更新しました", "success");
       router.back();
     } catch {
       Alert.alert("エラー", "プロフィールの保存に失敗しました");
     } finally {
       setIsSaving(false);
     }
-  }, [formData, router]);
+  }, [formData, router, showToast]);
 
   const displayName = formData.name || user?.name || "";
 
   return (
     <View testID="profile-edit-screen" className="flex-1 bg-background">
+      <Toast
+        message={toast.message}
+        variant={toast.variant}
+        visible={toast.visible}
+        onDismiss={dismissToast}
+      />
       <View className="flex-row items-center justify-between px-4 pt-14 pb-3 bg-surface border-b border-border">
         <Pressable
           testID="profile-edit-back-button"


### PR DESCRIPTION
## 概要

確認ダイアログとトースト通知を全画面に適用した。ログアウトなどの破壊的操作には確認ダイアログを、記事保存・プロフィール更新などの成功操作にはトースト通知を追加。

## 変更内容

- `settings.tsx`: ログアウトボタンに `ConfirmDialog` を使用した確認ダイアログを追加（`Alert.alert` から `confirm()` に変更）
- `profile/edit.tsx`: プロフィール保存成功時に `Toast` コンポーネントでフィードバック表示を追加
- `article/save.tsx`: 記事保存成功時に `Toast` コンポーネントでフィードバック表示を追加（インライン成功メッセージを削除）
- `__tests__/screens/settings.test.tsx`: ログアウト確認ダイアログのテストを追加
- `__tests__/screens/profile-edit.test.tsx`: プロフィール保存フィードバックのテストを追加

## テスト

- [x] Unit テスト追加・更新済み（settings, profile-edit）
- [ ] Integration テスト追加・更新済み
- [x] `pnpm lint` がエラーなしで通ること（biome check 済み）

## 関連Issue

Closes #158