### PR TITLE
test: Maestro E2E テスト #98

### DIFF
--- a/tests/e2e/.maestro.yaml
+++ b/tests/e2e/.maestro.yaml
@@ -1,0 +1,17 @@
+# Maestro グローバル設定
+# https://maestro.mobile.dev/reference/configuration
+
+# アプリのバンドルID（iOS）/ パッケージ名（Android）
+appId: com.techclip.app
+
+# デフォルトタイムアウト（ミリ秒）
+# 要素が見つかるまで待機する最大時間
+waitForAppToSettleTimeout: 3000
+
+# 環境変数ファイル（認証情報はここで管理）
+# .env.yaml はコミット禁止（.gitignore に追加済み）
+env:
+  TEST_EMAIL: test-e2e@techclip.example.com
+  TEST_PASSWORD: E2ETestPass123!
+  TEST_NAME: E2Eテストユーザー
+  API_BASE_URL: http://localhost:8787

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,56 @@
+# TechClip E2E Tests (Maestro)
+
+Maestroを使ったE2Eテストフロー集。実機またはシミュレーターで動作確認する。
+
+## 前提条件
+
+```bash
+# Maestro CLI のインストール
+curl -Ls "https://get.maestro.mobile.dev" | bash
+```
+
+## 実行方法
+
+```bash
+# 全フローを実行
+maestro test tests/e2e/flows/
+
+# 特定フローを実行
+maestro test tests/e2e/flows/01-onboarding.yaml
+
+# タグでフィルター
+maestro test --tags smoke tests/e2e/flows/
+
+# デバッグモード（スクリーンショット保存）
+maestro test --debug-output tests/e2e/output/ tests/e2e/flows/
+```
+
+## フロー一覧
+
+| ファイル | 説明 | タグ |
+|---------|------|------|
+| `01-onboarding.yaml` | 初回起動オンボーディング | smoke |
+| `02-auth-login.yaml` | ログインフロー | smoke, auth |
+| `03-auth-register.yaml` | 新規登録フロー | auth |
+| `04-article-save.yaml` | 記事保存フロー | smoke, article |
+| `05-article-detail.yaml` | 記事詳細・お気に入り | article |
+| `06-profile-edit.yaml` | プロフィール編集 | profile |
+| `07-settings.yaml` | 設定画面・ログアウト | settings |
+| `08-search.yaml` | 検索フロー | search |
+
+## 環境設定
+
+`.env.yaml` をこのディレクトリに作成して認証情報を設定:
+
+```yaml
+# tests/e2e/.env.yaml (コミット禁止)
+TEST_EMAIL: test@example.com
+TEST_PASSWORD: TestPass123!
+```
+
+## CI/CD 統合
+
+```bash
+# GitHub Actions での実行例
+maestro cloud --apiKey $MAESTRO_API_KEY tests/e2e/flows/
+```

--- a/tests/e2e/flows/01-onboarding.yaml
+++ b/tests/e2e/flows/01-onboarding.yaml
@@ -1,0 +1,38 @@
+# オンボーディングフロー
+# 初回起動時のウォークスルー4ページを順に進み、ログイン画面まで遷移することを確認する
+#
+# tags: smoke
+
+appId: com.techclip.app
+tags:
+  - smoke
+
+---
+
+# アプリ起動
+- launchApp:
+    clearState: true
+
+# --- ページ1: 技術記事をワンタップで保存 ---
+- assertVisible: "技術記事をワンタップで保存"
+- assertVisible: "Zenn、Qiita"
+- tapOn: "次へ"
+
+# --- ページ2: AIが要約・翻訳 ---
+- assertVisible: "AIが要約・翻訳"
+- assertVisible: "英語記事も日本語で読める"
+- tapOn: "次へ"
+
+# --- ページ3: お気に入り・タグで整理 ---
+- assertVisible: "お気に入り・タグで整理"
+- assertVisible: "タグ付けで記事を分類"
+- tapOn: "次へ"
+
+# --- ページ4: さあ、始めましょう（最終ページ）---
+- assertVisible: "さあ、始めましょう"
+- assertVisible: "アカウントを作成して"
+- assertVisible: "はじめる"
+- tapOn: "はじめる"
+
+# ログイン画面またはホーム画面に遷移することを確認
+- assertVisible: "TechClip"

