### PR TITLE
docs: fix API endpoint path in release checklist

### DIFF
--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -325,7 +325,7 @@ eas update --channel production --message "リリースノート"
 curl https://api.techclip.app/health
 
 # 認証エンドポイントの確認
-curl -X POST https://api.techclip.app/auth/sign-in \
+curl -X POST https://api.techclip.app/api/auth/sign-in \
   -H "Content-Type: application/json" \
   -d '{"email":"test@example.com","password":"testpassword"}'
 ```


### PR DESCRIPTION
## 概要

`docs/RELEASE_CHECKLIST.md` のデプロイ後検証セクションで認証エンドポイントのパスが `/auth/sign-in` となっていたが、正しくは `/api/auth/sign-in` であるため修正。

## 変更内容

- `docs/RELEASE_CHECKLIST.md` line 328: `/auth/sign-in` -> `/api/auth/sign-in`

## テスト

TDD対象外（ドキュメント変更のみ）。

## 関連Issue

Closes #425