### PR TITLE
fix: AI limit middleware TOCTOU race condition - atomic UPDATE #443

### DIFF
--- a/apps/api/src/middleware/ai-limit.test.ts
+++ b/apps/api/src/middleware/ai-limit.test.ts
@@ -53,8 +53,11 @@ const mockSelect = vi.fn().mockReturnValue({
   from: mockSelectFrom,
 });
 
-/** モックの db.update クエリ結果 */
-const mockUpdateWhere = vi.fn();
+/** モックの db.update クエリ結果（.returning()付きアトミック更新用） */
+const mockUpdateReturning = vi.fn();
+const mockUpdateWhere = vi.fn().mockReturnValue({
+  returning: mockUpdateReturning,
+});
 const mockUpdateSet = vi.fn().mockReturnValue({
   where: mockUpdateWhere,
 });
@@ -99,7 +102,7 @@ function createTestApp(userId?: string, downstreamStatus = HTTP_OK) {
 describe("aiLimitMiddleware", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUpdateWhere.mockResolvedValue(undefined);
+    mockUpdateReturning.mockResolvedValue(undefined);
   });
 
   describe("無料ユーザー - 残回数あり", () => {
@@ -107,6 +110,7 @@ describe("aiLimitMiddleware", () => {
       // Arrange
       const userData = createFreeUserData({ remaining: 3 });
       mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue([userData]);
       const app = createTestApp(TEST_USER_ID);
 
       // Act
@@ -123,6 +127,7 @@ describe("aiLimitMiddleware", () => {
       // Arrange
       const userData = createFreeUserData({ remaining: 3 });
       mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue([userData]);
       const app = createTestApp(TEST_USER_ID);
 
       // Act
@@ -135,6 +140,40 @@ describe("aiLimitMiddleware", () => {
       expect(mockUpdate).toHaveBeenCalledTimes(1);
       expect(mockUpdateSet).toHaveBeenCalledTimes(1);
       expect(mockUpdateWhere).toHaveBeenCalledTimes(1);
+    });
+
+    it("アトミック更新でreturningが呼ばれること（TOCTOU競合防止）", async () => {
+      // Arrange
+      const userData = createFreeUserData({ remaining: 3 });
+      mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert: アトミック更新には.returning()が必須
+      expect(mockUpdateReturning).toHaveBeenCalledTimes(1);
+    });
+
+    it("アトミック更新が0件返した場合（競合負け）402を返すこと", async () => {
+      // Arrange: SELECT時点では残回数ありだが、UPDATE時点で他リクエストに先を越された場合
+      const userData = createFreeUserData({ remaining: 1 });
+      mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue([]);
+      const app = createTestApp(TEST_USER_ID);
+
+      // Act
+      const res = await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_PAYMENT_REQUIRED);
     });
   });
 
@@ -239,6 +278,7 @@ describe("aiLimitMiddleware", () => {
       const pastDate = new Date("2025-01-01T00:00:00Z").toISOString();
       const userData = createFreeUserData({ remaining: 0, resetAt: pastDate });
       mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue(undefined);
       const app = createTestApp(TEST_USER_ID);
 
       // Act
@@ -256,6 +296,7 @@ describe("aiLimitMiddleware", () => {
       const pastDate = new Date("2025-01-01T00:00:00Z").toISOString();
       const userData = createFreeUserData({ remaining: 0, resetAt: pastDate });
       mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue(undefined);
       const app = createTestApp(TEST_USER_ID);
 
       // Act
@@ -277,6 +318,7 @@ describe("aiLimitMiddleware", () => {
       // Arrange
       const userData = createFreeUserData({ remaining: 0, resetAt: null });
       mockSelectWhere.mockResolvedValue([userData]);
+      mockUpdateReturning.mockResolvedValue(undefined);
       const app = createTestApp(TEST_USER_ID);
 
       // Act

--- a/apps/api/src/middleware/ai-limit.ts
+++ b/apps/api/src/middleware/ai-limit.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, gt, sql } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 
 import type { Database } from "../db";
@@ -60,8 +60,9 @@ const HTTP_SUCCESS_MAX_STATUS = 399;
  * 要約/翻訳API呼び出し前にユーザーのfreeAiUsesRemainingをチェックし、
  * 無料ユーザーの使用回数を制限する。
  * - プレミアムユーザー: 制限なし（通過）
- * - 無料ユーザー（残回数あり）: 通過後にデクリメント（成功時のみ）
- * - 無料ユーザー（残回数なし、リセット期限切れ）: リセットして通過（成功時のみ適用）
+ * - 無料ユーザー（残回数あり）: アトミックUPDATE（WHERE freeAiUsesRemaining > 0）で
+ *   デクリメント。更新0件の場合はTOCTOU競合とみなし402を返却
+ * - 無料ユーザー（残回数なし、リセット期限切れ）: リセットして通過
  * - 無料ユーザー（残回数なし、リセット期限内）: 402を返却
  *
  * @param db - Drizzle ORMデータベースインスタンス
@@ -111,6 +112,28 @@ export function createAiLimitMiddleware(db: Database): MiddlewareHandler {
     const remaining = dbUser.freeAiUsesRemaining ?? 0;
 
     if (remaining > 0) {
+      const updated = await db
+        .update(users)
+        .set({
+          freeAiUsesRemaining: sql`${users.freeAiUsesRemaining} - 1`,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(and(eq(users.id, userId), gt(users.freeAiUsesRemaining, 0)))
+        .returning();
+
+      if (updated.length === 0) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: AI_LIMIT_ERROR_CODE,
+              message: AI_LIMIT_ERROR_MESSAGE,
+            },
+          },
+          HTTP_PAYMENT_REQUIRED,
+        );
+      }
+
       await next();
 
       if (c.res.status <= HTTP_SUCCESS_MAX_STATUS) {


### PR DESCRIPTION
## 概要

`ai-limit.ts` のデクリメント処理で発生していたTOCTOU（Time-of-Check-Time-of-Use）競合状態を修正。
別々のSELECT + UPDATEを、`WHERE freeAiUsesRemaining > 0` 付きの単一アトミックUPDATE...RETURNINGに変更した。

## 変更内容

- `apps/api/src/middleware/ai-limit.ts`: デクリメントブランチのSELECT+UPDATEを `sql\`${users.freeAiUsesRemaining} - 1\`` + `.where(and(eq(users.id, userId), gt(users.freeAiUsesRemaining, 0)))` + `.returning()` のアトミックUPDATEに変更
- `apps/api/src/middleware/ai-limit.test.ts`: モックに `.returning()` を追加し、競合負け（returning空配列）→402のテストケースを追加

## テスト

- [x] Unit テスト追加・更新済み（競合負け時402テストを新規追加）
- [x] `pnpm test` がすべてパスすること（15/15 passed）
- [x] `pnpm lint` がエラーなしで通ること（Biome: No fixes applied）

## 関連Issue

Closes #443