### PR TITLE
fix: Biome .worktrees ignore + jest watchman設定 #389 #390

### DIFF
--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: "jest-expo/node",
+  watchman: false,
   transformIgnorePatterns: [
     "/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|react-native-svg|nativewind|react-native-reanimated|lucide-react-native|zustand|@tanstack|react-native-purchases|@shopify/flash-list))",
   ],

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
     "enabled": true
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".turbo", ".wrangler", ".expo", ".claude", "drizzle", ".omc"]
+    "ignore": ["node_modules", "dist", ".turbo", ".wrangler", ".expo", ".claude", "drizzle", ".omc", ".worktrees"]
   },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
## 概要
lint・テスト実行の安定性修正

## 変更内容
- biome.jsonのfiles.ignoreに`.worktrees`追加（worktree配下のlint失敗防止）
- mobile jest.config.jsに`watchman: false`追加（CI安定性向上）

## テスト
- [x] biome checkがworktree配下で失敗しないこと
- [x] jest設定が正しいこと

Closes #389
Closes #390