### PR TITLE
fix: resolve Biome lint errors

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,9 +8,6 @@ import { corsMiddleware } from "./middleware/cors";
 import { securityHeadersMiddleware } from "./middleware/security-headers";
 import { createSentryMiddleware } from "./middleware/sentry";
 import { openApiSpec } from "./openapi";
-import { parseArticle } from "./services/article-parser";
-import { summarizeArticle } from "./services/summary";
-import { translateArticle } from "./services/translator";
 import { createAiRoute } from "./routes/ai";
 import { createArticlesRoute } from "./routes/articles";
 import { createAuthRoute } from "./routes/auth";
@@ -26,6 +23,9 @@ import { createSubscriptionRoute } from "./routes/subscription";
 import { createSummaryRoute } from "./routes/summary";
 import { createTagsRoute } from "./routes/tags";
 import { createUsersRoute } from "./routes/users";
+import { parseArticle } from "./services/article-parser";
+import { summarizeArticle } from "./services/summary";
+import { translateArticle } from "./services/translator";
 
 /** Cloudflare Workers バインディング型定義 */
 type Bindings = {
@@ -342,9 +342,7 @@ app.on(["GET", "POST", "PATCH", "DELETE"], "/api/users/**", async (c) => {
   const usersRoute = createUsersRoute({
     db,
     r2Bucket: c.env.AVATARS_BUCKET,
-    r2PublicUrl: c.env.ENVIRONMENT === "production"
-      ? "https://avatars.techclip.io"
-      : undefined,
+    r2PublicUrl: c.env.ENVIRONMENT === "production" ? "https://avatars.techclip.io" : undefined,
   });
 
   const followsRoute = createFollowsRoute({

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -301,9 +301,7 @@ describe("POST /api/auth/refresh", () => {
         from: vi.fn().mockReturnThis(),
         where: vi.fn().mockResolvedValue([MOCK_USER]),
       };
-      mockDb.select
-        .mockReturnValueOnce(selectChain)
-        .mockReturnValueOnce(selectChain2);
+      mockDb.select.mockReturnValueOnce(selectChain).mockReturnValueOnce(selectChain2);
       const app = createTestApp();
 
       // Act

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -129,10 +129,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
         );
       }
 
-      const [sessionRow] = await db
-        .select()
-        .from(sessions)
-        .where(eq(sessions.token, result.token));
+      const [sessionRow] = await db.select().from(sessions).where(eq(sessions.token, result.token));
 
       if (!sessionRow) {
         return c.json(
@@ -316,10 +313,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
         );
       }
 
-      const [userRow] = await db
-        .select()
-        .from(users)
-        .where(eq(users.id, sessionRow.userId));
+      const [userRow] = await db.select().from(users).where(eq(users.id, sessionRow.userId));
 
       if (!userRow) {
         return c.json(

--- a/apps/mobile/__tests__/components/FollowButton.test.tsx
+++ b/apps/mobile/__tests__/components/FollowButton.test.tsx
@@ -141,7 +141,7 @@ describe("FollowButton", () => {
 
       // Cleanup
       await act(async () => {
-        resolve!();
+        resolve?.();
       });
     });
   });

--- a/apps/mobile/__tests__/components/PremiumGate.test.tsx
+++ b/apps/mobile/__tests__/components/PremiumGate.test.tsx
@@ -23,8 +23,8 @@ jest.mock("lucide-react-native", () => {
   };
 });
 
-import type React from "react";
 import { fireEvent, render } from "@testing-library/react-native";
+import type React from "react";
 import { Text } from "react-native";
 
 import { PremiumGate } from "../../src/components/PremiumGate";
@@ -42,7 +42,9 @@ const BASE_PROPS = {
  * レンダリングされたコンポーネントからTextノードのchildren一覧を取得する
  */
 function getAllTextContent(
-  unsafeGetAllByType: <P>(type: React.ComponentType<P>) => Array<{ props: Record<string, unknown> }>,
+  unsafeGetAllByType: <P>(
+    type: React.ComponentType<P>,
+  ) => Array<{ props: Record<string, unknown> }>,
 ): string[] {
   const textNodes = unsafeGetAllByType(Text);
   return textNodes


### PR DESCRIPTION
## 概要

Biome lintエラー5件を修正。

## 変更内容

- `apps/api/src/index.ts` - フォーマット修正
- `apps/api/src/routes/auth.ts` - フォーマット修正
- `apps/api/src/routes/auth.test.ts` - フォーマット修正
- `apps/mobile/__tests__/components/PremiumGate.test.tsx` - フォーマット修正
- `apps/mobile/__tests__/components/FollowButton.test.tsx` - non-null assertionをoptional chainingに修正

## テスト

- [x] `pnpm lint` がエラーなしで通ること

Closes #405