### PR TITLE
feat: add accessibility support to all screens #139

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -89,7 +89,11 @@ export default function LoginScreen() {
           <Text className="mb-6 text-center text-xl font-semibold text-text">ログイン</Text>
 
           {errorMessage !== "" && (
-            <View className="mb-4 rounded-lg bg-error/10 px-4 py-3">
+            <View
+              className="mb-4 rounded-lg bg-error/10 px-4 py-3"
+              accessibilityRole="alert"
+              accessibilityLabel={errorMessage}
+            >
               <Text className="text-sm text-error">{errorMessage}</Text>
             </View>
           )}
@@ -108,6 +112,8 @@ export default function LoginScreen() {
               autoComplete="email"
               editable={!isSubmitting}
               testID="login-email-input"
+              accessibilityLabel="メールアドレス"
+              accessibilityHint="メールアドレスを入力してください"
             />
           </View>
 
@@ -126,6 +132,8 @@ export default function LoginScreen() {
                 autoComplete="password"
                 editable={!isSubmitting}
                 testID="login-password-input"
+                accessibilityLabel="パスワード"
+                accessibilityHint="8文字以上のパスワードを入力してください"
               />
               <Pressable
                 onPress={() => setIsPasswordVisible((prev) => !prev)}
@@ -147,6 +155,10 @@ export default function LoginScreen() {
               isSubmitting || !isFormValid ? "bg-primary/50" : "bg-primary"
             }`}
             testID="login-submit-button"
+            accessibilityRole="button"
+            accessibilityLabel="ログイン"
+            accessibilityHint="メールアドレスとパスワードでログインします"
+            accessibilityState={{ disabled: isSubmitting || !isFormValid }}
           >
             {isSubmitting ? (
               <ActivityIndicator color="#e2e8f0" />

--- a/apps/mobile/app/(auth)/register.tsx
+++ b/apps/mobile/app/(auth)/register.tsx
@@ -72,7 +72,11 @@ export default function RegisterScreen() {
         </View>
 
         {errorMessage !== "" && (
-          <View className="mb-4 rounded-lg border border-error/30 bg-error/10 px-4 py-3">
+          <View
+            className="mb-4 rounded-lg border border-error/30 bg-error/10 px-4 py-3"
+            accessibilityRole="alert"
+            accessibilityLabel={errorMessage}
+          >
             <Text className="text-sm text-error">{errorMessage}</Text>
           </View>
         )}
@@ -90,6 +94,8 @@ export default function RegisterScreen() {
               autoComplete="name"
               textContentType="name"
               editable={!isSubmitting}
+              accessibilityLabel="名前"
+              accessibilityHint="お名前を入力してください"
             />
           </View>
 
@@ -106,6 +112,8 @@ export default function RegisterScreen() {
               keyboardType="email-address"
               textContentType="emailAddress"
               editable={!isSubmitting}
+              accessibilityLabel="メールアドレス"
+              accessibilityHint="メールアドレスを入力してください"
             />
           </View>
 
@@ -121,6 +129,8 @@ export default function RegisterScreen() {
               autoComplete="new-password"
               textContentType="newPassword"
               editable={!isSubmitting}
+              accessibilityLabel="パスワード"
+              accessibilityHint="8文字以上のパスワードを入力してください"
             />
           </View>
         </View>
@@ -132,6 +142,10 @@ export default function RegisterScreen() {
           style={({ pressed }) => ({
             opacity: pressed || isSubmitting ? 0.7 : 1,
           })}
+          accessibilityRole="button"
+          accessibilityLabel="アカウントを作成"
+          accessibilityHint="入力した情報で新規アカウントを作成します"
+          accessibilityState={{ disabled: isSubmitting }}
         >
           {isSubmitting ? (
             <ActivityIndicator color="#ffffff" />

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -81,6 +81,7 @@ export default function TabLayout() {
                   testID="tab-badge"
                   style={{ backgroundColor: BADGE_BG_COLOR }}
                   className="absolute -top-1 -right-2 rounded-full min-w-[16px] h-4 items-center justify-center px-1"
+                  accessibilityLabel={`未読通知${unreadCount > BADGE_MAX_COUNT ? `${BADGE_MAX_COUNT}件以上` : `${unreadCount}件`}`}
                 >
                   <Text className="text-white text-[10px] font-bold">
                     {unreadCount > BADGE_MAX_COUNT ? `${BADGE_MAX_COUNT}+` : String(unreadCount)}

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -114,7 +114,13 @@ export default function HomeScreen() {
           {isError ? "記事の取得に失敗しました" : "記事がありません"}
         </Text>
         {isError && (
-          <Pressable onPress={() => refetch()} className="mt-4 flex-row items-center gap-2">
+          <Pressable
+            onPress={() => refetch()}
+            className="mt-4 flex-row items-center gap-2"
+            accessibilityRole="button"
+            accessibilityLabel="再試行"
+            accessibilityHint="記事の取得を再試行します"
+          >
             <RefreshCw size={FILTER_ICON_SIZE} color={FILTER_ACTIVE_BG} />
             <Text className="text-primary">再試行</Text>
           </Pressable>
@@ -140,6 +146,10 @@ export default function HomeScreen() {
                 backgroundColor:
                   selectedSource === item.value ? FILTER_ACTIVE_BG : FILTER_INACTIVE_BG,
               }}
+              accessibilityRole="button"
+              accessibilityLabel={item.label}
+              accessibilityHint={`${item.label}の記事のみ表示します`}
+              accessibilityState={{ selected: selectedSource === item.value }}
             >
               <Text
                 className="text-sm"

--- a/apps/mobile/app/(tabs)/notifications.tsx
+++ b/apps/mobile/app/(tabs)/notifications.tsx
@@ -87,6 +87,9 @@ export default function NotificationsScreen() {
             testID="retry-button"
             onPress={() => refetch()}
             className="mt-4 flex-row items-center gap-2"
+            accessibilityRole="button"
+            accessibilityLabel="再試行"
+            accessibilityHint="通知の取得を再試行します"
           >
             <RefreshCw size={HEADER_ICON_SIZE} color={LOADING_COLOR} />
             <Text className="text-primary">再試行</Text>

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,11 +1,20 @@
-import { Bell, ChevronRight, CreditCard, Globe, KeyRound, LogOut, Trash2, User } from "lucide-react-native";
+import {
+  Bell,
+  ChevronRight,
+  CreditCard,
+  Globe,
+  KeyRound,
+  LogOut,
+  Trash2,
+  User,
+} from "lucide-react-native";
 import type { ReactNode } from "react";
 import { useState } from "react";
 import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
 
 import { confirm } from "@/components/ConfirmDialog";
-import { useAuthStore } from "../../src/stores/auth-store";
 import { useRouter } from "expo-router";
+import { useAuthStore } from "../../src/stores/auth-store";
 
 /** 設定セクションの区切り線コンポーネント */
 function SectionDivider() {
@@ -57,7 +66,12 @@ function SettingsRow({ icon, label, value, onPress, trailing }: SettingsRowProps
 
   if (onPress) {
     return (
-      <Pressable onPress={onPress} accessibilityRole="button">
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={value ? `${label}、現在の設定: ${value}` : label}
+        accessibilityHint={`${label}の設定を変更します`}
+      >
         {content}
       </Pressable>
     );
@@ -190,6 +204,13 @@ export default function SettingsScreen() {
               onValueChange={setIsNotificationsEnabled}
               trackColor={{ false: "#2d2d44", true: "#6366f1" }}
               thumbColor="#ffffff"
+              accessibilityLabel="通知"
+              accessibilityHint={
+                isNotificationsEnabled
+                  ? "タップして通知をオフにします"
+                  : "タップして通知をオンにします"
+              }
+              accessibilityRole="switch"
             />
           }
         />

--- a/apps/mobile/app/article/save.tsx
+++ b/apps/mobile/app/article/save.tsx
@@ -142,7 +142,13 @@ export default function SaveScreen() {
         <View className="px-4 pt-4 pb-8">
           {/* ヘッダー */}
           <View className="flex-row items-center mb-6">
-            <Pressable onPress={() => router.back()} accessibilityLabel="戻る" className="mr-3 p-1">
+            <Pressable
+              onPress={() => router.back()}
+              accessibilityRole="button"
+              accessibilityLabel="戻る"
+              accessibilityHint="前の画面に戻ります"
+              className="mr-3 p-1"
+            >
               <ArrowLeft size={ICON_SIZE_LG} color="#e2e8f0" />
             </Pressable>
             <Text className="text-xl font-bold text-text">記事を保存</Text>
@@ -181,8 +187,17 @@ export default function SaveScreen() {
 
           {/* エラーメッセージ */}
           {errorMessage && (
-            <View className="flex-row items-center gap-2 rounded-lg bg-error/10 border border-error/30 p-3 mb-4">
-              <AlertCircle size={ERROR_ICON_SIZE} color={ERROR_COLOR} />
+            <View
+              className="flex-row items-center gap-2 rounded-lg bg-error/10 border border-error/30 p-3 mb-4"
+              accessibilityRole="alert"
+              accessibilityLabel={errorMessage}
+            >
+              <AlertCircle
+                size={ERROR_ICON_SIZE}
+                color={ERROR_COLOR}
+                accessibilityElementsHidden={true}
+                importantForAccessibility="no-hide-descendants"
+              />
               <Text className="text-error text-sm flex-1">{errorMessage}</Text>
             </View>
           )}

--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -87,20 +87,34 @@ export default function OnboardingScreen() {
       </ScrollView>
 
       {/* ページインジケーター */}
-      <View testID="page-indicator" className="flex-row items-center justify-center py-4">
+      <View
+        testID="page-indicator"
+        className="flex-row items-center justify-center py-4"
+        accessibilityLabel={`${currentIndex + 1}ページ目（全${PAGE_COUNT}ページ）`}
+        accessible={true}
+      >
         {ONBOARDING_PAGES.map((page, index) => (
           <View
             key={page.id}
             className={`mx-1 h-2 rounded-full ${
               index === currentIndex ? "w-6 bg-stone-700" : "w-2 bg-stone-300"
             }`}
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
           />
         ))}
       </View>
 
       {/* ボタンエリア */}
       <View className="flex-row items-center justify-between px-6 pb-12 pt-2">
-        <Pressable testID="skip-button" onPress={handleSkip} className="px-4 py-3">
+        <Pressable
+          testID="skip-button"
+          onPress={handleSkip}
+          className="px-4 py-3"
+          accessibilityRole="button"
+          accessibilityLabel="スキップ"
+          accessibilityHint="オンボーディングをスキップしてログイン画面に進みます"
+        >
           <Text className="text-base text-stone-500">スキップ</Text>
         </Pressable>
 
@@ -109,6 +123,9 @@ export default function OnboardingScreen() {
             testID="finish-button"
             onPress={handleFinish}
             className="rounded-xl bg-stone-800 px-8 py-3"
+            accessibilityRole="button"
+            accessibilityLabel="始める"
+            accessibilityHint="アカウント作成画面に進みます"
           >
             <Text className="text-base font-semibold text-white">始める</Text>
           </Pressable>
@@ -117,6 +134,9 @@ export default function OnboardingScreen() {
             testID="next-button"
             onPress={handleNext}
             className="rounded-xl bg-stone-800 px-8 py-3"
+            accessibilityRole="button"
+            accessibilityLabel="次へ"
+            accessibilityHint={`次のページ（${currentIndex + 2}ページ目）に進みます`}
           >
             <Text className="text-base font-semibold text-white">次へ</Text>
           </Pressable>

--- a/apps/mobile/app/profile/[id].tsx
+++ b/apps/mobile/app/profile/[id].tsx
@@ -85,10 +85,19 @@ export default function UserProfileScreen() {
             setTimeout(() => setIsLoading(false), 500);
           }}
           className="mt-4 bg-primary rounded-lg px-6 py-3"
+          accessibilityRole="button"
+          accessibilityLabel="再試行"
+          accessibilityHint="ユーザー情報の取得を再試行します"
         >
           <Text className="text-white font-semibold">再試行</Text>
         </Pressable>
-        <Pressable onPress={handleBack} className="mt-3">
+        <Pressable
+          onPress={handleBack}
+          className="mt-3"
+          accessibilityRole="button"
+          accessibilityLabel="戻る"
+          accessibilityHint="前の画面に戻ります"
+        >
           <Text className="text-primary">戻る</Text>
         </Pressable>
       </View>

--- a/apps/mobile/src/components/ui/Badge.tsx
+++ b/apps/mobile/src/components/ui/Badge.tsx
@@ -34,7 +34,11 @@ const TEXT_VARIANT_STYLES: Record<BadgeVariant, string> = {
  */
 export function Badge({ children, variant = "default" }: BadgeProps) {
   return (
-    <View className={`rounded-full border px-2.5 py-0.5 self-start ${VARIANT_STYLES[variant]}`}>
+    <View
+      className={`rounded-full border px-2.5 py-0.5 self-start ${VARIANT_STYLES[variant]}`}
+      accessibilityRole="text"
+      accessibilityLabel={children}
+    >
       <Text className={`text-xs font-medium ${TEXT_VARIANT_STYLES[variant]}`}>{children}</Text>
     </View>
   );

--- a/apps/mobile/src/components/ui/EmptyState.tsx
+++ b/apps/mobile/src/components/ui/EmptyState.tsx
@@ -33,8 +33,18 @@ export function EmptyState({
   className = "",
 }: EmptyStateProps) {
   return (
-    <View className={`flex-1 items-center justify-center px-8 py-12 ${className}`}>
-      <View className="mb-4">{icon}</View>
+    <View
+      className={`flex-1 items-center justify-center px-8 py-12 ${className}`}
+      accessibilityRole="text"
+      accessibilityLabel={description ? `${title}。${description}` : title}
+    >
+      <View
+        className="mb-4"
+        accessibilityElementsHidden={true}
+        importantForAccessibility="no-hide-descendants"
+      >
+        {icon}
+      </View>
       <Text className="text-lg font-semibold text-text text-center">{title}</Text>
       {description ? (
         <Text className="mt-2 text-sm text-text-muted text-center">{description}</Text>

--- a/apps/mobile/src/components/ui/Skeleton.tsx
+++ b/apps/mobile/src/components/ui/Skeleton.tsx
@@ -52,7 +52,12 @@ export function Skeleton({ width, height, borderRadius = 8, className = "" }: Sk
   }, [opacity]);
 
   return (
-    <View className={className}>
+    <View
+      className={className}
+      accessibilityLabel="読み込み中"
+      accessibilityHint="コンテンツを読み込んでいます"
+      accessible={true}
+    >
       <Animated.View
         style={{
           width,

--- a/apps/mobile/src/components/ui/skeletons/ArticleDetailSkeleton.tsx
+++ b/apps/mobile/src/components/ui/skeletons/ArticleDetailSkeleton.tsx
@@ -19,7 +19,12 @@ const BODY_LINE_COUNT = 8;
  */
 export function ArticleDetailSkeleton() {
   return (
-    <View className="px-4">
+    <View
+      className="px-4"
+      accessibilityLabel="記事の詳細を読み込み中"
+      accessibilityHint="しばらくお待ちください"
+      accessible={true}
+    >
       <Skeleton width="100%" height={HEADER_IMAGE_HEIGHT} borderRadius={12} />
       <Skeleton width="90%" height={TITLE_HEIGHT} className="mt-4" />
       <Skeleton width="60%" height={TITLE_HEIGHT} className="mt-2" />

--- a/apps/mobile/src/components/ui/skeletons/ArticleListSkeleton.tsx
+++ b/apps/mobile/src/components/ui/skeletons/ArticleListSkeleton.tsx
@@ -25,13 +25,20 @@ type ArticleListSkeletonProps = {
  */
 export function ArticleListSkeleton({ count = DEFAULT_ITEM_COUNT }: ArticleListSkeletonProps) {
   return (
-    <View className="px-4">
+    <View
+      className="px-4"
+      accessibilityLabel="記事一覧を読み込み中"
+      accessibilityHint="しばらくお待ちください"
+      accessible={true}
+    >
       {Array.from({ length: count }, (_, index) => (
         <View
           // biome-ignore lint/suspicious/noArrayIndexKey: skeleton items have no stable id
           key={`article-skeleton-${index}`}
           testID="article-skeleton"
           className="flex-row gap-3 py-3 border-b border-border"
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no-hide-descendants"
         >
           <Skeleton width={ARTICLE_ITEM_HEIGHT} height={ARTICLE_ITEM_HEIGHT} borderRadius={12} />
           <View className="flex-1 justify-center gap-2">

--- a/apps/mobile/src/components/ui/skeletons/ProfileSkeleton.tsx
+++ b/apps/mobile/src/components/ui/skeletons/ProfileSkeleton.tsx
@@ -22,7 +22,12 @@ const STAT_WIDTH = 60;
  */
 export function ProfileSkeleton() {
   return (
-    <View className="items-center px-4 pt-8">
+    <View
+      className="items-center px-4 pt-8"
+      accessibilityLabel="プロフィールを読み込み中"
+      accessibilityHint="しばらくお待ちください"
+      accessible={true}
+    >
       <Skeleton width={AVATAR_SIZE} height={AVATAR_SIZE} borderRadius={40} />
       <Skeleton width={120} height={NAME_HEIGHT} className="mt-4" />
       <Skeleton width={180} height={EMAIL_HEIGHT} className="mt-2" />


### PR DESCRIPTION
## 概要

全モバイル画面・コンポーネントにReact Nativeアクセシビリティプロパティを追加し、VoiceOver (iOS) / TalkBack (Android) 対応を実現した。

## 変更内容

- `Badge`, `Skeleton`, `EmptyState`, スケルトン3種にaccessibility属性追加
- `onboarding.tsx`: ページインジケーター・ナビゲーションボタンにラベル・ヒント追加
- `login.tsx`, `register.tsx`: フォーム入力・エラー表示・送信ボタンにrole/label/hint追加
- `settings.tsx`: 設定行・通知スイッチにlabel/hint追加（動的テキスト対応）
- `index.tsx`: ソースフィルターボタンにselected state追加、再試行ボタン対応
- `notifications.tsx`: 再試行ボタンにrole/label/hint追加
- `save.tsx`: エラーアラート・戻るボタン・装飾アイコン非表示化
- `profile/[id].tsx`: 再試行・戻るボタンにrole/label/hint追加
- `_layout.tsx`: 未読通知バッジに件数アナウンス対応

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [ ] `pnpm test` がすべてパスすること
- [x] `biome check` がエラーなしで通ること（15ファイル確認済み）

## 関連Issue

Closes #139