### PR TITLE
feat: wire RunPod config to AI translation route #357

### DIFF
--- a/apps/api/__tests__/integration/ai.test.ts
+++ b/apps/api/__tests__/integration/ai.test.ts
@@ -91,6 +91,10 @@ function createTestApp(
   const route = createAiRoute({
     db: mockDb as unknown as Parameters<typeof createAiRoute>[0]["db"],
     translateArticleFn: mockTranslateFn,
+    runpodConfig: {
+      apiKey: "test-api-key",
+      endpointId: "test-endpoint-id",
+    },
   });
 
   const app = new Hono<{ Variables: { user?: Record<string, unknown> } }>();

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -223,6 +223,10 @@ app.on(["GET", "POST", "PATCH", "DELETE"], "/api/articles/**", async (c) => {
   const aiRoute = createAiRoute({
     db,
     translateArticleFn: translateArticle,
+    runpodConfig: {
+      apiKey: c.env.RUNPOD_API_KEY,
+      endpointId: c.env.RUNPOD_ENDPOINT_ID,
+    },
   });
 
   const favoriteRoute = createFavoriteRoute({ db });

--- a/apps/api/src/routes/ai.test.ts
+++ b/apps/api/src/routes/ai.test.ts
@@ -129,6 +129,10 @@ function createTestApp() {
   const aiRoute = createAiRoute({
     db: mockDb as never,
     translateArticleFn: mockTranslateArticle,
+    runpodConfig: {
+      apiKey: "test-api-key",
+      endpointId: "test-endpoint-id",
+    },
   });
   app.route("/api/articles", aiRoute);
 
@@ -146,6 +150,10 @@ function createTestAppWithoutAuth() {
   const aiRoute = createAiRoute({
     db: mockDb as never,
     translateArticleFn: mockTranslateArticle,
+    runpodConfig: {
+      apiKey: "test-api-key",
+      endpointId: "test-endpoint-id",
+    },
   });
   app.route("/api/articles", aiRoute);
 

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -76,10 +76,17 @@ const TranslateRequestSchema = z.object({
 /** translateArticle関数の型 */
 type TranslateArticleFn = (options: TranslateOptions) => Promise<TranslationResult>;
 
+/** RunPod設定 */
+type RunpodConfig = {
+  apiKey: string;
+  endpointId: string;
+};
+
 /** createAiRouteのオプション */
 type AiRouteOptions = {
   db: Database;
   translateArticleFn: TranslateArticleFn;
+  runpodConfig: RunpodConfig;
 };
 
 /**
@@ -92,7 +99,7 @@ type AiRouteOptions = {
  * @returns Hono ルーターインスタンス
  */
 export function createAiRoute(options: AiRouteOptions) {
-  const { db, translateArticleFn } = options;
+  const { db, translateArticleFn, runpodConfig } = options;
   const route = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
 
   route.post("/:id/translate", async (c) => {
@@ -198,8 +205,8 @@ export function createAiRoute(options: AiRouteOptions) {
         title: article.title,
         content: article.content,
         targetLanguage,
-        runpodApiKey: "",
-        runpodEndpointId: "",
+        runpodApiKey: runpodConfig.apiKey,
+        runpodEndpointId: runpodConfig.endpointId,
       });
 
       const now = new Date();


### PR DESCRIPTION
## 概要
AI翻訳ルートにRunPod API設定を正しく接続。ハードコードされた空文字列を環境変数経由に修正。

## 変更内容
- `AiRouteOptions` に `runpodConfig` フィールド追加
- `translateArticleFn` 呼び出しに `runpodConfig.apiKey`/`endpointId` を渡すよう修正
- `index.ts` で `c.env.RUNPOD_API_KEY`/`RUNPOD_ENDPOINT_ID` を `createAiRoute` に渡す
- ユニットテスト・統合テストに `runpodConfig` モック追加

## テスト
- [x] 全1156テストがパス（81ファイル）
- [x] AI翻訳ルートテスト全パス

Closes #357