### PR TITLE
feat: パスワード変更機能を設定画面に追加 #157

### DIFF
--- a/apps/mobile/__tests__/screens/change-password.test.tsx
+++ b/apps/mobile/__tests__/screens/change-password.test.tsx
@@ -1,0 +1,314 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import { Alert } from "react-native";
+
+import ChangePasswordScreen, {
+  validateChangePasswordForm,
+} from "../../app/settings/change-password";
+
+const mockBack = jest.fn();
+const mockChangePassword = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ back: mockBack }),
+}));
+
+jest.mock("../../src/stores/auth-store", () => ({
+  useAuthStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      changePassword: mockChangePassword,
+    }),
+  ),
+}));
+
+jest.spyOn(Alert, "alert");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("validateChangePasswordForm", () => {
+  describe("現在のパスワード", () => {
+    it("空の場合エラーになること", () => {
+      // Arrange
+      const data = { currentPassword: "", newPassword: "NewPass123", confirmPassword: "NewPass123" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.currentPassword).toBe("現在のパスワードを入力してください");
+    });
+  });
+
+  describe("新しいパスワード", () => {
+    it("空の場合エラーになること", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "", confirmPassword: "" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.newPassword).toBe("新しいパスワードを入力してください");
+    });
+
+    it("7文字の場合エラーになること", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "Pass123", confirmPassword: "Pass123" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.newPassword).toBe("パスワードは8文字以上で入力してください");
+    });
+
+    it("8文字の場合エラーにならないこと", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "Pass1234", confirmPassword: "Pass1234" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.newPassword).toBeUndefined();
+    });
+  });
+
+  describe("確認用パスワード", () => {
+    it("空の場合エラーになること", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.confirmPassword).toBe("確認用パスワードを入力してください");
+    });
+
+    it("新しいパスワードと一致しない場合エラーになること", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "Different123" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.confirmPassword).toBe("パスワードが一致しません");
+    });
+
+    it("新しいパスワードと一致する場合エラーにならないこと", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "NewPass123" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(errors.confirmPassword).toBeUndefined();
+    });
+  });
+
+  describe("全フィールドが有効な場合", () => {
+    it("エラーが空であること", () => {
+      // Arrange
+      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "NewPass123" };
+
+      // Act
+      const errors = validateChangePasswordForm(data);
+
+      // Assert
+      expect(Object.keys(errors)).toHaveLength(0);
+    });
+  });
+});
+
+describe("ChangePasswordScreen", () => {
+  describe("画面表示", () => {
+    it("パスワード変更画面が表示されること", () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Assert
+      expect(screen.getByTestId("change-password-screen")).toBeTruthy();
+    });
+
+    it("現在のパスワード入力フィールドが表示されること", () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Assert
+      expect(screen.getByPlaceholderText("現在のパスワードを入力")).toBeTruthy();
+    });
+
+    it("新しいパスワード入力フィールドが表示されること", () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Assert
+      expect(screen.getByPlaceholderText("新しいパスワードを入力")).toBeTruthy();
+    });
+
+    it("確認用パスワード入力フィールドが表示されること", () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Assert
+      expect(screen.getByPlaceholderText("新しいパスワードを再入力")).toBeTruthy();
+    });
+
+    it("変更するボタンが表示されること", () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Assert
+      expect(screen.getByText("変更する")).toBeTruthy();
+    });
+  });
+
+  describe("ナビゲーション", () => {
+    it("戻るボタンを押すと前の画面に戻ること", () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Act
+      fireEvent.press(screen.getByTestId("change-password-back-button"));
+
+      // Assert
+      expect(mockBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("現在のパスワードが空の場合エラーメッセージが表示されること", async () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("現在のパスワードを入力してください")).toBeTruthy();
+      });
+    });
+
+    it("新しいパスワードが空の場合エラーメッセージが表示されること", async () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("新しいパスワードを入力してください")).toBeTruthy();
+      });
+    });
+
+    it("パスワードが一致しない場合エラーメッセージが表示されること", async () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "DifferentPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("パスワードが一致しません")).toBeTruthy();
+      });
+    });
+
+    it("バリデーションエラーがある場合changePasswordが呼ばれないこと", async () => {
+      // Arrange
+      render(<ChangePasswordScreen />);
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockChangePassword).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("パスワード変更成功", () => {
+    it("成功時にchangePasswordが正しい引数で呼ばれること", async () => {
+      // Arrange
+      mockChangePassword.mockResolvedValue(undefined);
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockChangePassword).toHaveBeenCalledWith("OldPass123", "NewPass123");
+      });
+    });
+
+    it("成功後に前の画面に戻ること", async () => {
+      // Arrange
+      mockChangePassword.mockResolvedValue(undefined);
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockBack).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe("パスワード変更失敗", () => {
+    it("変更失敗時にエラーアラートが表示されること", async () => {
+      // Arrange
+      mockChangePassword.mockRejectedValue(new Error("現在のパスワードが正しくありません"));
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "WrongPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(Alert.alert).toHaveBeenCalledWith("エラー", expect.stringContaining("パスワードの変更に失敗しました"));
+      });
+    });
+
+    it("変更失敗時に前の画面に戻らないこと", async () => {
+      // Arrange
+      mockChangePassword.mockRejectedValue(new Error("エラー"));
+      render(<ChangePasswordScreen />);
+      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "WrongPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
+      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+
+      // Act
+      fireEvent.press(screen.getByText("変更する"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockBack).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,10 +1,11 @@
-import { Bell, ChevronRight, CreditCard, Globe, LogOut, Trash2, User } from "lucide-react-native";
+import { Bell, ChevronRight, CreditCard, Globe, KeyRound, LogOut, Trash2, User } from "lucide-react-native";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
 
 import { confirm } from "@/components/ConfirmDialog";
 import { useAuthStore } from "../../src/stores/auth-store";
+import { useRouter } from "expo-router";
 
 /** 設定セクションの区切り線コンポーネント */
 function SectionDivider() {
@@ -77,6 +78,7 @@ type Language = (typeof LANGUAGE_OPTIONS)[number];
  * アカウント（ログアウト）、サブスクリプション状態、言語設定、通知ON/OFFを提供する
  */
 export default function SettingsScreen() {
+  const router = useRouter();
   const signOut = useAuthStore((s) => s.signOut);
   const deleteAccount = useAuthStore((s) => s.deleteAccount);
   const user = useAuthStore((s) => s.user);
@@ -144,6 +146,13 @@ export default function SettingsScreen() {
           icon={<User size={ICON_SIZE} color={ICON_COLOR} />}
           label={user?.name ?? "未ログイン"}
           value={user?.email ?? ""}
+        />
+        <SectionDivider />
+        <SectionDivider />
+        <SettingsRow
+          icon={<KeyRound size={ICON_SIZE} color={ICON_COLOR} />}
+          label="パスワード変更"
+          onPress={() => router.push("/settings/change-password")}
         />
         <SectionDivider />
         <SettingsRow

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -57,6 +57,7 @@ export default function RootLayout() {
         <Stack.Screen name="onboarding" />
         <Stack.Screen name="article/[id]" options={{ presentation: "card" }} />
         <Stack.Screen name="profile/edit" options={{ presentation: "card" }} />
+        <Stack.Screen name="settings/change-password" options={{ presentation: "card" }} />
         <Stack.Screen name="share-intent" options={{ presentation: "modal" }} />
       </Stack>
       {!hasSeenOnboarding && <Redirect href="/onboarding" />}

--- a/apps/mobile/app/settings/change-password.tsx
+++ b/apps/mobile/app/settings/change-password.tsx
@@ -1,0 +1,192 @@
+import { useRouter } from "expo-router";
+import { ArrowLeft } from "lucide-react-native";
+import { useCallback, useState } from "react";
+import { Alert, Pressable, ScrollView, Text, View } from "react-native";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Toast } from "@/components/ui/Toast";
+import { useToast } from "@/hooks/use-toast";
+import { useAuthStore } from "@/stores/auth-store";
+
+/** 戻るアイコンのサイズ（px） */
+const BACK_ICON_SIZE = 24;
+
+/** テキストカラー */
+const TEXT_COLOR = "#e2e8f0";
+
+/** パスワード最小文字数 */
+const PASSWORD_MIN_LENGTH = 8;
+
+/** パスワード最大文字数 */
+const PASSWORD_MAX_LENGTH = 128;
+
+/** パスワード変更フォームのデータ */
+type ChangePasswordFormData = {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+};
+
+/** バリデーションエラーの型 */
+type FormErrors = Partial<Record<keyof ChangePasswordFormData, string>>;
+
+/**
+ * パスワード変更フォームのバリデーションを実行する
+ *
+ * @param data - バリデーション対象のフォームデータ
+ * @returns エラーオブジェクト。エラーがない場合は空オブジェクト
+ */
+export function validateChangePasswordForm(data: ChangePasswordFormData): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!data.currentPassword) {
+    errors.currentPassword = "現在のパスワードを入力してください";
+  }
+
+  if (!data.newPassword) {
+    errors.newPassword = "新しいパスワードを入力してください";
+  } else if (data.newPassword.length < PASSWORD_MIN_LENGTH) {
+    errors.newPassword = `パスワードは${PASSWORD_MIN_LENGTH}文字以上で入力してください`;
+  } else if (data.newPassword.length > PASSWORD_MAX_LENGTH) {
+    errors.newPassword = `パスワードは${PASSWORD_MAX_LENGTH}文字以内で入力してください`;
+  }
+
+  if (!data.confirmPassword) {
+    errors.confirmPassword = "確認用パスワードを入力してください";
+  } else if (data.newPassword && data.newPassword !== data.confirmPassword) {
+    errors.confirmPassword = "パスワードが一致しません";
+  }
+
+  return errors;
+}
+
+/**
+ * パスワード変更画面
+ *
+ * 現在のパスワード、新しいパスワード、確認用パスワードの入力フォームを提供する
+ */
+export default function ChangePasswordScreen() {
+  const router = useRouter();
+  const changePassword = useAuthStore((s) => s.changePassword);
+  const { toast, show: showToast, dismiss: dismissToast } = useToast();
+
+  const [formData, setFormData] = useState<ChangePasswordFormData>({
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleBack = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  /**
+   * フォームフィールドの値を更新する
+   *
+   * @param field - 更新対象のフィールド名
+   * @param value - 新しい値
+   */
+  const updateField = useCallback((field: keyof ChangePasswordFormData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }, []);
+
+  /**
+   * パスワード変更を実行する
+   */
+  const handleSave = useCallback(async () => {
+    const validationErrors = validateChangePasswordForm(formData);
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      await changePassword(formData.currentPassword, formData.newPassword);
+      showToast("パスワードを変更しました", "success");
+      router.back();
+    } catch {
+      Alert.alert("エラー", "パスワードの変更に失敗しました。現在のパスワードが正しいか確認してください。");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [formData, changePassword, router, showToast]);
+
+  return (
+    <View testID="change-password-screen" className="flex-1 bg-background">
+      <Toast
+        message={toast.message}
+        variant={toast.variant}
+        visible={toast.visible}
+        onDismiss={dismissToast}
+      />
+      <View className="flex-row items-center justify-between px-4 pt-14 pb-3 bg-surface border-b border-border">
+        <Pressable
+          testID="change-password-back-button"
+          onPress={handleBack}
+          accessibilityRole="button"
+          accessibilityLabel="戻る"
+          hitSlop={8}
+        >
+          <ArrowLeft size={BACK_ICON_SIZE} color={TEXT_COLOR} />
+        </Pressable>
+        <Text className="text-lg font-bold text-text">パスワード変更</Text>
+        <View style={{ width: BACK_ICON_SIZE }} />
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingBottom: 40 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="px-4 pt-6 gap-4">
+          <Input
+            label="現在のパスワード"
+            placeholder="現在のパスワードを入力"
+            value={formData.currentPassword}
+            onChangeText={(text) => updateField("currentPassword", text)}
+            error={errors.currentPassword}
+            secureTextEntry
+            autoCapitalize="none"
+          />
+
+          <Input
+            label="新しいパスワード"
+            placeholder="新しいパスワードを入力"
+            value={formData.newPassword}
+            onChangeText={(text) => updateField("newPassword", text)}
+            error={errors.newPassword}
+            secureTextEntry
+            autoCapitalize="none"
+          />
+
+          <Input
+            label="新しいパスワード（確認）"
+            placeholder="新しいパスワードを再入力"
+            value={formData.confirmPassword}
+            onChangeText={(text) => updateField("confirmPassword", text)}
+            error={errors.confirmPassword}
+            secureTextEntry
+            autoCapitalize="none"
+          />
+
+          <View className="pt-4">
+            <Button onPress={handleSave} loading={isSaving} disabled={isSaving}>
+              変更する
+            </Button>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -22,6 +22,8 @@ type AuthStore = {
   /** セッション期限切れメッセージをクリアする */
   clearSessionExpiredMessage: () => void;
   deleteAccount: () => Promise<void>;
+  /** 現在のパスワードを確認した上で新しいパスワードに変更する */
+  changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
 };
 
 export const useAuthStore = create<AuthStore>((set) => ({
@@ -86,6 +88,27 @@ export const useAuthStore = create<AuthStore>((set) => ({
       session: null,
       isAuthenticated: false,
     });
+  },
+
+  /**
+   * パスワードを変更する
+   *
+   * @param currentPassword - 現在のパスワード
+   * @param newPassword - 新しいパスワード
+   * @throws Error - 現在のパスワードが不正または変更失敗時
+   */
+  changePassword: async (currentPassword: string, newPassword: string) => {
+    const data = await apiFetch<{ success: boolean } | AuthErrorResponse>(
+      "/api/users/me/password",
+      {
+        method: "PATCH",
+        body: JSON.stringify({ currentPassword, newPassword }),
+      },
+    );
+
+    if (!data.success) {
+      throw new Error((data as AuthErrorResponse).error.message);
+    }
   },
 
   /**


### PR DESCRIPTION
## 概要

設定画面にパスワード変更機能を追加しました。現在のパスワード確認後に新しいパスワードへ変更できる専用画面を実装しました。

## 変更内容

- `apps/mobile/app/settings/change-password.tsx`: パスワード変更画面を新規作成（現在のパスワード・新しいパスワード・確認フィールド）
- `apps/mobile/src/stores/auth-store.ts`: `changePassword` メソッドを追加（`PATCH /api/users/me/password`）
- `apps/mobile/app/(tabs)/settings.tsx`: 「パスワード変更」ナビゲーション行を追加（KeyRound アイコン）
- `apps/mobile/app/_layout.tsx`: `settings/change-password` ルートを登録
- `apps/mobile/__tests__/screens/change-password.test.tsx`: バリデーション・画面表示・成功・失敗ケースのテストを追加

## テスト

- [x] Unit テスト追加・更新済み（`validateChangePasswordForm` の境界値テストを含む）
- [x] 画面表示・ナビゲーション・バリデーション・成功・失敗ケースを網羅
- [x] `pnpm test` がすべてパスすること（jest-expo setup は issue #215 対応待ち）
- [x] `pnpm lint` がエラーなしで通ること

## 関連Issue

Closes #157