### PR TITLE
feat: add token refresh and session expiry handling

### DIFF
--- a/apps/mobile/__tests__/screens/profile-edit.test.tsx
+++ b/apps/mobile/__tests__/screens/profile-edit.test.tsx
@@ -1,5 +1,5 @@
-import { Alert } from "react-native";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import { Alert } from "react-native";
 
 import ProfileEditScreen from "../../app/profile/edit";
 

--- a/apps/mobile/__tests__/screens/settings.test.tsx
+++ b/apps/mobile/__tests__/screens/settings.test.tsx
@@ -1,5 +1,5 @@
-import { Alert } from "react-native";
 import { fireEvent, render, screen } from "@testing-library/react-native";
+import { Alert } from "react-native";
 
 import SettingsScreen from "../../app/(tabs)/settings";
 
@@ -28,11 +28,7 @@ describe("SettingsScreen", () => {
 
       // Assert
       expect(Alert.alert).toHaveBeenCalledTimes(1);
-      expect(Alert.alert).toHaveBeenCalledWith(
-        "ログアウト",
-        expect.any(String),
-        expect.any(Array),
-      );
+      expect(Alert.alert).toHaveBeenCalledWith("ログアウト", expect.any(String), expect.any(Array));
     });
 
     it("確認ダイアログのキャンセルボタンを押してもサインアウトが実行されないこと", () => {

--- a/apps/mobile/src/lib/api.test.ts
+++ b/apps/mobile/src/lib/api.test.ts
@@ -1,0 +1,182 @@
+jest.mock("expo-constants", () => ({
+  __esModule: true,
+  default: {
+    expoConfig: {
+      extra: { apiUrl: "http://test-api.example.com" },
+    },
+  },
+}));
+
+jest.mock("./secure-store", () => ({
+  getAuthToken: jest.fn(),
+  getRefreshToken: jest.fn(),
+  setAuthToken: jest.fn(),
+  clearAuthTokens: jest.fn(),
+}));
+
+import { clearAuthTokens, getAuthToken, getRefreshToken, setAuthToken } from "./secure-store";
+
+import { SessionExpiredError, apiFetch } from "./api";
+
+/** モック型キャスト */
+const mockGetAuthToken = getAuthToken as jest.MockedFunction<typeof getAuthToken>;
+const mockGetRefreshToken = getRefreshToken as jest.MockedFunction<typeof getRefreshToken>;
+const mockSetAuthToken = setAuthToken as jest.MockedFunction<typeof setAuthToken>;
+const mockClearAuthTokens = clearAuthTokens as jest.MockedFunction<typeof clearAuthTokens>;
+
+/** fetchモック */
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+/**
+ * fetchレスポンスのモックヘルパー
+ */
+function createFetchResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+describe("apiFetch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthToken.mockResolvedValue("valid-access-token");
+    mockGetRefreshToken.mockResolvedValue("valid-refresh-token");
+    mockSetAuthToken.mockResolvedValue(undefined);
+    mockClearAuthTokens.mockResolvedValue(undefined);
+  });
+
+  describe("正常系", () => {
+    it("認証トークンをAuthorizationヘッダーに付与してリクエストを送信できること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(createFetchResponse({ success: true, data: { id: "1" } }));
+
+      // Act
+      const result = await apiFetch<{ success: true; data: { id: string } }>("/articles");
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://test-api.example.com/articles",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer valid-access-token",
+          }),
+        }),
+      );
+      expect(result).toEqual({ success: true, data: { id: "1" } });
+    });
+
+    it("トークンがない場合はAuthorizationヘッダーなしでリクエストを送信できること", async () => {
+      // Arrange
+      mockGetAuthToken.mockResolvedValue(null);
+      mockFetch.mockResolvedValue(createFetchResponse({ success: true, data: [] }));
+
+      // Act
+      await apiFetch<{ success: true; data: unknown[] }>("/public/articles");
+
+      // Assert
+      const callArgs = mockFetch.mock.calls[0][1] as RequestInit;
+      const headers = callArgs.headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe("トークンリフレッシュ", () => {
+    it("401レスポンス時にリフレッシュトークンでトークンを更新して再試行できること", async () => {
+      // Arrange
+      const newToken = "new-access-token";
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+        )
+        .mockResolvedValueOnce(createFetchResponse({ success: true, data: { token: newToken } }))
+        .mockResolvedValueOnce(createFetchResponse({ success: true, data: { id: "1" } }));
+
+      // Act
+      const result = await apiFetch<{ success: true; data: { id: string } }>("/articles");
+
+      // Assert
+      expect(mockSetAuthToken).toHaveBeenCalledWith(newToken);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ success: true, data: { id: "1" } });
+    });
+
+    it("401レスポンス時にリフレッシュトークンがなければSessionExpiredErrorをスローすること", async () => {
+      // Arrange
+      mockGetRefreshToken.mockResolvedValue(null);
+      mockFetch.mockResolvedValue(
+        createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it("リフレッシュAPIが失敗した場合はSessionExpiredErrorをスローすること", async () => {
+      // Arrange
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+        )
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "REFRESH_FAILED" } }, 401),
+        );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it("リフレッシュ後の再試行が401を返した場合はSessionExpiredErrorをスローすること", async () => {
+      // Arrange
+      const newToken = "new-access-token";
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+        )
+        .mockResolvedValueOnce(createFetchResponse({ success: true, data: { token: newToken } }))
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+        );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it("401以外のエラーはそのままレスポンスデータを返すこと", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse(
+          { success: false, error: { code: "NOT_FOUND", message: "見つかりません" } },
+          404,
+        ),
+      );
+
+      // Act
+      const result = await apiFetch("/articles/999");
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: { code: "NOT_FOUND", message: "見つかりません" },
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("SessionExpiredError", () => {
+    it("SessionExpiredErrorはErrorのサブクラスであること", () => {
+      // Arrange & Act
+      const error = new SessionExpiredError();
+
+      // Assert
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(SessionExpiredError);
+      expect(error.message).toBe("セッションの有効期限が切れました。再度ログインしてください");
+    });
+  });
+});

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,9 +1,31 @@
 import Constants from "expo-constants";
 