--- a/tests/e2e/flows/02-auth-login.yaml
+++ b/tests/e2e/flows/02-auth-login.yaml
@@ -1,0 +1,88 @@
+# 認証フロー: ログイン
+# メール・パスワードを入力してログインし、ホーム画面に遷移することを確認する
+#
+# tags: smoke, auth
+
+appId: com.techclip.app
+tags:
+  - smoke
+  - auth
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+
+---
+
+# アプリ起動（オンボーディング済み状態）
+- launchApp:
+    clearState: true
+
+# オンボーディングをスキップしてログイン画面へ
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "はじめる"
+
+# --- ログイン画面 ---
+- assertVisible: "ログイン"
+- assertVisible: "メールアドレス"
+
+# メールアドレス入力
+- tapOn:
+    id: "login-email-input"
+- inputText: ${TEST_EMAIL}
+
+# パスワード入力
+- tapOn:
+    id: "login-password-input"
+- inputText: ${TEST_PASSWORD}
+
+# パスワード表示トグルの確認
+- tapOn:
+    id: "login-toggle-password"
+- assertVisible: "隠す"
+- tapOn:
+    id: "login-toggle-password"
+- assertVisible: "表示"
+
+# ログインボタンをタップ
+- tapOn:
+    id: "login-submit-button"
+
+# ローディング中の表示確認（任意）
+- waitForAnimationToEnd
+
+# ホーム画面に遷移することを確認
+- assertVisible: "すべて"
+
+# --- バリデーションエラーのテスト ---
+- launchApp:
+    clearState: true
+
+# オンボーディングスキップ
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "はじめる"
+
+# 空のまま送信 → エラー表示
+- tapOn:
+    id: "login-submit-button"
+- assertVisible: "メールアドレスを入力してください"
+
+# メールのみ入力してパスワード短すぎエラー
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@example.com"
+- tapOn:
+    id: "login-password-input"
+- inputText: "short"
+- tapOn:
+    id: "login-submit-button"
+- assertVisible: "8文字以上"
+
+# 新規登録リンクへの遷移確認
+- tapOn:
+    id: "login-register-link"
+- assertVisible: "アカウントを作成"

--- a/tests/e2e/flows/03-auth-register.yaml
+++ b/tests/e2e/flows/03-auth-register.yaml
@@ -1,0 +1,78 @@
+# 認証フロー: 新規登録
+# 名前・メール・パスワードを入力してアカウント作成フローを確認する
+#
+# tags: auth
+
+appId: com.techclip.app
+tags:
+  - auth
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+  TEST_NAME: ${TEST_NAME}
+
+---
+
+# アプリ起動（オンボーディング済み状態から）
+- launchApp:
+    clearState: true
+
+# オンボーディングをスキップ
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "はじめる"
+
+# ログイン画面から新規登録へ
+- assertVisible: "ログイン"
+- tapOn: "新規登録"
+
+# --- 新規登録画面 ---
+- assertVisible: "アカウントを作成"
+- assertVisible: "名前"
+- assertVisible: "メールアドレス"
+- assertVisible: "パスワード"
+
+# バリデーション: 空送信
+- tapOn: "アカウントを作成"
+- assertVisible: "名前を入力してください"
+
+# 名前入力
+- tapOn:
+    text: "名前を入力"
+- inputText: ${TEST_NAME}
+
+# バリデーション: 名前のみで送信
+- tapOn: "アカウントを作成"
+- assertVisible: "メールアドレスを入力してください"
+
+# メールアドレス入力
+- tapOn:
+    text: "example@domain.com"
+- inputText: ${TEST_EMAIL}
+
+# バリデーション: パスワードなしで送信
+- tapOn: "アカウントを作成"
+- assertVisible: "パスワードを入力してください"
+
+# パスワード入力
+- tapOn:
+    text: "8文字以上"
+- inputText: ${TEST_PASSWORD}
+
+# フォーム送信
+- tapOn: "アカウントを作成"
+- waitForAnimationToEnd
+
+# ログイン画面へのリンク確認
+- launchApp:
+    clearState: true
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "次へ"
+- tapOn: "はじめる"
+- tapOn: "新規登録"
+- assertVisible: "すでにアカウントをお持ちですか？"
+- tapOn: "ログイン"
+- assertVisible: "ログイン"

