### PR TITLE
fix: auth sign-in validation error with Zod v4 .issues property

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -100,7 +100,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
           error: {
             code: VALIDATION_FAILED_CODE,
             message: "入力内容を確認してください",
-            details: parsed.error.errors.map((e) => ({
+            details: parsed.error.issues.map((e) => ({
               field: e.path.join("."),
               message: e.message,
             })),


### PR DESCRIPTION
## 概要

auth.tsのサインインバリデーションでZod v4の`.errors`→`.issues`プロパティ変更に対応。422の代わりに500が返されていた問題を修正。

## 変更内容

- `apps/api/src/routes/auth.ts:103`: `parsed.error.errors.map()` → `parsed.error.issues.map()`

## テスト

- [x] 全1177テストパス（修正前: 2件失敗）
- [x] `pnpm test` がすべてパスすること

Closes #396