### PR TITLE
ci: add GitHub Actions workflow for automated EAS Build

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,48 @@
+name: EAS Build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-ios:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Build iOS
+        working-directory: apps/mobile
+        run: eas build --platform ios --profile production --non-interactive
+      - name: Submit iOS to App Store
+        working-directory: apps/mobile
+        run: eas submit --platform ios --latest --non-interactive
+
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Build Android
+        working-directory: apps/mobile
+        run: eas build --platform android --profile production --non-interactive
+      - name: Submit Android to Google Play
+        working-directory: apps/mobile
+        run: eas submit --platform android --latest --non-interactive


### PR DESCRIPTION
## Summary

- Add `.github/workflows/eas-build.yml` triggered on push to `main`
- iOS and Android build jobs run in parallel using `expo/expo-github-action@v8`
- Each job builds with `eas build --profile production` then submits to the respective store via `eas submit`
- Requires `EXPO_TOKEN` secret to be set in GitHub repository settings

## Required Secrets

| Secret | Description |
|--------|-------------|
| `EXPO_TOKEN` | Expo access token for EAS CLI authentication |

Store submission credentials (App Store Connect API key, Google Play service account JSON) must be configured in the EAS project dashboard at https://expo.dev.

## Test plan

- [ ] Verify `EXPO_TOKEN` secret is configured in GitHub repository settings
- [ ] Merge a commit to `main` and confirm both iOS and Android build jobs trigger
- [ ] Confirm builds appear in the EAS dashboard
- [ ] Confirm store submissions succeed after successful builds

Closes #160

🤖 Generated with [Claude Code](https://claude.ai/code)