### PR TITLE
test: add coverage configuration for API tests

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/**/*.spec.ts", "src/db/seed.ts"],
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Vitest のカバレッジ設定を追加（v8 プロバイダー、text + json-summary レポーター）
- `src/**/*.ts` を対象とし、テストファイルと seed ファイルを除外

## Test plan
- [ ] `pnpm --filter api test:coverage` でカバレッジレポートが出力されることを確認

Closes #100

🤖 Generated with [Claude Code](https://claude.ai/code)