### PR TITLE
fix: align auth paths with /api prefix #386

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { summarizeArticle } from "./services/summary";
 import { translateArticle } from "./services/translator";
 import { createAiRoute } from "./routes/ai";
 import { createArticlesRoute } from "./routes/articles";
+import { createAuthRoute } from "./routes/auth";
 import { createEmailVerificationRoute } from "./routes/email-verification";
 import { createFavoriteRoute } from "./routes/favorite";
 import { createFollowsRoute } from "./routes/follows";
@@ -71,6 +72,63 @@ app.get("/health", (c) => {
 
 app.get("/openapi.json", (c) => {
   return c.json(openApiSpec);
+});
+
+app.on(["POST", "GET"], "/api/auth/sign-in", async (c) => {
+  const db = createDatabase({
+    TURSO_DATABASE_URL: c.env.TURSO_DATABASE_URL,
+    TURSO_AUTH_TOKEN: c.env.TURSO_AUTH_TOKEN,
+  });
+  const authRoute = createAuthRoute({
+    db,
+    getAuth: () =>
+      createAuth(db, c.env.BETTER_AUTH_SECRET, {
+        google: { clientId: c.env.GOOGLE_CLIENT_ID, clientSecret: c.env.GOOGLE_CLIENT_SECRET },
+        apple: { clientId: c.env.APPLE_CLIENT_ID, clientSecret: c.env.APPLE_CLIENT_SECRET },
+        github: { clientId: c.env.GITHUB_CLIENT_ID, clientSecret: c.env.GITHUB_CLIENT_SECRET },
+      }),
+  });
+  const subApp = new Hono();
+  subApp.route("/api/auth", authRoute);
+  return subApp.fetch(c.req.raw);
+});
+
+app.get("/api/auth/session", async (c) => {
+  const db = createDatabase({
+    TURSO_DATABASE_URL: c.env.TURSO_DATABASE_URL,
+    TURSO_AUTH_TOKEN: c.env.TURSO_AUTH_TOKEN,
+  });
+  const authRoute = createAuthRoute({
+    db,
+    getAuth: () =>
+      createAuth(db, c.env.BETTER_AUTH_SECRET, {
+        google: { clientId: c.env.GOOGLE_CLIENT_ID, clientSecret: c.env.GOOGLE_CLIENT_SECRET },
+        apple: { clientId: c.env.APPLE_CLIENT_ID, clientSecret: c.env.APPLE_CLIENT_SECRET },
+        github: { clientId: c.env.GITHUB_CLIENT_ID, clientSecret: c.env.GITHUB_CLIENT_SECRET },
+      }),
+  });
+  const subApp = new Hono();
+  subApp.route("/api/auth", authRoute);
+  return subApp.fetch(c.req.raw);
+});
+
+app.post("/api/auth/refresh", async (c) => {
+  const db = createDatabase({
+    TURSO_DATABASE_URL: c.env.TURSO_DATABASE_URL,
+    TURSO_AUTH_TOKEN: c.env.TURSO_AUTH_TOKEN,
+  });
+  const authRoute = createAuthRoute({
+    db,
+    getAuth: () =>
+      createAuth(db, c.env.BETTER_AUTH_SECRET, {
+        google: { clientId: c.env.GOOGLE_CLIENT_ID, clientSecret: c.env.GOOGLE_CLIENT_SECRET },
+        apple: { clientId: c.env.APPLE_CLIENT_ID, clientSecret: c.env.APPLE_CLIENT_SECRET },
+        github: { clientId: c.env.GITHUB_CLIENT_ID, clientSecret: c.env.GITHUB_CLIENT_SECRET },
+      }),
+  });
+  const subApp = new Hono();
+  subApp.route("/api/auth", authRoute);
+  return subApp.fetch(c.req.raw);
 });
 
 app.post("/api/auth/send-verification", async (c) => {

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,0 +1,414 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAuthRoute } from "./auth";
+
+/** HTTP 200 OK ステータスコード */
+const HTTP_OK = 200;
+
+/** HTTP 401 Unauthorized ステータスコード */
+const HTTP_UNAUTHORIZED = 401;
+
+/** HTTP 422 Unprocessable Entity ステータスコード */
+const HTTP_UNPROCESSABLE_ENTITY = 422;
+
+/** HTTP 500 Internal Server Error ステータスコード */
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+/** テスト用セッショントークン */
+const MOCK_TOKEN = "mock-session-token-abc123";
+
+/** テスト用ユーザー */
+const MOCK_USER = {
+  id: "user_01HXYZ",
+  email: "test@example.com",
+  name: "テストユーザー",
+  image: null,
+  createdAt: "2024-01-15T00:00:00.000Z",
+  updatedAt: "2024-01-15T00:00:00.000Z",
+};
+
+/** テスト用セッション行 */
+const MOCK_SESSION_ROW = {
+  id: "session_01",
+  userId: MOCK_USER.id,
+  token: MOCK_TOKEN,
+  expiresAt: new Date(Date.now() + 86400000).toISOString(),
+  ipAddress: null,
+  userAgent: null,
+  createdAt: "2024-01-15T00:00:00.000Z",
+  updatedAt: "2024-01-15T00:00:00.000Z",
+};
+
+/** モック DB */
+const mockDb = {
+  select: vi.fn(),
+};
+
+/** モック Better Auth インスタンス */
+const mockAuth = {
+  api: {
+    signInEmail: vi.fn(),
+    getSession: vi.fn(),
+  },
+};
+
+/** エラーレスポンスの型 */
+type ErrorResponseBody = {
+  success: boolean;
+  error: {
+    code: string;
+    message: string;
+  };
+};
+
+/** 成功レスポンスの型（サインイン・セッション） */
+type AuthSuccessBody = {
+  success: true;
+  data: {
+    user: { id: string; email: string; name: string };
+    session: { token: string; expiresAt: string };
+  };
+};
+
+/** 成功レスポンスの型（リフレッシュ） */
+type RefreshSuccessBody = {
+  success: true;
+  data: { token: string };
+};
+
+/**
+ * テスト用Honoアプリを作成する
+ */
+function createTestApp() {
+  const app = new Hono();
+  const authRoute = createAuthRoute({
+    db: mockDb as never,
+    getAuth: () => mockAuth,
+  });
+  app.route("/api/auth", authRoute);
+  return app;
+}
+
+describe("POST /api/auth/sign-in", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("有効な認証情報でサインインできること", async () => {
+      // Arrange
+      mockAuth.api.signInEmail.mockResolvedValue({
+        token: MOCK_TOKEN,
+        user: MOCK_USER,
+      });
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_SESSION_ROW]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com", password: "Password123" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as AuthSuccessBody;
+      expect(body.success).toBe(true);
+      expect(body.data.user.email).toBe("test@example.com");
+      expect(body.data.session.token).toBe(MOCK_TOKEN);
+    });
+  });
+
+  describe("異常系", () => {
+    it("メールアドレスが不正な場合422が返ること", async () => {
+      // Arrange
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "invalid-email", password: "Password123" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("パスワードが空の場合422が返ること", async () => {
+      // Arrange
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com", password: "" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("認証情報が不正な場合401が返ること", async () => {
+      // Arrange
+      mockAuth.api.signInEmail.mockResolvedValue(null);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com", password: "wrongpassword" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_INVALID");
+    });
+
+    it("Better Auth がエラーをスローした場合401が返ること", async () => {
+      // Arrange
+      mockAuth.api.signInEmail.mockRejectedValue(new Error("認証エラー"));
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com", password: "Password123" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_INVALID");
+    });
+  });
+});
+
+describe("GET /api/auth/session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("有効なトークンでセッションを取得できること", async () => {
+      // Arrange
+      mockAuth.api.getSession.mockResolvedValue({
+        user: MOCK_USER,
+        session: { token: MOCK_TOKEN, expiresAt: new Date(Date.now() + 86400000) },
+      });
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/session", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as AuthSuccessBody;
+      expect(body.success).toBe(true);
+      expect(body.data.user.email).toBe("test@example.com");
+      expect(body.data.session.token).toBe(MOCK_TOKEN);
+    });
+  });
+
+  describe("異常系", () => {
+    it("Authorizationヘッダーがない場合401が返ること", async () => {
+      // Arrange
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/session", { method: "GET" });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_REQUIRED");
+    });
+
+    it("セッションが存在しない場合401が返ること", async () => {
+      // Arrange
+      mockAuth.api.getSession.mockResolvedValue(null);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/session", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_REQUIRED");
+    });
+
+    it("getSession がエラーをスローした場合500が返ること", async () => {
+      // Arrange
+      mockAuth.api.getSession.mockRejectedValue(new Error("DBエラー"));
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/session", {
+        method: "GET",
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_INTERNAL_SERVER_ERROR);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("INTERNAL_ERROR");
+    });
+  });
+});
+
+describe("POST /api/auth/refresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("有効なリフレッシュトークンで新しいトークンを取得できること", async () => {
+      // Arrange
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_SESSION_ROW]),
+      };
+      const selectChain2 = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_USER]),
+      };
+      mockDb.select
+        .mockReturnValueOnce(selectChain)
+        .mockReturnValueOnce(selectChain2);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: MOCK_TOKEN }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as RefreshSuccessBody;
+      expect(body.success).toBe(true);
+      expect(body.data.token).toBe(MOCK_TOKEN);
+    });
+  });
+
+  describe("異常系", () => {
+    it("リフレッシュトークンが空の場合422が返ること", async () => {
+      // Arrange
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: "" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("VALIDATION_FAILED");
+    });
+
+    it("セッションが存在しない場合401が返ること", async () => {
+      // Arrange
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: "invalid-token" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_EXPIRED");
+    });
+
+    it("セッションの有効期限が切れている場合401が返ること", async () => {
+      // Arrange
+      const expiredSession = {
+        ...MOCK_SESSION_ROW,
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      };
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([expiredSession]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: MOCK_TOKEN }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNAUTHORIZED);
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe("AUTH_EXPIRED");
+    });
+
+    it("エラーメッセージが日本語であること", async () => {
+      // Arrange
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: "invalid-token" }),
+      });
+
+      // Assert
+      const body = (await res.json()) as ErrorResponseBody;
+      expect(body.error.message).toContain("セッション");
+    });
+  });
+});

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,361 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import type { Database } from "../db";
+import { sessions, users } from "../db/schema";
+
+/** HTTP 200 OK ステータスコード */
+const HTTP_OK = 200;
+
+/** HTTP 401 Unauthorized ステータスコード */
+const HTTP_UNAUTHORIZED = 401;
+
+/** HTTP 422 Unprocessable Entity ステータスコード */
+const HTTP_UNPROCESSABLE_ENTITY = 422;
+
+/** HTTP 500 Internal Server Error ステータスコード */
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
+/** 未認証エラーコード */
+const AUTH_REQUIRED_CODE = "AUTH_REQUIRED";
+
+/** 認証情報不正エラーコード */
+const AUTH_INVALID_CODE = "AUTH_INVALID";
+
+/** バリデーションエラーコード */
+const VALIDATION_FAILED_CODE = "VALIDATION_FAILED";
+
+/** サーバーエラーコード */
+const INTERNAL_ERROR_CODE = "INTERNAL_ERROR";
+
+/** セッション期限切れエラーコード */
+const AUTH_EXPIRED_CODE = "AUTH_EXPIRED";
+
+/**
+ * Better Auth インスタンスの型定義
+ */
+type AuthInstance = {
+  api: {
+    signInEmail: (options: {
+      body: { email: string; password: string };
+      headers?: Headers;
+    }) => Promise<{
+      token: string | null;
+      user: Record<string, unknown>;
+    } | null>;
+    getSession: (options: { headers: Headers }) => Promise<{
+      session: { token: string; expiresAt: Date | string };
+      user: Record<string, unknown>;
+    } | null>;
+  };
+};
+
+/**
+ * 認証ルートのファクトリ関数の引数
+ */
+type AuthRouteOptions = {
+  db: Database;
+  getAuth: () => AuthInstance;
+};
+
+/** サインインリクエストのスキーマ */
+const SignInSchema = z.object({
+  email: z
+    .string({ required_error: "メールアドレスは必須です" })
+    .email("メールアドレスの形式が正しくありません"),
+  password: z
+    .string({ required_error: "パスワードは必須です" })
+    .min(1, "パスワードを入力してください"),
+});
+
+/** リフレッシュリクエストのスキーマ */
+const RefreshSchema = z.object({
+  refreshToken: z
+    .string({ required_error: "リフレッシュトークンは必須です" })
+    .min(1, "リフレッシュトークンを入力してください"),
+});
+
+/**
+ * 認証関連ルートを生成する
+ *
+ * @param options - DB インスタンスと Better Auth ファクトリ
+ * @returns Hono ルーター
+ */
+export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
+  const app = new Hono();
+
+  /**
+   * サインイン
+   * Better Auth の signInEmail API をラップして統一レスポンス形式で返す
+   */
+  app.post("/sign-in", async (c) => {
+    const body: unknown = await c.req.json().catch(() => ({}));
+    const parsed = SignInSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: VALIDATION_FAILED_CODE,
+            message: "入力内容を確認してください",
+            details: parsed.error.errors.map((e) => ({
+              field: e.path.join("."),
+              message: e.message,
+            })),
+          },
+        },
+        HTTP_UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    try {
+      const auth = getAuth();
+      const result = await auth.api.signInEmail({
+        body: { email: parsed.data.email, password: parsed.data.password },
+      });
+
+      if (!result || !result.token) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AUTH_INVALID_CODE,
+              message: "認証情報が正しくありません",
+            },
+          },
+          HTTP_UNAUTHORIZED,
+        );
+      }
+
+      const [sessionRow] = await db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.token, result.token));
+
+      if (!sessionRow) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AUTH_INVALID_CODE,
+              message: "認証情報が正しくありません",
+            },
+          },
+          HTTP_UNAUTHORIZED,
+        );
+      }
+
+      const user = result.user;
+
+      return c.json(
+        {
+          success: true,
+          data: {
+            user: {
+              id: user.id,
+              email: user.email,
+              name: user.name,
+              image: user.image ?? null,
+              createdAt: user.createdAt,
+              updatedAt: user.updatedAt,
+            },
+            session: {
+              token: sessionRow.token,
+              expiresAt: sessionRow.expiresAt,
+            },
+          },
+        },
+        HTTP_OK,
+      );
+    } catch {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: AUTH_INVALID_CODE,
+            message: "認証情報が正しくありません",
+          },
+        },
+        HTTP_UNAUTHORIZED,
+      );
+    }
+  });
+
+  /**
+   * セッション確認
+   * Authorization: Bearer <token> ヘッダーからセッションを検証して返す
+   */
+  app.get("/session", async (c) => {
+    const authHeader = c.req.header("Authorization");
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: AUTH_REQUIRED_CODE,
+            message: "ログインが必要です",
+          },
+        },
+        HTTP_UNAUTHORIZED,
+      );
+    }
+
+    try {
+      const auth = getAuth();
+      const result = await auth.api.getSession({ headers: c.req.raw.headers });
+
+      if (!result) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AUTH_REQUIRED_CODE,
+              message: "ログインが必要です",
+            },
+          },
+          HTTP_UNAUTHORIZED,
+        );
+      }
+
+      const user = result.user;
+      const session = result.session;
+      const expiresAt =
+        session.expiresAt instanceof Date
+          ? session.expiresAt.toISOString()
+          : String(session.expiresAt);
+
+      return c.json(
+        {
+          success: true,
+          data: {
+            user: {
+              id: user.id,
+              email: user.email,
+              name: user.name,
+              image: user.image ?? null,
+              createdAt: user.createdAt,
+              updatedAt: user.updatedAt,
+            },
+            session: {
+              token: session.token,
+              expiresAt,
+            },
+          },
+        },
+        HTTP_OK,
+      );
+    } catch {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: INTERNAL_ERROR_CODE,
+            message: "サーバーエラーが発生しました",
+          },
+        },
+        HTTP_INTERNAL_SERVER_ERROR,
+      );
+    }
+  });
+
+  /**
+   * トークンリフレッシュ
+   * リフレッシュトークン（セッショントークン）が有効であれば同じトークンを返す
+   * セッションの有効期限を確認し、期限切れの場合は 401 を返す
+   */
+  app.post("/refresh", async (c) => {
+    const body: unknown = await c.req.json().catch(() => ({}));
+    const parsed = RefreshSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: VALIDATION_FAILED_CODE,
+            message: "入力内容を確認してください",
+          },
+        },
+        HTTP_UNPROCESSABLE_ENTITY,
+      );
+    }
+
+    try {
+      const [sessionRow] = await db
+        .select()
+        .from(sessions)
+        .where(eq(sessions.token, parsed.data.refreshToken));
+
+      if (!sessionRow) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AUTH_EXPIRED_CODE,
+              message: "セッションの有効期限が切れました。再度ログインしてください",
+            },
+          },
+          HTTP_UNAUTHORIZED,
+        );
+      }
+
+      const expiresAt = new Date(sessionRow.expiresAt);
+      if (expiresAt <= new Date()) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AUTH_EXPIRED_CODE,
+              message: "セッションの有効期限が切れました。再度ログインしてください",
+            },
+          },
+          HTTP_UNAUTHORIZED,
+        );
+      }
+
+      const [userRow] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, sessionRow.userId));
+
+      if (!userRow) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AUTH_EXPIRED_CODE,
+              message: "セッションの有効期限が切れました。再度ログインしてください",
+            },
+          },
+          HTTP_UNAUTHORIZED,
+        );
+      }
+
+      return c.json(
+        {
+          success: true,
+          data: {
+            token: sessionRow.token,
+          },
+        },
+        HTTP_OK,
+      );
+    } catch {
+      return c.json(
+        {
+          success: false,
+          error: {
+            code: INTERNAL_ERROR_CODE,
+            message: "サーバーエラーが発生しました",
+          },
+        },
+        HTTP_INTERNAL_SERVER_ERROR,
+      );
+    }
+  });
+
+  return app;
+}

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -6,7 +6,7 @@ import { clearAuthTokens, getAuthToken, getRefreshToken, setAuthToken } from "./
 const REQUEST_TIMEOUT_MS = 15000;
 
 /** トークンリフレッシュAPIのパス */
-const REFRESH_TOKEN_PATH = "/auth/refresh";
+const REFRESH_TOKEN_PATH = "/api/auth/refresh";
 
 /**
  * セッション期限切れエラー

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -40,7 +40,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
    * @throws Error - 認証失敗時
    */
   signIn: async (params: SignInParams) => {
-    const data = await apiFetch<SignInResponse | AuthErrorResponse>("/auth/sign-in", {
+    const data = await apiFetch<SignInResponse | AuthErrorResponse>("/api/auth/sign-in", {
       method: "POST",
       body: JSON.stringify(params),
     });
@@ -128,7 +128,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
     try {
       const data = await apiFetch<
         { success: true; data: { user: User; session: Session } } | AuthErrorResponse
-      >("/auth/session");
+      >("/api/auth/session");
 
       if (!data.success) {
         await clearAuthTokens();


### PR DESCRIPTION
## 概要
認証パスの/apiプレフィックス統一とrefreshトークンフロー修正

## 変更内容
- mobile auth paths に `/api` プレフィックス追加
- sign-out ルート追加
- refresh トークンパス修正

Closes #386