### PR TITLE
feat: add EAS Build configuration for iOS and Android #95

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,48 @@
+{
+  "cli": {
+    "version": ">= 12.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      },
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "ios": {
+        "simulator": false
+      },
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "",
+        "ascAppId": "",
+        "appleTeamId": ""
+      },
+      "android": {
+        "serviceAccountKeyPath": "",
+        "track": "production"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 概要

EAS Build の設定ファイル (`apps/mobile/eas.json`) を追加しました。iOS および Android 向けに development・preview・production の3つのビルドプロファイルを定義しています。

## 変更内容

- `apps/mobile/eas.json` を新規作成
  - `development`: 開発用クライアント（iOS シミュレーター対応、Android APK）
  - `preview`: 内部配布用（iOS 実機、Android APK）
  - `production`: ストア公開用（iOS App Store、Android AAB）
  - `submit`: App Store / Google Play 提出設定の雛形

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [ ] `pnpm test` がすべてパスすること
- [ ] `pnpm lint` がエラーなしで通ること

> 注: 本 Issue は設定ファイルのみの変更であり、TDD 対象外です（環境設定・インフラ構成のみの変更）。

## 関連Issue

Closes #95