### PR TITLE
chore: exclude .omc from Biome lint config #359

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
     "enabled": true
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".turbo", ".wrangler", ".expo", ".claude", "drizzle"]
+    "ignore": ["node_modules", "dist", ".turbo", ".wrangler", ".expo", ".claude", "drizzle", ".omc"]
   },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
## 概要
Biome lint設定に.omc配下を除外設定を追加

## 変更内容
- biome.jsonの`files.ignore`に`.omc`を追加

## テスト
- [x] `pnpm biome check`が.omc配下でエラーにならないこと

Closes #359