### PR TITLE
fix: use correct isFavorite query parameter name #446

### DIFF
--- a/apps/mobile/src/hooks/use-articles.ts
+++ b/apps/mobile/src/hooks/use-articles.ts
@@ -43,7 +43,7 @@ async function fetchArticles(
   if (cursor) params.set("cursor", cursor);
   params.set("limit", String(DEFAULT_PAGE_LIMIT));
   if (filter.source) params.set("source", filter.source);
-  if (filter.isFavorite) params.set("favorite", "true");
+  if (filter.isFavorite) params.set("isFavorite", "true");
   if (filter.search) params.set("q", filter.search);
 
   const queryString = params.toString();


### PR DESCRIPTION
## 概要

お気に入りフィルタのクエリパラメータ名を `favorite` から `isFavorite` に修正し、APIの期待するパラメータ名と一致させる。

## 変更内容

- `apps/mobile/src/hooks/use-articles.ts`: `params.set("favorite", "true")` を `params.set("isFavorite", "true")` に変更

## テスト

- [x] Unit テスト追加・更新済み
- [x] `pnpm test` がすべてパスすること（540 tests passed）
- [x] `biome check` がエラーなしで通ること

## 関連Issue

Closes #446