--- a/tests/e2e/flows/04-article-save.yaml
+++ b/tests/e2e/flows/04-article-save.yaml
@@ -1,0 +1,75 @@
+# 記事保存フロー
+# URLを入力して記事をパース・プレビュー表示し、保存するフローを確認する
+#
+# tags: smoke, article
+
+appId: com.techclip.app
+tags:
+  - smoke
+  - article
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+  TEST_ARTICLE_URL: https://zenn.dev/techclip_test/articles/sample-article
+
+---
+
+# ログイン済み状態でアプリ起動
+- launchApp:
+    clearState: false
+
+# --- 記事保存画面への遷移 ---
+# ホーム画面から記事保存画面へ（シェアボタン等経由）
+# Expo Router の /article/save へ直接遷移
+- openLink: techclip://article/save
+
+# --- 記事保存画面 ---
+- assertVisible: "記事を保存"
+- assertVisible: "URL"
+
+# --- バリデーション: 空URL送信 ---
+- tapOn: "取得"
+- assertVisible: "URLを入力してください"
+
+# --- バリデーション: 不正URL ---
+- tapOn:
+    text: "https://"
+- inputText: "not-a-valid-url"
+- tapOn: "取得"
+- assertVisible: "有効なURLを入力してください"
+
+# URLフィールドをクリア
+- clearText
+
+# --- 正常系: 有効なURLで記事を取得 ---
+- tapOn:
+    text: "https://"
+- inputText: ${TEST_ARTICLE_URL}
+- tapOn: "取得"
+
+# ローディング表示を確認
+- assertVisible:
+    id: "fetch-loading"
+    optional: true
+- waitForAnimationToEnd
+
+# プレビュー表示を確認
+- assertVisible:
+    id: "article-preview"
+- assertVisible: "プレビュー"
+
+# 保存ボタンをタップ
+- tapOn: "保存する"
+- waitForAnimationToEnd
+
+# 保存成功トースト確認
+- assertVisible: "記事を保存しました"
+
+# --- 戻るボタン ---
+- launchApp:
+    clearState: false
+- openLink: techclip://article/save
+- assertVisible: "記事を保存"
+- tapOn:
+    accessibilityLabel: "戻る"

--- a/tests/e2e/flows/05-article-detail.yaml
+++ b/tests/e2e/flows/05-article-detail.yaml
@@ -1,0 +1,93 @@
+# 記事詳細フロー
+# ホーム画面から記事をタップして詳細表示、お気に入り・要約・翻訳操作を確認する
+#
+# tags: article
+
+appId: com.techclip.app
+tags:
+  - article
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+
+---
+
+# ログイン済み状態でアプリ起動
+- launchApp:
+    clearState: false
+
+# --- ホーム画面: 記事一覧表示 ---
+- assertVisible: "すべて"
+
+# ソースフィルター確認
+- assertVisible: "Zenn"
+- assertVisible: "Qiita"
+- assertVisible: "はてな"
+
+# お気に入りフィルター
+- tapOn:
+    accessibilityLabel: "お気に入りのみ表示"
+- assertVisible:
+    accessibilityLabel: "お気に入りフィルター解除"
+- tapOn:
+    accessibilityLabel: "お気に入りフィルター解除"
+
+# 記事カードをタップして詳細へ
+- tapOn:
+    index: 0
+    type: com.techclip.ArticleCard
+
+# --- 記事詳細画面 ---
+- assertVisible:
+    accessibilityLabel: "戻る"
+
+# お気に入り追加
+- tapOn:
+    accessibilityLabel: "お気に入り追加"
+- assertVisible:
+    accessibilityLabel: "お気に入り解除"
+
+# お気に入り解除
+- tapOn:
+    accessibilityLabel: "お気に入り解除"
+- assertVisible:
+    accessibilityLabel: "お気に入り追加"
+
+# 要約ボタン
+- assertVisible:
+    accessibilityLabel: "要約を生成"
+- tapOn:
+    accessibilityLabel: "要約を生成"
+- waitForAnimationToEnd
+
+# 翻訳ボタン
+- assertVisible:
+    accessibilityLabel: "翻訳する"
+- tapOn:
+    accessibilityLabel: "翻訳する"
+- waitForAnimationToEnd
+
+# ブラウザで開くボタン確認
+- assertVisible:
+    accessibilityLabel: "ブラウザで開く"
+
+# 戻るボタンでホームへ
+- tapOn:
+    accessibilityLabel: "戻る"
+- assertVisible: "すべて"
+
+# --- ソースフィルター: Zenn ---
+- tapOn: "Zenn"
+- waitForAnimationToEnd
+
+# --- ソースフィルター: すべて ---
+- tapOn: "すべて"
+- waitForAnimationToEnd
+
+# プルリフレッシュ
+- swipe:
+    direction: DOWN
+    from:
+      x: 50%
+      y: 40%

