### PR TITLE
feat: add password change screen in settings #157

### DIFF
--- a/apps/mobile/__tests__/screens/change-password.test.tsx
+++ b/apps/mobile/__tests__/screens/change-password.test.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import { Alert } from "react-native";
+import type { ReactTestInstance } from "react-test-renderer";
 
 import ChangePasswordScreen, {
   validateChangePasswordForm,
@@ -20,7 +21,33 @@ jest.mock("../../src/stores/auth-store", () => ({
   ),
 }));
 
+jest.mock("@/components/ui/Toast", () => ({
+  Toast: () => null,
+}));
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: { message: "", variant: "info", visible: false },
+    show: jest.fn(),
+    dismiss: jest.fn(),
+  }),
+}));
+
 jest.spyOn(Alert, "alert");
+
+/**
+ * propsでReactTestInstanceを検索するヘルパー
+ */
+function findByProps(root: ReactTestInstance, props: Record<string, unknown>): ReactTestInstance {
+  return root.findByProps(props);
+}
+
+/**
+ * placeholder属性でTextInputを検索するヘルパー
+ */
+function findInputByPlaceholder(root: ReactTestInstance, placeholder: string): ReactTestInstance {
+  return root.findByProps({ placeholder });
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -30,7 +57,11 @@ describe("validateChangePasswordForm", () => {
   describe("現在のパスワード", () => {
     it("空の場合エラーになること", () => {
       // Arrange
-      const data = { currentPassword: "", newPassword: "NewPass123", confirmPassword: "NewPass123" };
+      const data = {
+        currentPassword: "",
+        newPassword: "NewPass123",
+        confirmPassword: "NewPass123",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -54,7 +85,11 @@ describe("validateChangePasswordForm", () => {
 
     it("7文字の場合エラーになること", () => {
       // Arrange
-      const data = { currentPassword: "OldPass123", newPassword: "Pass123", confirmPassword: "Pass123" };
+      const data = {
+        currentPassword: "OldPass123",
+        newPassword: "Pass123",
+        confirmPassword: "Pass123",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -65,7 +100,11 @@ describe("validateChangePasswordForm", () => {
 
     it("8文字の場合エラーにならないこと", () => {
       // Arrange
-      const data = { currentPassword: "OldPass123", newPassword: "Pass1234", confirmPassword: "Pass1234" };
+      const data = {
+        currentPassword: "OldPass123",
+        newPassword: "Pass1234",
+        confirmPassword: "Pass1234",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -78,7 +117,11 @@ describe("validateChangePasswordForm", () => {
   describe("確認用パスワード", () => {
     it("空の場合エラーになること", () => {
       // Arrange
-      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "" };
+      const data = {
+        currentPassword: "OldPass123",
+        newPassword: "NewPass123",
+        confirmPassword: "",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -89,7 +132,11 @@ describe("validateChangePasswordForm", () => {
 
     it("新しいパスワードと一致しない場合エラーになること", () => {
       // Arrange
-      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "Different123" };
+      const data = {
+        currentPassword: "OldPass123",
+        newPassword: "NewPass123",
+        confirmPassword: "Different123",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -100,7 +147,11 @@ describe("validateChangePasswordForm", () => {
 
     it("新しいパスワードと一致する場合エラーにならないこと", () => {
       // Arrange
-      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "NewPass123" };
+      const data = {
+        currentPassword: "OldPass123",
+        newPassword: "NewPass123",
+        confirmPassword: "NewPass123",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -113,7 +164,11 @@ describe("validateChangePasswordForm", () => {
   describe("全フィールドが有効な場合", () => {
     it("エラーが空であること", () => {
       // Arrange
-      const data = { currentPassword: "OldPass123", newPassword: "NewPass123", confirmPassword: "NewPass123" };
+      const data = {
+        currentPassword: "OldPass123",
+        newPassword: "NewPass123",
+        confirmPassword: "NewPass123",
+      };
 
       // Act
       const errors = validateChangePasswordForm(data);
@@ -127,53 +182,53 @@ describe("validateChangePasswordForm", () => {
 describe("ChangePasswordScreen", () => {
   describe("画面表示", () => {
     it("パスワード変更画面が表示されること", () => {
-      // Arrange
-      render(<ChangePasswordScreen />);
+      // Arrange & Act
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Assert
-      expect(screen.getByTestId("change-password-screen")).toBeTruthy();
+      expect(findByProps(UNSAFE_root, { testID: "change-password-screen" })).toBeDefined();
     });
 
     it("現在のパスワード入力フィールドが表示されること", () => {
-      // Arrange
-      render(<ChangePasswordScreen />);
+      // Arrange & Act
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Assert
-      expect(screen.getByPlaceholderText("現在のパスワードを入力")).toBeTruthy();
+      expect(findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力")).toBeDefined();
     });
 
     it("新しいパスワード入力フィールドが表示されること", () => {
-      // Arrange
-      render(<ChangePasswordScreen />);
+      // Arrange & Act
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Assert
-      expect(screen.getByPlaceholderText("新しいパスワードを入力")).toBeTruthy();
+      expect(findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力")).toBeDefined();
     });
 
     it("確認用パスワード入力フィールドが表示されること", () => {
-      // Arrange
-      render(<ChangePasswordScreen />);
+      // Arrange & Act
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Assert
-      expect(screen.getByPlaceholderText("新しいパスワードを再入力")).toBeTruthy();
+      expect(findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力")).toBeDefined();
     });
 
     it("変更するボタンが表示されること", () => {
-      // Arrange
-      render(<ChangePasswordScreen />);
+      // Arrange & Act
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Assert
-      expect(screen.getByText("変更する")).toBeTruthy();
+      expect(findByProps(UNSAFE_root, { children: "変更する" })).toBeDefined();
     });
   });
 
   describe("ナビゲーション", () => {
     it("戻るボタンを押すと前の画面に戻ること", () => {
       // Arrange
-      render(<ChangePasswordScreen />);
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Act
-      fireEvent.press(screen.getByTestId("change-password-back-button"));
+      fireEvent.press(findByProps(UNSAFE_root, { testID: "change-password-back-button" }));
 
       // Assert
       expect(mockBack).toHaveBeenCalledTimes(1);
@@ -183,55 +238,77 @@ describe("ChangePasswordScreen", () => {
   describe("バリデーション", () => {
     it("現在のパスワードが空の場合エラーメッセージが表示されること", async () => {
       // Arrange
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力"),
+        "NewPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力"),
+        "NewPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
-        expect(screen.getByText("現在のパスワードを入力してください")).toBeTruthy();
+        expect(
+          UNSAFE_root.findByProps({ children: "現在のパスワードを入力してください" }),
+        ).toBeDefined();
       });
     });
 
     it("新しいパスワードが空の場合エラーメッセージが表示されること", async () => {
       // Arrange
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力"),
+        "OldPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
-        expect(screen.getByText("新しいパスワードを入力してください")).toBeTruthy();
+        expect(
+          UNSAFE_root.findByProps({ children: "新しいパスワードを入力してください" }),
+        ).toBeDefined();
       });
     });
 
     it("パスワードが一致しない場合エラーメッセージが表示されること", async () => {
       // Arrange
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "DifferentPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力"),
+        "OldPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力"),
+        "NewPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力"),
+        "DifferentPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
-        expect(screen.getByText("パスワードが一致しません")).toBeTruthy();
+        expect(UNSAFE_root.findByProps({ children: "パスワードが一致しません" })).toBeDefined();
       });
     });
 
     it("バリデーションエラーがある場合changePasswordが呼ばれないこと", async () => {
       // Arrange
-      render(<ChangePasswordScreen />);
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
@@ -244,13 +321,22 @@ describe("ChangePasswordScreen", () => {
     it("成功時にchangePasswordが正しい引数で呼ばれること", async () => {
       // Arrange
       mockChangePassword.mockResolvedValue(undefined);
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力"),
+        "OldPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力"),
+        "NewPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力"),
+        "NewPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
@@ -261,13 +347,22 @@ describe("ChangePasswordScreen", () => {
     it("成功後に前の画面に戻ること", async () => {
       // Arrange
       mockChangePassword.mockResolvedValue(undefined);
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "OldPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力"),
+        "OldPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力"),
+        "NewPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力"),
+        "NewPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
@@ -280,30 +375,51 @@ describe("ChangePasswordScreen", () => {
     it("変更失敗時にエラーアラートが表示されること", async () => {
       // Arrange
       mockChangePassword.mockRejectedValue(new Error("現在のパスワードが正しくありません"));
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "WrongPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力"),
+        "WrongPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力"),
+        "NewPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力"),
+        "NewPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith("エラー", expect.stringContaining("パスワードの変更に失敗しました"));
+        expect(Alert.alert).toHaveBeenCalledWith(
+          "エラー",
+          expect.stringContaining("パスワードの変更に失敗しました"),
+        );
       });
     });
 
     it("変更失敗時に前の画面に戻らないこと", async () => {
       // Arrange
       mockChangePassword.mockRejectedValue(new Error("エラー"));
-      render(<ChangePasswordScreen />);
-      fireEvent.changeText(screen.getByPlaceholderText("現在のパスワードを入力"), "WrongPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを入力"), "NewPass123");
-      fireEvent.changeText(screen.getByPlaceholderText("新しいパスワードを再入力"), "NewPass123");
+      const { UNSAFE_root } = render(<ChangePasswordScreen />);
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "現在のパスワードを入力"),
+        "WrongPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを入力"),
+        "NewPass123",
+      );
+      fireEvent.changeText(
+        findInputByPlaceholder(UNSAFE_root, "新しいパスワードを再入力"),
+        "NewPass123",
+      );
 
       // Act
-      fireEvent.press(screen.getByText("変更する"));
+      fireEvent.press(UNSAFE_root.findAllByProps({ children: "変更する" })[0]);
 
       // Assert
       await waitFor(() => {

--- a/apps/mobile/app/settings/change-password.tsx
+++ b/apps/mobile/app/settings/change-password.tsx
@@ -116,7 +116,10 @@ export default function ChangePasswordScreen() {
       showToast("パスワードを変更しました", "success");
       router.back();
     } catch {
-      Alert.alert("エラー", "パスワードの変更に失敗しました。現在のパスワードが正しいか確認してください。");
+      Alert.alert(
+        "エラー",
+        "パスワードの変更に失敗しました。現在のパスワードが正しいか確認してください。",
+      );
     } finally {
       setIsSaving(false);
     }

--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -11,3 +11,20 @@ configure({ defaultIncludeHiddenElements: true, testIdAttribute: "data-testid" }
 // React Native Animated uses requestAnimationFrame which is not available in Node.js
 global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
 global.cancelAnimationFrame = (id) => clearTimeout(id);
+
+// react-native-web TextInput uses document in a useEffect; provide a minimal stub
+// so tests using TextInput don't crash in the Node test environment.
+if (typeof global.document === "undefined") {
+  global.document = {
+    createElement: () => ({ style: {}, addEventListener: () => {}, removeEventListener: () => {} }),
+    createTextNode: () => ({}),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+    body: { style: {}, appendChild: () => {}, removeChild: () => {} },
+    head: { appendChild: () => {}, removeChild: () => {} },
+    documentElement: { style: {} },
+  };
+}


### PR DESCRIPTION
## 概要

設定画面からパスワード変更画面へのナビゲーションと、パスワード変更画面の実装を行いました。

## 変更内容

- `apps/mobile/app/settings/change-password.tsx`: パスワード変更画面（現在のパスワード・新しいパスワード・確認用パスワードフィールド、バリデーション、changePassword ストア呼び出し、成功/失敗ハンドリング）
- `apps/mobile/app/(tabs)/settings.tsx`: 設定画面から `/settings/change-password` へのナビゲーション追加
- `apps/mobile/__tests__/screens/change-password.test.tsx`: UNSAFE_root + findByProps パターンによるテスト（22テスト）
- `apps/mobile/jest.setup.js`: react-native-web の TextInput が Node 環境で `document` を参照するため global stub を追加

## テスト

- [x] Unit テスト追加・更新済み（validateChangePasswordForm の8ケース）
- [x] Integration テスト追加・更新済み（ChangePasswordScreen の14ケース）
- [x] `BABEL_ENV=test npx jest --no-cache --forceExit` で 22 passed
- [x] `pnpm biome check` がエラーなしで通ること

## 関連Issue

Closes #157