### PR TITLE
chore: add deny rules for enforce_admins, merge --admin, and main push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -83,7 +83,11 @@
       "mcp__sequential-thinking__*"
     ],
     "deny": [
-      "Bash(drizzle-kit push:*)"
+      "Bash(drizzle-kit push:*)",
+      "Bash(*enforce_admins*)",
+      "Bash(*merge*--admin*)",
+      "Bash(*git push origin main*)",
+      "Bash(*git push*main*)"
     ]
   },
   "worktree": {


### PR DESCRIPTION
## 概要

settings.jsonのdenyリストに危険なコマンドパターンを追加し、物理的にブロック。

## 変更内容

- `Bash(*enforce_admins*)` - ブランチ保護設定の変更を禁止
- `Bash(*merge*--admin*)` - adminフラグでのマージを禁止
- `Bash(*git push origin main*)` / `Bash(*git push*main*)` - mainへの直接pushを禁止

Closes #422