--- a/tests/e2e/flows/06-profile-edit.yaml
+++ b/tests/e2e/flows/06-profile-edit.yaml
@@ -1,0 +1,90 @@
+# プロフィール編集フロー
+# プロフィールタブからプロフィール編集画面へ遷移し、名前・bio・SNSリンクを更新する
+#
+# tags: profile
+
+appId: com.techclip.app
+tags:
+  - profile
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+
+---
+
+# ログイン済み状態でアプリ起動
+- launchApp:
+    clearState: false
+
+# プロフィールタブへ移動
+- tapOn:
+    text: "プロフィール"
+
+# --- プロフィール画面 ---
+- assertVisible: "プロフィール"
+
+# プロフィール編集画面へ遷移（設定ボタン or 編集ボタン）
+- tapOn:
+    accessibilityLabel: "設定"
+
+# 設定画面経由でプロフィール確認
+- assertVisible: "アカウント"
+
+# 戻ってプロフィール編集へ
+- tapOn:
+    accessibilityLabel: "戻る"
+
+# --- プロフィール編集画面への直接遷移 ---
+- openLink: techclip://profile/edit
+
+# --- プロフィール編集画面 ---
+- assertVisible:
+    id: "profile-edit-screen"
+- assertVisible: "プロフィール編集"
+
+# アバター変更ボタンの確認
+- assertVisible:
+    id: "profile-edit-avatar-button"
+- assertVisible:
+    id: "profile-edit-camera-badge"
+
+# --- バリデーション: 名前を空にして保存 ---
+- clearText:
+    text: "名前を入力"
+- tapOn: "保存する"
+- assertVisible: "名前を入力してください"
+
+# --- 正常系: プロフィール更新 ---
+- tapOn:
+    text: "名前を入力"
+- inputText: "テストユーザー更新"
+
+- tapOn:
+    text: "username"
+- inputText: "testuser_e2e"
+
+- tapOn:
+    text: "自己紹介を入力"
+- inputText: "E2Eテスト用のプロフィールです"
+
+# SNSリンク
+- scrollDown
+- tapOn:
+    text: "https://x.com/username"
+- inputText: "https://x.com/testuser_e2e"
+
+- tapOn:
+    text: "https://github.com/username"
+- inputText: "https://github.com/testuser_e2e"
+
+# 保存
+- tapOn: "保存する"
+- waitForAnimationToEnd
+
+# 保存成功トーストまたは前画面への遷移を確認
+- assertVisible: "プロフィールを更新しました"
+
+# 戻るボタン
+- tapOn:
+    id: "profile-edit-back-button"

