### PR TITLE
fix: add PR comment check to review verification #363

### DIFF
--- a/scripts/review-and-merge.sh
+++ b/scripts/review-and-merge.sh
@@ -15,13 +15,15 @@ if [ "$STATE" != "OPEN" ]; then
   exit 1
 fi
 
-# 2. レビュー済みか確認
+# 2. レビュー済みか確認（GH review または PRコメント）
 REVIEW_COUNT=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --jq 'length' 2>/dev/null || echo "0")
-if [ "$REVIEW_COUNT" = "0" ]; then
+COMMENT_COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --jq 'length' 2>/dev/null || echo "0")
+
+if [ "$REVIEW_COUNT" = "0" ] && [ "$COMMENT_COUNT" = "0" ]; then
   echo "ERROR: レビューがありません。先にcode-reviewを実行してください"
   exit 1
 fi
-echo "--- レビュー: ${REVIEW_COUNT}件確認 ---"
+echo "--- レビュー: ${REVIEW_COUNT}件（GH review）+ ${COMMENT_COUNT}件（コメント）確認 ---"
 
 # 3. マージ可能か確認
 MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable --jq .mergeable)


### PR DESCRIPTION
## 概要

`review-and-merge.sh` のレビュー検証ロジックを改善し、GH review に加えて PR コメント（issueコメント）の存在もレビュー完了とみなすように修正した。

## 変更内容

- `gh api repos/.../issues/.../comments` でPRコメント数を取得する変数 `COMMENT_COUNT` を追加
- GH review と PRコメントの両方が0件の場合のみエラーとするよう条件を変更（`&&` による AND条件）
- ログ出力にコメント件数も含めて可視化

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [ ] `pnpm test` がすべてパスすること
- [ ] `pnpm lint` がエラーなしで通ること

## 関連Issue

Closes #363