### PR TITLE
fix: repair backgroundSync test mock harness

### DIFF
--- a/apps/mobile/__mocks__/react-native.js
+++ b/apps/mobile/__mocks__/react-native.js
@@ -1,0 +1,16 @@
+/**
+ * react-native のテストモック
+ *
+ * jest-expo/node プリセットは react-native を react-native-web に解決するが、
+ * moduleNameMapper でこのファイルを優先させることで AppState.addEventListener を
+ * jest.fn() として扱えるようにする。
+ */
+const reactNativeWeb = jest.requireActual("react-native-web");
+
+module.exports = {
+  ...reactNativeWeb,
+  AppState: {
+    ...reactNativeWeb.AppState,
+    addEventListener: jest.fn(),
+  },
+};

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^react-native$": "<rootDir>/__mocks__/react-native.js",
     "^nativewind$": "<rootDir>/__mocks__/nativewind.js",
     "^lucide-react-native$": "<rootDir>/__mocks__/lucide-react-native.js",
     "^react-native-css-interop$": "<rootDir>/__mocks__/react-native-css-interop.js",


### PR DESCRIPTION
## 概要

backgroundSync.test.tsのモックハーネスを修正。AppState.addEventListenerのモックが正しく動作するようにした。

## 変更内容

- `apps/mobile/__mocks__/react-native.js` 追加 - AppStateモック
- `apps/mobile/jest.config.js` 更新

## テスト

- [ ] backgroundSyncテストがパスすること

Closes #403