### PR TITLE
fix: only decrement AI free uses on successful response #436

### DIFF
--- a/apps/api/src/middleware/ai-limit.test.ts
+++ b/apps/api/src/middleware/ai-limit.test.ts
@@ -68,8 +68,11 @@ const mockDb = {
   update: mockUpdate,
 };
 
+/** HTTP 500 Internal Server Error ステータスコード */
+const HTTP_INTERNAL_SERVER_ERROR = 500;
+
 /** テスト用のHonoアプリを作成する */
-function createTestApp(userId?: string) {
+function createTestApp(userId?: string, downstreamStatus = HTTP_OK) {
   const app = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
 
   if (userId) {
@@ -81,6 +84,12 @@ function createTestApp(userId?: string) {
 
   app.use("/ai/*", createAiLimitMiddleware(mockDb as never));
   app.post("/ai/summarize", (c) => {
+    if (downstreamStatus >= 400) {
+      return c.json(
+        { success: false, error: { code: "INTERNAL_ERROR", message: "サーバーエラーが発生しました" } },
+        downstreamStatus as 500,
+      );
+    }
     return c.json({ success: true, data: { summary: "テスト要約" } }, HTTP_OK);
   });
 
@@ -315,6 +324,24 @@ describe("aiLimitMiddleware", () => {
 
       // Assert
       expect(res.status).toBe(HTTP_UNAUTHORIZED);
+    });
+  });
+
+  describe("ダウンストリーム失敗時", () => {
+    it("ダウンストリームが500を返した場合db.updateが呼ばれないこと", async () => {
+      // Arrange
+      const userData = createFreeUserData({ remaining: 3 });
+      mockSelectWhere.mockResolvedValue([userData]);
+      const app = createTestApp(TEST_USER_ID, HTTP_INTERNAL_SERVER_ERROR);
+
+      // Act
+      await app.request("/ai/summarize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      // Assert
+      expect(mockUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/middleware/ai-limit.ts
+++ b/apps/api/src/middleware/ai-limit.ts
@@ -51,14 +51,17 @@ function isResetExpired(resetAt: string | null): boolean {
   return new Date(resetAt).getTime() <= Date.now();
 }
 
+/** レスポンスが成功とみなす最大ステータスコード */
+const HTTP_SUCCESS_MAX_STATUS = 399;
+
 /**
  * AI使用回数制限ミドルウェアを生成する
  *
  * 要約/翻訳API呼び出し前にユーザーのfreeAiUsesRemainingをチェックし、
  * 無料ユーザーの使用回数を制限する。
  * - プレミアムユーザー: 制限なし（通過）
- * - 無料ユーザー（残回数あり）: 通過後にデクリメント
- * - 無料ユーザー（残回数なし、リセット期限切れ）: リセットして通過
+ * - 無料ユーザー（残回数あり）: 通過後にデクリメント（成功時のみ）
+ * - 無料ユーザー（残回数なし、リセット期限切れ）: リセットして通過（成功時のみ適用）
  * - 無料ユーザー（残回数なし、リセット期限内）: 402を返却
  *
  * @param db - Drizzle ORMデータベースインスタンス
@@ -108,31 +111,37 @@ export function createAiLimitMiddleware(db: Database): MiddlewareHandler {
     const remaining = dbUser.freeAiUsesRemaining ?? 0;
 
     if (remaining > 0) {
-      await db
-        .update(users)
-        .set({
-          freeAiUsesRemaining: remaining - 1,
-          updatedAt: new Date().toISOString(),
-        })
-        .where(eq(users.id, userId));
-
       await next();
+
+      if (c.res.status <= HTTP_SUCCESS_MAX_STATUS) {
+        await db
+          .update(users)
+          .set({
+            freeAiUsesRemaining: remaining - 1,
+            updatedAt: new Date().toISOString(),
+          })
+          .where(eq(users.id, userId));
+      }
+
       return;
     }
 
     if (isResetExpired(dbUser.freeAiResetAt)) {
       const nextResetAt = calculateNextResetAt();
 
-      await db
-        .update(users)
-        .set({
-          freeAiUsesRemaining: FREE_AI_USES_PER_MONTH - 1,
-          freeAiResetAt: nextResetAt,
-          updatedAt: new Date().toISOString(),
-        })
-        .where(eq(users.id, userId));
-
       await next();
+
+      if (c.res.status <= HTTP_SUCCESS_MAX_STATUS) {
+        await db
+          .update(users)
+          .set({
+            freeAiUsesRemaining: FREE_AI_USES_PER_MONTH - 1,
+            freeAiResetAt: nextResetAt,
+            updatedAt: new Date().toISOString(),
+          })
+          .where(eq(users.id, userId));
+      }
+
       return;
     }
 


### PR DESCRIPTION
## 概要
AI制限ミドルウェアのデクリメントを成功レスポンス時のみに変更

## 変更内容
- `await next()` 後にレスポンスステータスを確認し、成功時のみデクリメント
- ダウンストリーム失敗時にユーザーの無料枠が消費されない

## テスト
- [x] 全1177テストパス
- [x] Biomeエラーなし

Closes #436