### PR TITLE
fix: reject CORS requests with missing Origin header #437

### DIFF
--- a/apps/api/src/middleware/cors.test.ts
+++ b/apps/api/src/middleware/cors.test.ts
@@ -87,7 +87,7 @@ describe("corsMiddleware", () => {
   });
 
   describe("Originヘッダーなし", () => {
-    it("Originなしリクエストにワイルドカードを返すこと", async () => {
+    it("Originなしリクエストにワイルドカードを返さないこと", async () => {
       // Arrange
       const app = createTestApp();
 
@@ -96,7 +96,7 @@ describe("corsMiddleware", () => {
 
       // Assert
       expect(res.status).toBe(200);
-      expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(res.headers.get("Access-Control-Allow-Origin")).not.toBe("*");
     });
   });
 

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -23,7 +23,7 @@ const PREFLIGHT_MAX_AGE_SECONDS = 86400;
  */
 function resolveOrigin(origin: string): string {
   if (!origin) {
-    return "*";
+    return "";
   }
   if (ALLOWED_ORIGINS.includes(origin)) {
     return origin;


### PR DESCRIPTION
## 概要

Originヘッダーが欠落したリクエストに対して、ワイルドカード `*` を返していた問題を修正。Origin が空の場合は `""` (拒否) を返すよう変更。

## 変更内容

- `apps/api/src/middleware/cors.ts`: `resolveOrigin` の `!origin` 分岐で `"*"` → `""` に変更
- `apps/api/src/middleware/cors.test.ts`: 対応するテストケースを「ワイルドカードを返さないこと」に更新

## テスト

- [x] Unit テスト追加・更新済み
- [x] `pnpm test` がすべてパスすること（1177 tests passed）
- [x] `pnpm lint` がエラーなしで通ること（Biome: 0 errors）

## 関連Issue

Closes #437