### PR TITLE
fix: use safe-merge.sh in finish skill #360

### DIFF
--- a/.claude/skills/finish/SKILL.md
+++ b/.claude/skills/finish/SKILL.md
@@ -35,7 +35,6 @@ triggers:
 
 ## マージ後
 
-- `gh pr merge <番号> --merge`
-- `git worktree remove ../tech_clip-issue-<N>`
-- `gh issue close <番号>`（PRの`Closes`で自動クローズされない場合）
+- `bash scripts/safe-merge.sh <番号>`
+- `git worktree remove .worktrees/issue-<N>`
 - mainブランチで `git pull`


### PR DESCRIPTION
## 概要
finishスキルのマージコマンドをsafe-merge.sh経由に変更

## 変更内容
- `gh pr merge --merge` を `bash scripts/safe-merge.sh` に変更
- worktreeパスを `.worktrees/issue-<N>` 形式に修正

## テスト
- [x] SKILL.mdの内容が正しいこと

Closes #360