### PR TITLE
fix: enable real test execution for mobile #355

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "build:ios": "eas build --platform ios",
     "build:android": "eas build --platform android",
     "typecheck": "tsc --noEmit",
-    "test": "echo 'mobile tests: jest-expo setup pending (see issue #215)' && exit 0",
+    "test": "jest --passWithNoTests --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "echo 'lint configured in root'"


### PR DESCRIPTION
## 概要

`apps/mobile/package.json` の `test` スクリプトをダミー実装から実テスト実行に変更。

## 変更内容

- `test` スクリプトを `echo 'pending' && exit 0` から `jest --passWithNoTests --forceExit` に変更
- テストファイルが存在する場合は実行し、存在しない場合はスキップ（`--passWithNoTests`）
- テスト完了後に強制終了（`--forceExit`）

## テスト

- [x] `pnpm test` が jest を実行することを確認済み
- [x] `biome check` がエラーなしで通ること

## 関連Issue

Closes #355