### PR TITLE
fix: resolve remaining Biome lint formatting issues

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -64,9 +64,7 @@ const SignInSchema = z.object({
   email: z
     .string({ error: "メールアドレスは必須です" })
     .email("メールアドレスの形式が正しくありません"),
-  password: z
-    .string({ error: "パスワードは必須です" })
-    .min(1, "パスワードを入力してください"),
+  password: z.string({ error: "パスワードは必須です" }).min(1, "パスワードを入力してください"),
 });
 
 /** リフレッシュリクエストのスキーマ */

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,17 @@
     "enabled": true
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".turbo", ".wrangler", ".expo", ".claude", "drizzle", ".omc", ".worktrees"]
+    "ignore": [
+      "node_modules",
+      "dist",
+      ".turbo",
+      ".wrangler",
+      ".expo",
+      ".claude",
+      "drizzle",
+      ".omc",
+      ".worktrees"
+    ]
   },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
## 概要

Biome lintの残りフォーマット差分2件を修正。

## 変更内容

- `biome.json:19` - ignoreリストをmultiline形式に展開
- `apps/api/src/routes/auth.ts:67-69` - Zodチェーンをline-widthに収まるよう整形

## テスト

- [x] `pnpm lint` エラー0

Closes #414