### PR TITLE
fix: use timing-safe comparison for webhook secret #434

### DIFF
--- a/apps/api/src/routes/subscription.ts
+++ b/apps/api/src/routes/subscription.ts
@@ -16,12 +16,10 @@ import { users } from "../db/schema";
  * @returns 一致する場合 true
  */
 function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-  let result = 0;
-  for (let i = 0; i < a.length; i++) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  const maxLen = Math.max(a.length, b.length);
+  let result = a.length ^ b.length;
+  for (let i = 0; i < maxLen; i++) {
+    result |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
   }
   return result === 0;
 }


### PR DESCRIPTION
## 概要
RevenueCat Webhook認証のsecret比較をタイミングセーフな定数時間比較に変更

## 変更内容
- `subscription.ts` に `timingSafeEqual()` 関数を追加
- `===` 比較をタイミングセーフな比較に置換
- Node.js/Vitest環境でも動作するpure JS実装

## テスト
- [x] 全1177テストパス
- [x] Biomeエラーなし

Closes #434