### PR TITLE
feat: PRマージ時のコンフリクト防止ガードレール

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,32 @@ Closes #<issue番号>
 
 ---
 
+## コンフリクト防止ルール
+
+### 並列実装時の分類ルール
+
+1. **Backend issues** (apps/api/): 別ファイルなら並列マージOK
+2. **Mobile issues** (apps/mobile/):
+   - パッケージ追加あり → 1つずつ直列マージ（pnpm-lock.yaml衝突防止）
+   - 同じ画面/storeを変更 → 1つずつ直列マージ
+   - 新規ファイルのみ → 並列マージOK
+3. **Docs issues**: 並列マージOK
+4. **wrangler.toml を変更するissue**: 直列マージ
+
+### マージ手順
+
+- `scripts/safe-merge.sh <PR番号> [worktree_path]` を使用
+- コンフリクト時は自動rebaseを試みる
+- 自動rebase失敗時のみ手動介入
+
+```bash
+# 使用例
+bash scripts/safe-merge.sh 123
+bash scripts/safe-merge.sh 123 .worktrees/issue-123
+```
+
+---
+
 ## プロダクション完遂ルール
 
 **TechClipはプロダクション用アプリケーションである。全Issueを最後まで作り切ること。**

--- a/scripts/safe-merge.sh
+++ b/scripts/safe-merge.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# PRマージ前のコンフリクト自動検出・自動rebase・マージスクリプト
+# Usage: scripts/safe-merge.sh <PR番号> [worktree_path]
+set -euo pipefail
+
+PR_NUMBER="${1:?PR番号を指定してください}"
+WORKTREE_PATH="${2:-}"
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "kirinnokubinagai/tech_clip")
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+
+echo "=== PR #${PR_NUMBER} セーフマージ ==="
+
+# 1. コンフリクトチェック
+MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq .mergeable)
+
+if [ "$MERGEABLE" = "CONFLICTING" ]; then
+  echo "コンフリクト検出。自動rebase開始..."
+
+  if [ -z "$WORKTREE_PATH" ]; then
+    BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq .headRefName)
+    ISSUE_NUM="${BRANCH#*issue/}"
+    ISSUE_NUM="${ISSUE_NUM%%/*}"
+    WORKTREE_PATH="$ROOT/.worktrees/issue-$ISSUE_NUM"
+  fi
+
+  if [ ! -d "$WORKTREE_PATH" ]; then
+    echo "ERROR: Worktree $WORKTREE_PATH が見つかりません"
+    exit 1
+  fi
+
+  git -C "$WORKTREE_PATH" fetch origin main
+
+  if ! git -C "$WORKTREE_PATH" rebase origin/main; then
+    echo "ERROR: 自動rebase失敗。手動でコンフリクト解消が必要です"
+    git -C "$WORKTREE_PATH" rebase --abort
+    exit 1
+  fi
+
+  git -C "$WORKTREE_PATH" push --force-with-lease
+  echo "rebase完了。再チェック..."
+  sleep 5
+fi
+
+# 2. 再確認
+MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq .mergeable)
+if [ "$MERGEABLE" = "CONFLICTING" ]; then
+  echo "ERROR: rebase後もコンフリクトが残っています"
+  exit 1
+fi
+
+# 3. マージ
+gh pr merge "$PR_NUMBER" --repo "$REPO" --squash --delete-branch
+echo "=== PR #${PR_NUMBER} マージ完了 ==="


### PR DESCRIPTION
## 概要

並列PRマージ時に毎回発生するコンフリクトを防ぐため、自動rebase付きのセーフマージスクリプトとコンフリクト防止ルールを追加した。

## 変更内容

- `scripts/safe-merge.sh`: コンフリクト自動検出・自動rebase・マージを行うスクリプト
  - `gh pr view` でマージ可能状態をチェック
  - CONFLICTINGの場合、worktreeで `git rebase origin/main` を自動実行
  - rebase後に `push --force-with-lease` でプッシュ
  - 自動rebase失敗時はabortして手動介入を促す
- `CLAUDE.md`: コンフリクト防止ルールセクションを追加
  - 並列実装時の直列/並列マージ分類ルール（Backend/Mobile/Docs/wrangler.toml）
  - `safe-merge.sh` の使用手順

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（スクリプト・ドキュメント変更のみ、TDD対象外）
- [x] `pnpm lint` がエラーなしで通ること（スクリプト・ドキュメント変更のみ）

## 関連Issue

Closes #335