-import { getAuthToken } from "./secure-store";
+import { clearAuthTokens, getAuthToken, getRefreshToken, setAuthToken } from "./secure-store";
 
 /** API通信のタイムアウト（ミリ秒） */
 const REQUEST_TIMEOUT_MS = 15000;
+
+/** トークンリフレッシュAPIのパス */
+const REFRESH_TOKEN_PATH = "/auth/refresh";
+
+/**
+ * セッション期限切れエラー
+ * トークンリフレッシュに失敗した場合にスローする
+ */
+export class SessionExpiredError extends Error {
+  constructor() {
+    super("セッションの有効期限が切れました。再度ログインしてください");
+    this.name = "SessionExpiredError";
+  }
+}
+
+/**
+ * リフレッシュトークンAPIのレスポンス型
+ */
+type RefreshTokenResponse = {
+  success: true;
+  data: { token: string };
+};
 
 /**
  * APIのベースURLを取得する
@@ -18,42 +40,114 @@ function getBaseUrl(): string {
   return "http://localhost:8787";
 }
 
-/** APIのベースURL */
-const BASE_URL = getBaseUrl();
+/**
+ * タイムアウト付きfetchを実行する
+ *
+ * @param url - リクエストURL
+ * @param options - fetchオプション
+ * @returns fetchレスポンス
+ */
+async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 /**
- * Workers APIへのfetchラッパー
- * Authorizationヘッダーを自動付与する
+ * リクエストヘッダーを構築する
  *
- * @param path - APIパス（例: "/users"）
- * @param options - fetchオプション
- * @returns レスポンスデータ
+ * @param token - 認証トークン。nullの場合はAuthorizationヘッダーを付与しない
+ * @param existingHeaders - 既存のヘッダー
+ * @returns 構築済みヘッダー
  */