--- a/tests/e2e/flows/07-settings.yaml
+++ b/tests/e2e/flows/07-settings.yaml
@@ -1,0 +1,88 @@
+# 設定フロー
+# 設定画面の各項目（通知・言語・パスワード変更・ログアウト）を確認する
+#
+# tags: settings
+
+appId: com.techclip.app
+tags:
+  - settings
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+
+---
+
+# ログイン済み状態でアプリ起動
+- launchApp:
+    clearState: false
+
+# 設定タブへ移動
+- tapOn:
+    text: "設定"
+
+# --- 設定画面 ---
+- assertVisible: "アカウント"
+- assertVisible: "サブスクリプション"
+- assertVisible: "一般"
+- assertVisible: "アカウント管理"
+
+# アカウントセクション
+- assertVisible: "パスワード変更"
+- assertVisible: "ログアウト"
+
+# サブスクリプションセクション
+- assertVisible: "プラン"
+- assertVisible: "Free"
+
+# バージョン表示
+- assertVisible: "TechClip v"
+
+# --- 通知スイッチ ---
+- assertVisible: "通知"
+# スイッチをオフにする
+- tapOn:
+    text: "通知"
+- waitForAnimationToEnd
+# スイッチをオンに戻す
+- tapOn:
+    text: "通知"
+- waitForAnimationToEnd
+
+# --- 言語設定 ---
+- tapOn: "言語"
+- assertVisible: "言語設定"
+- assertVisible: "日本語"
+- assertVisible: "English"
+- tapOn: "日本語"
+- assertVisible: "日本語"
+
+# --- パスワード変更画面への遷移 ---
+- tapOn: "パスワード変更"
+- assertVisible: "パスワード変更"
+- tapOn:
+    accessibilityLabel: "戻る"
+
+# --- ログアウト確認ダイアログ ---
+- tapOn: "ログアウト"
+- assertVisible: "ログアウトしますか？"
+# キャンセル
+- tapOn: "キャンセル"
+# 設定画面に戻ることを確認
+- assertVisible: "アカウント"
+
+# --- アカウント削除確認ダイアログ ---
+- tapOn: "アカウントを削除する"
+- assertVisible: "アカウントを削除する"
+- assertVisible: "この操作は取り消せません"
+# キャンセル
+- tapOn: "キャンセル"
+- assertVisible: "アカウント管理"
+
+# --- ログアウト実行 ---
+- tapOn: "ログアウト"
+- assertVisible: "ログアウトしますか？"
+- tapOn: "ログアウト"
+- waitForAnimationToEnd
+# ログイン画面に遷移することを確認
+- assertVisible: "ログイン"

--- a/tests/e2e/flows/08-search.yaml
+++ b/tests/e2e/flows/08-search.yaml
@@ -1,0 +1,58 @@
+# 検索フロー
+# 検索タブから記事を検索し、結果をタップして詳細画面へ遷移することを確認する
+#
+# tags: search
+
+appId: com.techclip.app
+tags:
+  - search
+
+env:
+  TEST_EMAIL: ${TEST_EMAIL}
+  TEST_PASSWORD: ${TEST_PASSWORD}
+
+---
+
+# ログイン済み状態でアプリ起動
+- launchApp:
+    clearState: false
+
+# 検索タブへ移動
+- tapOn:
+    text: "検索"
+
+# --- 検索画面 ---
+- assertVisible: "検索"
+
+# 検索フィールドをタップ
+- tapOn:
+    text: "記事を検索"
+
+# キーワードを入力
+- inputText: "TypeScript"
+- waitForAnimationToEnd
+
+# 検索結果が表示されることを確認
+- assertVisible: "TypeScript"
+
+# --- 検索結果をクリア ---
+- clearText
+- waitForAnimationToEnd
+
+# 別キーワードで検索
+- inputText: "React"
+- waitForAnimationToEnd
+
+# 検索結果の記事をタップ
+- tapOn:
+    index: 0
+    text: "React"
+
+# 記事詳細画面に遷移することを確認
+- assertVisible:
+    accessibilityLabel: "戻る"
+
+# 戻る
+- tapOn:
+    accessibilityLabel: "戻る"
+- assertVisible: "検索"


### PR DESCRIPTION
## Summary
- Maestro E2E テストフロー8本追加 (オンボーディング、認証、記事保存、プロフィール等)
- テスト設定ファイルとREADME

Closes #98

🤖 Generated with [Claude Code](https://claude.ai/code)