### PR TITLE
fix: Hookスクリプトのパスをworktree対応に修正 #329

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,19 +5,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/session-start.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/session-start.sh\"",
             "timeout": 15,
             "statusMessage": "Syncing with remote..."
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/check-worktrees.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/check-worktrees.sh\"",
             "timeout": 10,
             "statusMessage": "Checking worktree health..."
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/implementation-order-guard.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/implementation-order-guard.sh\"",
             "timeout": 10,
             "statusMessage": "Checking implementation order..."
           }
@@ -30,13 +30,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/secret-guard.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/secret-guard.sh\"",
             "timeout": 10,
             "statusMessage": "Checking for secrets..."
           },
           {
             "type": "command",
-            "command": "bash .claude/hooks/dangerous-command-guard.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/dangerous-command-guard.sh\"",
             "timeout": 5,
             "statusMessage": "Checking for dangerous commands..."
           }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/uncommitted-warn.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/uncommitted-warn.sh\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
## Summary
- 全hookコマンドで`git rev-parse --show-toplevel`を使い絶対パスで解決
- worktreeのサブディレクトリからでもhookが正常動作

Closes #329

🤖 Generated with [Claude Code](https://claude.ai/code)