### PR TITLE
fix: escape LIKE wildcard characters in search query

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,7 +18,7 @@ import { createNotificationSettingsRoute } from "./routes/notification-settings"
 import { createNotificationsRoute } from "./routes/notifications";
 import { createPasswordResetRoute } from "./routes/password-reset";
 import { createPublicArticlesRoute } from "./routes/public-articles";
-import { createSearchRoute } from "./routes/search";
+import { createSearchRoute, escapeLikeWildcards } from "./routes/search";
 import { createSubscriptionRoute } from "./routes/subscription";
 import { createSummaryRoute } from "./routes/summary";
 import { createTagsRoute } from "./routes/tags";
@@ -291,7 +291,7 @@ app.on(["GET", "POST", "PATCH", "DELETE"], "/api/articles/**", async (c) => {
 
   const searchRoute = createSearchRoute({
     searchQueryFn: async (params) => {
-      const keyword = `%${params.query}%`;
+      const keyword = `%${escapeLikeWildcards(params.query)}%`;
       const conditions = [
         eq(articles.userId, params.userId),
         or(

--- a/apps/api/src/routes/search.test.ts
+++ b/apps/api/src/routes/search.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SearchQueryFn } from "./search";
-import { createSearchRoute } from "./search";
+import { createSearchRoute, escapeLikeWildcards } from "./search";
 
 /** テスト用のモックユーザー */
 const MOCK_USER = {
@@ -107,6 +107,74 @@ function createTestAppWithoutAuth(mockSearchQueryFn: MockSearchQueryFn) {
 
   return app;
 }
+
+describe("escapeLikeWildcards", () => {
+  it("通常の文字列はそのまま返すこと", () => {
+    // Arrange
+    const input = "React hooks";
+
+    // Act
+    const result = escapeLikeWildcards(input);
+
+    // Assert
+    expect(result).toBe("React hooks");
+  });
+
+  it("%を含む場合エスケープされること", () => {
+    // Arrange
+    const input = "100%完了";
+
+    // Act
+    const result = escapeLikeWildcards(input);
+
+    // Assert
+    expect(result).toBe("100\\%完了");
+  });
+
+  it("_を含む場合エスケープされること", () => {
+    // Arrange
+    const input = "foo_bar";
+
+    // Act
+    const result = escapeLikeWildcards(input);
+
+    // Assert
+    expect(result).toBe("foo\\_bar");
+  });
+
+  it("バックスラッシュを含む場合エスケープされること", () => {
+    // Arrange
+    const input = "C:\\path";
+
+    // Act
+    const result = escapeLikeWildcards(input);
+
+    // Assert
+    expect(result).toBe("C:\\\\path");
+  });
+
+  it("%と_が混在する場合すべてエスケープされること", () => {
+    // Arrange
+    const input = "50%_off";
+
+    // Act
+    const result = escapeLikeWildcards(input);
+
+    // Assert
+    expect(result).toBe("50\\%\\_off");
+  });
+
+  it("空文字列は空文字列を返すこと", () => {
+    // Arrange
+    const input = "";
+
+    // Act
+    const result = escapeLikeWildcards(input);
+
+    // Assert
+    expect(result).toBe("");
+  });
+});
 
 describe("GET /api/articles/search", () => {
   let mockSearchQueryFn: MockSearchQueryFn;

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -47,6 +47,16 @@ type SearchRouteOptions = {
 };
 
 /**
+ * LIKE演算子のワイルドカード文字をエスケープする
+ *
+ * @param query - エスケープ対象の検索キーワード
+ * @returns ワイルドカード文字（%、_、\）をエスケープした文字列
+ */
+export function escapeLikeWildcards(query: string): string {
+  return query.replace(/[%_\\]/g, "\\$&");
+}
+
+/**
  * レスポンスからcontentフィールドを除外する
  *
  * @param article - 記事データ


### PR DESCRIPTION
## 概要

検索クエリに `%`、`_`、`\` が含まれる場合、LIKE演算子のワイルドカードとして解釈されてしまう問題を修正した。

## 変更内容

- `apps/api/src/routes/search.ts`: `escapeLikeWildcards()` 関数を追加・エクスポート
- `apps/api/src/index.ts`: `searchQueryFn` 内のキーワード構築時に `escapeLikeWildcards()` を適用
- `apps/api/src/routes/search.test.ts`: `escapeLikeWildcards` のユニットテスト6件を追加

## テスト

- [x] Unit テスト追加・更新済み
- [x] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（30/30 passed）
- [x] `pnpm lint` がエラーなしで通ること

## 関連Issue

Closes #442