-export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const token = await getAuthToken();
-
+function buildHeaders(
+  token: string | null,
+  existingHeaders: Record<string, string>,
+): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    ...((options.headers as Record<string, string>) ?? {}),
+    ...existingHeaders,
   };
 
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  return headers;
+}
 
-  try {
-    const response = await fetch(`${BASE_URL}${path}`, {
-      ...options,
-      headers,
-      signal: controller.signal,
-    });
+/**
+ * リフレッシュトークンで新しいアクセストークンを取得する
+ *
+ * @returns 新しいアクセストークン
+ * @throws SessionExpiredError - リフレッシュに失敗した場合
+ */
+async function refreshAccessToken(): Promise<string> {
+  const refreshToken = await getRefreshToken();
 
-    const data = (await response.json()) as T;
-    return data;
-  } finally {
-    clearTimeout(timeoutId);
+  if (!refreshToken) {
+    await clearAuthTokens();
+    throw new SessionExpiredError();
   }
+
+  const response = await fetchWithTimeout(`${getBaseUrl()}${REFRESH_TOKEN_PATH}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  const data = (await response.json()) as RefreshTokenResponse | { success: false };
+
+  if (!data.success) {
+    await clearAuthTokens();
+    throw new SessionExpiredError();
+  }
+
+  const newToken = (data as RefreshTokenResponse).data.token;
+  await setAuthToken(newToken);
+  return newToken;
+}
+
+/**
+ * Workers APIへのfetchラッパー
+ * Authorizationヘッダーを自動付与し、401時はトークンリフレッシュを試みる
+ *
+ * @param path - APIパス（例: "/users"）
+ * @param options - fetchオプション
+ * @returns レスポンスデータ
+ * @throws SessionExpiredError - セッションが期限切れでリフレッシュにも失敗した場合
+ */
+export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = await getAuthToken();
+  const existingHeaders = (options.headers as Record<string, string>) ?? {};
+  const headers = buildHeaders(token, existingHeaders);
+
+  const response = await fetchWithTimeout(`${getBaseUrl()}${path}`, {
+    ...options,
+    headers,
+  });
+
+  if (response.status !== 401) {
+    return (await response.json()) as T;
+  }
+
+  const newToken = await refreshAccessToken();
+
+  const retryHeaders = buildHeaders(newToken, existingHeaders);
+  const retryResponse = await fetchWithTimeout(`${getBaseUrl()}${path}`, {
+    ...options,
+    headers: retryHeaders,
+  });
+
+  if (retryResponse.status === 401) {
+    await clearAuthTokens();
+    throw new SessionExpiredError();
+  }
+
+  return (await retryResponse.json()) as T;
 }

--- a/apps/mobile/src/stores/auth-store.test.ts
+++ b/apps/mobile/src/stores/auth-store.test.ts
@@ -1,0 +1,198 @@
+jest.mock("@/lib/api", () => ({
+  apiFetch: jest.fn(),
+  SessionExpiredError: class SessionExpiredError extends Error {
+    constructor() {
+      super("セッションの有効期限が切れました。再度ログインしてください");
+      this.name = "SessionExpiredError";
+    }
+  },
+}));
+
+jest.mock("@/lib/secure-store", () => ({
+  getAuthToken: jest.fn(),
+  setAuthToken: jest.fn(),
+  clearAuthTokens: jest.fn(),
+}));
+
+import { SessionExpiredError, apiFetch } from "@/lib/api";
+import { clearAuthTokens, getAuthToken, setAuthToken } from "@/lib/secure-store";
+import { useAuthStore } from "./auth-store";
+
+/** モック型キャスト */
+const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
+const mockGetAuthToken = getAuthToken as jest.MockedFunction<typeof getAuthToken>;
+const mockSetAuthToken = setAuthToken as jest.MockedFunction<typeof setAuthToken>;
+const mockClearAuthTokens = clearAuthTokens as jest.MockedFunction<typeof clearAuthTokens>;
+
+/** テスト用ユーザーデータ */
+const TEST_USER = {
+  id: "user-1",
+  email: "test@example.com",
+  name: "テストユーザー",
+  image: null,
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+/** テスト用セッションデータ */
+const TEST_SESSION = {
+  token: "test-access-token",
+  expiresAt: "2024-12-31T00:00:00Z",
+};
+
+describe("useAuthStore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.setState({
+      user: null,
+      session: null,
+      isAuthenticated: false,
+      isLoading: true,
+      sessionExpiredMessage: null,
+    });
+    mockSetAuthToken.mockResolvedValue(undefined);
+    mockClearAuthTokens.mockResolvedValue(undefined);
+  });
+
+  describe("signIn", () => {
+    it("有効な認証情報でサインインできること", async () => {
+      // Arrange
+      mockApiFetch.mockResolvedValue({
+        success: true,
+        data: { user: TEST_USER, session: TEST_SESSION },
+      });
+
+      // Act
+      await useAuthStore.getState().signIn({ email: "test@example.com", password: "Password123" });
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.user).toEqual(TEST_USER);
+      expect(state.session).toEqual(TEST_SESSION);
+      expect(mockSetAuthToken).toHaveBeenCalledWith(TEST_SESSION.token);
+    });
+
+    it("認証失敗時にエラーをスローすること", async () => {
+      // Arrange
+      mockApiFetch.mockResolvedValue({
+        success: false,
+        error: { code: "AUTH_INVALID", message: "認証情報が正しくありません" },
+      });
+
+      // Act & Assert
+      await expect(
+        useAuthStore.getState().signIn({ email: "wrong@example.com", password: "wrong" }),
+      ).rejects.toThrow("認証情報が正しくありません");
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    });
+  });
+
+  describe("signOut", () => {
+    it("サインアウト後にstateがクリアされること", async () => {
+      // Arrange
+      useAuthStore.setState({ user: TEST_USER, session: TEST_SESSION, isAuthenticated: true });
+
+      // Act
+      await useAuthStore.getState().signOut();
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("checkSession", () => {
+    it("有効なトークンがある場合にセッションを復元できること", async () => {
+      // Arrange
+      mockGetAuthToken.mockResolvedValue("valid-token");
+      mockApiFetch.mockResolvedValue({
+        success: true,
+        data: { user: TEST_USER, session: TEST_SESSION },
+      });
+
+      // Act
+      await useAuthStore.getState().checkSession();
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.user).toEqual(TEST_USER);
+      expect(state.isLoading).toBe(false);
+    });
+
+    it("トークンがない場合は未認証状態になること", async () => {
+      // Arrange
+      mockGetAuthToken.mockResolvedValue(null);
+
+      // Act
+      await useAuthStore.getState().checkSession();
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe("セッション期限切れハンドリング", () => {
+    it("初期状態でsessionExpiredMessageがnullであること", () => {
+      // Arrange & Act
+      const state = useAuthStore.getState();
+
+      // Assert
+      expect(state.sessionExpiredMessage).toBeNull();
+    });
+
+    it("handleSessionExpiredを呼ぶと認証状態がクリアされsessionExpiredMessageが設定されること", async () => {
+      // Arrange
+      useAuthStore.setState({ user: TEST_USER, session: TEST_SESSION, isAuthenticated: true });
+
+      // Act
+      await useAuthStore.getState().handleSessionExpired();
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.user).toBeNull();
+      expect(state.session).toBeNull();
+      expect(state.sessionExpiredMessage).toBe(
+        "セッションの有効期限が切れました。再度ログインしてください",
+      );
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it("clearSessionExpiredMessageを呼ぶとsessionExpiredMessageがnullになること", async () => {
+      // Arrange
+      useAuthStore.setState({
+        sessionExpiredMessage: "セッションの有効期限が切れました。再度ログインしてください",
+      });
+
+      // Act
+      useAuthStore.getState().clearSessionExpiredMessage();
+
+      // Assert
+      expect(useAuthStore.getState().sessionExpiredMessage).toBeNull();
+    });
+
+    it("checkSession時にSessionExpiredErrorがスローされたらhandleSessionExpiredが呼ばれること", async () => {
+      // Arrange
+      mockGetAuthToken.mockResolvedValue("expired-token");
+      mockApiFetch.mockRejectedValue(new SessionExpiredError());
+
+      // Act
+      await useAuthStore.getState().checkSession();
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.sessionExpiredMessage).toBe(
+        "セッションの有効期限が切れました。再度ログインしてください",
+      );
+    });
+  });
+});

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -1,17 +1,26 @@
 import { create } from "zustand";
 
-import { apiFetch } from "@/lib/api";
+import { SessionExpiredError, apiFetch } from "@/lib/api";
 import { clearAuthTokens, getAuthToken, setAuthToken } from "@/lib/secure-store";
 import type { AuthErrorResponse, Session, SignInParams, SignInResponse, User } from "@/types/auth";
+
+/** セッション期限切れメッセージ */
+const SESSION_EXPIRED_MESSAGE = "セッションの有効期限が切れました。再度ログインしてください";
 
 type AuthStore = {
   user: User | null;
   session: Session | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  /** セッション期限切れ時に表示するメッセージ。nullの場合は表示しない */
+  sessionExpiredMessage: string | null;
   signIn: (params: SignInParams) => Promise<void>;
   signOut: () => Promise<void>;
   checkSession: () => Promise<void>;
+  /** セッション期限切れを処理する。トークンをクリアしてログイン画面へ誘導する */
+  handleSessionExpired: () => Promise<void>;
+  /** セッション期限切れメッセージをクリアする */
+  clearSessionExpiredMessage: () => void;
 };
 
 export const useAuthStore = create<AuthStore>((set) => ({
@@ -19,6 +28,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
   session: null,
   isAuthenticated: false,
   isLoading: true,
+  sessionExpiredMessage: null,
 
   /**
    * メールとパスワードでサインインする
@@ -90,7 +100,19 @@ export const useAuthStore = create<AuthStore>((set) => ({
         isAuthenticated: true,
         isLoading: false,
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof SessionExpiredError) {
+        await clearAuthTokens();
+        set({
+          user: null,
+          session: null,
+          isAuthenticated: false,
+          isLoading: false,
+          sessionExpiredMessage: SESSION_EXPIRED_MESSAGE,
+        });
+        return;
+      }
+
       await clearAuthTokens();
       set({
         user: null,
@@ -99,5 +121,28 @@ export const useAuthStore = create<AuthStore>((set) => ({
         isLoading: false,
       });
     }
+  },
+
+  /**
+   * セッション期限切れを処理する
+   * トークンをクリアし、ログイン画面へ誘導するためのメッセージを設定する
+   */
+  handleSessionExpired: async () => {
+    await clearAuthTokens();
+
+    set({
+      user: null,
+      session: null,
+      isAuthenticated: false,
+      sessionExpiredMessage: SESSION_EXPIRED_MESSAGE,
+    });
+  },
+
+  /**
+   * セッション期限切れメッセージをクリアする
+   * ログイン画面でメッセージを表示した後に呼び出す
+   */
+  clearSessionExpiredMessage: () => {
+    set({ sessionExpiredMessage: null });
   },
 }));


### PR DESCRIPTION
## 概要

トークンリフレッシュとセッション期限切れ処理を実装しました。

## 変更内容

- `apps/mobile/src/lib/api.ts`: `apiFetch` ラッパーにトークンリフレッシュロジックを追加。401レスポンス時にリフレッシュトークンで再取得し、失敗時は `SessionExpiredError` をスロー
- `apps/mobile/src/lib/api.test.ts`: `apiFetch` のユニットテスト（正常系・401リフレッシュ・セッション期限切れ）
- `apps/mobile/src/stores/auth-store.ts`: `SessionExpiredError` を購読してログアウト処理を実行するセッション期限切れハンドラーを追加
- `apps/mobile/src/stores/auth-store.test.ts`: auth-store のユニットテスト

## テスト

- [x] Unit テスト追加・更新済み
- [x] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（17 tests passed）
- [x] `pnpm biome check` がエラーなしで通ること

## 関連Issue

Closes #126