### PR TITLE
feat: add Sentry error monitoring for Workers API #129

### DIFF
--- a/apps/api/src/middleware/sentry.test.ts
+++ b/apps/api/src/middleware/sentry.test.ts
@@ -1,0 +1,203 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSentryMiddleware } from "./sentry";
+
+/** fetch のモック型 */
+type MockFetch = ReturnType<typeof vi.fn>;
+
+/** テスト用 Hono アプリを作成する */
+function createTestApp(sentryDsn: string | undefined, fetchMock: MockFetch) {
+  type Bindings = {
+    SENTRY_DSN?: string;
+  };
+
+  const app = new Hono<{ Bindings: Bindings }>();
+  app.use("*", createSentryMiddleware(fetchMock as typeof fetch));
+
+  app.get("/ok", (c) => c.json({ ok: true }));
+
+  app.get("/error", () => {
+    throw new Error("テストエラー");
+  });
+
+  app.get("/custom-error", () => {
+    const err = new Error("カスタムエラーメッセージ");
+    err.name = "CustomError";
+    throw err;
+  });
+
+  return {
+    request: (path: string, init?: RequestInit) => {
+      const req = new Request(`http://localhost${path}`, init);
+      return app.fetch(req, { SENTRY_DSN: sentryDsn } as Bindings);
+    },
+  };
+}
+
+describe("createSentryMiddleware", () => {
+  let fetchMock: MockFetch;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("正常系リクエスト", () => {
+    it("エラーがない場合はSentryにイベントを送信しないこと", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      const res = await app.request("/ok");
+
+      // Assert
+      expect(res.status).toBe(200);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("エラーキャプチャ", () => {
+    it("エラー発生時にSentryエンドポイントへfetchを呼ぶこと", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      const res = await app.request("/error");
+
+      // Assert
+      expect(res.status).toBe(500);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("SentryエンドポイントURLが正しいこと", async () => {
+      // Arrange
+      const dsn = "https://publickey@o123.ingest.sentry.io/456";
+      const app = createTestApp(dsn, fetchMock);
+
+      // Act
+      await app.request("/error");
+
+      // Assert
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("sentry.io");
+      expect(calledUrl).toContain("/api/");
+      expect(calledUrl).toContain("/store/");
+    });
+
+    it("SentryにPOSTリクエストを送信すること", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      await app.request("/error");
+
+      // Assert
+      const callOptions = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(callOptions.method).toBe("POST");
+    });
+
+    it("リクエストボディにエラーメッセージが含まれること", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      await app.request("/error");
+
+      // Assert
+      const callOptions = fetchMock.mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(callOptions.body as string) as Record<string, unknown>;
+      const exception = body.exception as {
+        values: Array<{ value: string; type: string }>;
+      };
+      expect(exception.values[0].value).toBe("テストエラー");
+    });
+
+    it("リクエストボディにエラー型が含まれること", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      await app.request("/custom-error");
+
+      // Assert
+      const callOptions = fetchMock.mock.calls[0][1] as RequestInit;
+      const body = JSON.parse(callOptions.body as string) as Record<string, unknown>;
+      const exception = body.exception as {
+        values: Array<{ value: string; type: string }>;
+      };
+      expect(exception.values[0].type).toBe("CustomError");
+    });
+
+    it("Content-Typeヘッダーがapplication/jsonであること", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      await app.request("/error");
+
+      // Assert
+      const callOptions = fetchMock.mock.calls[0][1] as RequestInit;
+      const headers = callOptions.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("X-Sentry-Authヘッダーが設定されていること", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      await app.request("/error");
+
+      // Assert
+      const callOptions = fetchMock.mock.calls[0][1] as RequestInit;
+      const headers = callOptions.headers as Record<string, string>;
+      expect(headers["X-Sentry-Auth"]).toBeDefined();
+      expect(headers["X-Sentry-Auth"]).toContain("Sentry ");
+      expect(headers["X-Sentry-Auth"]).toContain("sentry_key=");
+    });
+  });
+
+  describe("SENTRY_DSN未設定", () => {
+    it("SENTRY_DSNが未設定の場合はエラーをキャプチャせずにスルーすること", async () => {
+      // Arrange
+      const app = createTestApp(undefined, fetchMock);
+
+      // Act
+      const res = await app.request("/error");
+
+      // Assert
+      expect(res.status).toBe(500);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("エラーの再スロー", () => {
+    it("エラーをキャプチャした後もレスポンスは500を返すこと", async () => {
+      // Arrange
+      const app = createTestApp("https://key@sentry.io/123", fetchMock);
+
+      // Act
+      const res = await app.request("/error");
+
+      // Assert
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("DSN解析", () => {
+    it("プロジェクトIDがURLに含まれること", async () => {
+      // Arrange
+      const app = createTestApp("https://abc123@sentry.io/789", fetchMock);
+
+      // Act
+      await app.request("/error");
+
+      // Assert
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("789");
+    });
+  });
+});

--- a/apps/api/src/middleware/sentry.ts
+++ b/apps/api/src/middleware/sentry.ts
@@ -1,0 +1,141 @@
+import type { MiddlewareHandler } from "hono";
+
+/** Sentry DSN の解析結果 */
+type SentryDsnParts = {
+  publicKey: string;
+  host: string;
+  projectId: string;
+};
+
+/** Sentry イベントのペイロード型 */
+type SentryEvent = {
+  event_id: string;
+  timestamp: string;
+  platform: string;
+  exception: {
+    values: Array<{
+      type: string;
+      value: string;
+    }>;
+  };
+};
+
+/** Sentry ミドルウェアの Bindings 型（SENTRY_DSN を含む環境） */
+type SentryBindings = {
+  SENTRY_DSN?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Sentry DSN を解析して各部分を返す
+ *
+ * @param dsn - Sentry DSN 文字列（例: https://key@host/projectId）
+ * @returns 解析結果。不正な場合は null
+ */
+function parseDsn(dsn: string): SentryDsnParts | null {
+  try {
+    const url = new URL(dsn);
+    const publicKey = url.username;
+    const host = url.host;
+    const projectId = url.pathname.replace("/", "");
+    if (!publicKey || !host || !projectId) {
+      return null;
+    }
+    return { publicKey, host, projectId };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sentry エンドポイント URL を構築する
+ *
+ * @param parts - 解析済み DSN 情報
+ * @returns Sentry store エンドポイント URL
+ */
+function buildSentryUrl(parts: SentryDsnParts): string {
+  return `https://${parts.host}/api/${parts.projectId}/store/`;
+}
+
+/**
+ * Sentry 認証ヘッダー文字列を構築する
+ *
+ * @param publicKey - Sentry public key
+ * @returns X-Sentry-Auth ヘッダー値
+ */
+function buildAuthHeader(publicKey: string): string {
+  return `Sentry sentry_version=7, sentry_client=tech-clip-workers/1.0, sentry_key=${publicKey}`;
+}
+
+/**
+ * エラーから Sentry イベントペイロードを生成する
+ *
+ * @param error - キャプチャするエラー
+ * @returns Sentry イベントオブジェクト
+ */
+function buildSentryEvent(error: Error): SentryEvent {
+  return {
+    event_id: crypto.randomUUID().replace(/-/g, ""),
+    timestamp: new Date().toISOString(),
+    platform: "javascript",
+    exception: {
+      values: [
+        {
+          type: error.name,
+          value: error.message,
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Sentry にエラーイベントを送信する
+ *
+ * @param dsn - Sentry DSN 文字列
+ * @param error - 送信するエラー
+ * @param fetchFn - fetch 実装（テスト時にモック差し替え可能）
+ */
+async function captureError(dsn: string, error: Error, fetchFn: typeof fetch): Promise<void> {
+  const parts = parseDsn(dsn);
+  if (!parts) {
+    return;
+  }
+
+  const url = buildSentryUrl(parts);
+  const event = buildSentryEvent(error);
+
+  await fetchFn(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Sentry-Auth": buildAuthHeader(parts.publicKey),
+    },
+    body: JSON.stringify(event),
+  });
+}
+
+/**
+ * Sentry エラー監視ミドルウェアを生成する
+ *
+ * 未処理の例外を Sentry に送信する。
+ * 環境変数 SENTRY_DSN が未設定の場合はエラーをキャプチャしない。
+ *
+ * @param fetchFn - fetch 実装（デフォルトはグローバル fetch）
+ * @returns Hono ミドルウェアハンドラー
+ */
+export function createSentryMiddleware(
+  fetchFn: typeof fetch = fetch,
+): MiddlewareHandler<{ Bindings: SentryBindings }> {
+  return async (c, next) => {
+    try {
+      await next();
+    } catch (err) {
+      const dsn = c.env?.SENTRY_DSN;
+      if (dsn && err instanceof Error) {
+        await captureError(dsn, err, fetchFn);
+      }
+      throw err;
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Cloudflare Workers API に Sentry エラーモニタリングミドルウェアを追加
- `sentry.ts`: Hono ミドルウェアとして Sentry 初期化・エラーキャプチャを実装
- `sentry.test.ts`: ユニットテストを追加

Closes #129