### PR TITLE
docs: add app versioning strategy and bump script #153

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -7,7 +7,11 @@
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
-    "platforms": ["ios", "android", "web"],
+    "platforms": [
+      "ios",
+      "android",
+      "web"
+    ],
     "icon": "./assets/images/icon.svg",
     "splash": {
       "image": "./assets/images/splash-icon.svg",
@@ -16,14 +20,16 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.techclip.app"
+      "bundleIdentifier": "com.techclip.app",
+      "buildNumber": "1"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.svg",
         "backgroundColor": "#0c0a09"
       },
-      "package": "com.techclip.app"
+      "package": "com.techclip.app",
+      "versionCode": 1
     },
     "web": {
       "bundler": "metro",
@@ -38,7 +44,9 @@
             "NSExtensionActivationSupportsWebURLWithMaxCount": 1,
             "NSExtensionActivationSupportsWebPageWithMaxCount": 1
           },
-          "androidIntentFilters": ["text/*"]
+          "androidIntentFilters": [
+            "text/*"
+          ]
         }
       ]
     ]

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,114 @@
+# バージョニング戦略
+
+TechClip のバージョン管理方針を定義する。
+
+---
+
+## バージョン形式
+
+[Semantic Versioning 2.0.0](https://semver.org/lang/ja/) に準拠する。
+
+```
+MAJOR.MINOR.PATCH
+例: 1.2.3
+```
+
+| セグメント | 変更タイミング |
+|-----------|--------------|
+| MAJOR | 後方互換性のない変更（API破壊、DB構造の非互換変更） |
+| MINOR | 後方互換性を保った新機能追加 |
+| PATCH | 後方互換性を保ったバグ修正 |
+
+---
+
+## プラットフォーム別バージョン管理
+
+### iOS: buildNumber
+
+`app.json` の `expo.ios.buildNumber` はストアへの提出ごとに単調増加させる。
+
+```
+形式: 整数文字列（例: "42"）
+ルール: 同じ version でも buildNumber は必ず増加させる
+```
+
+### Android: versionCode
+
+`app.json` の `expo.android.versionCode` はストアへの提出ごとに単調増加させる。
+
+```
+形式: 整数（例: 42）
+ルール: 同じ version でも versionCode は必ず増加させる
+```
+
+### ルート package.json
+
+モノレポルートの `package.json` の `version` はアプリと同期させる。
+
+---
+
+## バージョンバンプの運用
+
+### 手順
+
+```bash
+# 1. バンプ種別を選択して実行
+./scripts/bump-version.sh patch   # バグ修正
+./scripts/bump-version.sh minor   # 新機能追加
+./scripts/bump-version.sh major   # 破壊的変更
+
+# 2. 変更を確認
+git diff
+
+# 3. コミット・プッシュ
+git add apps/mobile/app.json package.json
+git commit -m "chore: bump version to X.Y.Z"
+git push
+```
+
+### バンプ対象ファイル
+
+| ファイル | 更新フィールド |
+|---------|-------------|
+| `apps/mobile/app.json` | `expo.version`, `expo.ios.buildNumber`, `expo.android.versionCode` |
+| `package.json` | `version` |
+
+---
+
+## リリースフロー
+
+```
+開発完了
+  ↓
+RELEASE_CHECKLIST.md を確認
+  ↓
+bump-version.sh でバージョンバンプ
+  ↓
+PR 作成 → レビュー → マージ
+  ↓
+Git タグ付け: git tag v1.2.3
+  ↓
+EAS Build でビルド
+  ↓
+TestFlight / Internal Testing で検証
+  ↓
+ストア公開
+```
+
+---
+
+## バージョン対応表
+
+| バンプ種別 | 変更例 | 前 → 後 |
+|-----------|-------|---------|
+| patch | クラッシュ修正 | 1.2.3 → 1.2.4 |
+| minor | 新機能（お気に入り機能） | 1.2.3 → 1.3.0 |
+| major | 認証フロー刷新 | 1.2.3 → 2.0.0 |
+
+---
+
+## 注意事項
+
+- `buildNumber` / `versionCode` は一度公開したら絶対に下げない
+- `version` を変えない場合でも、ストア再提出時は `buildNumber` / `versionCode` を増加させる
+- MAJOR バンプ時は `RELEASE_CHECKLIST.md` の全項目を完了させること

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "tech-clip",
+  "version": "0.0.1",
   "private": true,
   "packageManager": "pnpm@10.7.1",
   "scripts": {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# bump-version.sh - TechClip バージョンバンプスクリプト
+#
+# 使い方:
+#   ./scripts/bump-version.sh patch   # 1.2.3 → 1.2.4
+#   ./scripts/bump-version.sh minor   # 1.2.3 → 1.3.0
+#   ./scripts/bump-version.sh major   # 1.2.3 → 2.0.0
+#
+# 更新対象:
+#   - apps/mobile/app.json  (expo.version, ios.buildNumber, android.versionCode)
+#   - package.json          (version)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+APP_JSON="${REPO_ROOT}/apps/mobile/app.json"
+PKG_JSON="${REPO_ROOT}/package.json"
+
+# --- 引数チェック ---
+
+BUMP_TYPE="${1:-}"
+
+if [[ -z "${BUMP_TYPE}" ]]; then
+  echo "エラー: バンプ種別を指定してください。"
+  echo "使い方: $0 <patch|minor|major>"
+  exit 1
+fi
+
+if [[ "${BUMP_TYPE}" != "patch" && "${BUMP_TYPE}" != "minor" && "${BUMP_TYPE}" != "major" ]]; then
+  echo "エラー: バンプ種別は patch / minor / major のいずれかを指定してください。"
+  echo "使い方: $0 <patch|minor|major>"
+  exit 1
+fi
+
+# --- ファイル存在確認 ---
+
+if [[ ! -f "${APP_JSON}" ]]; then
+  echo "エラー: ${APP_JSON} が見つかりません。"
+  exit 1
+fi
+
+if [[ ! -f "${PKG_JSON}" ]]; then
+  echo "エラー: ${PKG_JSON} が見つかりません。"
+  exit 1
+fi
+
+# --- jq の存在確認 ---
+
+if ! command -v jq &>/dev/null; then
+  echo "エラー: jq がインストールされていません。"
+  echo "  macOS: brew install jq"
+  echo "  Ubuntu: apt-get install jq"
+  exit 1
+fi
+
+# --- 現在のバージョン取得 ---
+
+CURRENT_VERSION="$(jq -r '.expo.version' "${APP_JSON}")"
+CURRENT_BUILD_NUMBER="$(jq -r '.expo.ios.buildNumber // "0"' "${APP_JSON}")"
+CURRENT_VERSION_CODE="$(jq -r '.expo.android.versionCode // 0' "${APP_JSON}")"
+
+if [[ -z "${CURRENT_VERSION}" || "${CURRENT_VERSION}" == "null" ]]; then
+  echo "エラー: app.json から expo.version を取得できませんでした。"
+  exit 1
+fi
+
+# --- 新バージョン計算 ---
+
+IFS='.' read -r MAJOR MINOR PATCH <<< "${CURRENT_VERSION}"
+
+case "${BUMP_TYPE}" in
+  major)
+    MAJOR=$((MAJOR + 1))
+    MINOR=0
+    PATCH=0
+    ;;
+  minor)
+    MINOR=$((MINOR + 1))
+    PATCH=0
+    ;;
+  patch)
+    PATCH=$((PATCH + 1))
+    ;;
+esac
+
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+NEW_BUILD_NUMBER=$((CURRENT_BUILD_NUMBER + 1))
+NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
+
+# --- 変更内容の表示 ---
+
+echo "バージョンバンプ: ${BUMP_TYPE}"
+echo ""
+echo "  version:     ${CURRENT_VERSION} → ${NEW_VERSION}"
+echo "  buildNumber: ${CURRENT_BUILD_NUMBER} → ${NEW_BUILD_NUMBER}"
+echo "  versionCode: ${CURRENT_VERSION_CODE} → ${NEW_VERSION_CODE}"
+echo ""
+
+# --- app.json の更新 ---
+
+UPDATED_APP_JSON="$(
+  jq \
+    --arg version "${NEW_VERSION}" \
+    --arg buildNumber "${NEW_BUILD_NUMBER}" \
+    --argjson versionCode "${NEW_VERSION_CODE}" \
+    '.expo.version = $version
+     | .expo.ios.buildNumber = $buildNumber
+     | .expo.android.versionCode = $versionCode' \
+    "${APP_JSON}"
+)"
+
+echo "${UPDATED_APP_JSON}" > "${APP_JSON}"
+echo "更新済み: ${APP_JSON}"
+
+# --- package.json の更新 ---
+
+UPDATED_PKG_JSON="$(
+  jq \
+    --arg version "${NEW_VERSION}" \
+    '.version = $version' \
+    "${PKG_JSON}"
+)"
+
+echo "${UPDATED_PKG_JSON}" > "${PKG_JSON}"
+echo "更新済み: ${PKG_JSON}"
+
+echo ""
+echo "完了: v${NEW_VERSION}"
+echo ""
+echo "次のステップ:"
+echo "  git add apps/mobile/app.json package.json"
+echo "  git commit -m \"chore: bump version to ${NEW_VERSION}\""


### PR DESCRIPTION
## 概要

アプリバージョニング戦略のドキュメントと自動バージョンバンプスクリプトを追加する。

## 変更内容

- `docs/VERSIONING.md`: semver 方針、iOS/Android のバージョン管理ルール、リリースフローを文書化
- `scripts/bump-version.sh`: `patch`/`minor`/`major` を引数に取り、`app.json` と `package.json` を自動更新するシェルスクリプト
- `apps/mobile/app.json`: `ios.buildNumber`（文字列）と `android.versionCode`（整数）フィールドを追加
- `package.json`: ルートに `version` フィールドを追加

## テスト

> このIssueはドキュメント・スクリプト・設定のみの変更のため、TDD対象外（CLAUDE.md「TDD対象外」に該当）

## 動作確認

```bash
# patch バンプ（0.0.1 → 0.0.2）
./scripts/bump-version.sh patch

# minor バンプ（0.0.1 → 0.1.0）
./scripts/bump-version.sh minor

# major バンプ（0.0.1 → 1.0.0）
./scripts/bump-version.sh major
```

## 関連Issue

Closes #153