### PR TITLE
fix: disable analytics fetch until backend /analytics/events route exists #426

### DIFF
--- a/apps/mobile/src/lib/analytics.test.ts
+++ b/apps/mobile/src/lib/analytics.test.ts
@@ -7,13 +7,6 @@ jest.mock("expo-constants", () => ({
   },
 }));
 
-jest.mock("./secure-store", () => ({
-  getAuthToken: jest.fn().mockResolvedValue(null),
-  getRefreshToken: jest.fn().mockResolvedValue(null),
-  setAuthToken: jest.fn().mockResolvedValue(undefined),
-  clearAuthTokens: jest.fn().mockResolvedValue(undefined),
-}));
-
 import {
   AnalyticsEventName,
   trackAiSummaryRequest,
@@ -29,169 +22,83 @@ import {
 const mockFetch = jest.fn();
 (globalThis as Record<string, unknown>).fetch = mockFetch;
 
-/**
- * fetchレスポンスのモックヘルパー
- */
-function createFetchResponse(body: unknown, status = 200): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: jest.fn().mockResolvedValue(body),
-  } as unknown as Response;
-}
-
 describe("analytics", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFetch.mockResolvedValue(createFetchResponse({ success: true, data: null }));
   });
 
   describe("trackEvent", () => {
-    it("イベント名とプロパティをAPIに送信できること", async () => {
-      // Arrange
-      const eventName = AnalyticsEventName.ARTICLE_VIEW;
-      const properties = { articleId: "article-123", source: "zenn" };
-
+    it("バックエンド未実装のためfetchを呼び出さないこと", async () => {
       // Act
-      await trackEvent(eventName, properties);
+      await trackEvent(AnalyticsEventName.ARTICLE_VIEW, { articleId: "article-123" });
 
       // Assert
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://test-api.example.com/analytics/events",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            "Content-Type": "application/json",
-          }),
-        }),
-      );
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(eventName);
-      expect(callBody.properties).toEqual(properties);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("APIが失敗してもエラーをスローせずに静かに失敗すること", async () => {
-      // Arrange
-      mockFetch.mockRejectedValue(new Error("ネットワークエラー"));
-
-      // Act & Assert（エラーがスローされないこと）
-      await expect(trackEvent(AnalyticsEventName.ARTICLE_VIEW, {})).resolves.toBeUndefined();
-    });
-
-    it("APIが500を返してもエラーをスローせずに静かに失敗すること", async () => {
-      // Arrange
-      mockFetch.mockResolvedValue(
-        createFetchResponse({ success: false, error: { code: "INTERNAL_ERROR" } }, 500),
-      );
-
+    it("エラーをスローせずに正常に完了すること", async () => {
       // Act & Assert
-      await expect(
-        trackEvent(AnalyticsEventName.SCREEN_VIEW, { screen: "Home" }),
-      ).resolves.toBeUndefined();
-    });
-
-    it("送信データにtimestampが含まれること", async () => {
-      // Arrange
-      const before = Date.now();
-
-      // Act
-      await trackEvent(AnalyticsEventName.SEARCH, { query: "react" });
-
-      // Assert
-      const after = Date.now();
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.timestamp).toBeGreaterThanOrEqual(before);
-      expect(callBody.timestamp).toBeLessThanOrEqual(after);
+      await expect(trackEvent(AnalyticsEventName.ARTICLE_VIEW, {})).resolves.toBeUndefined();
     });
   });
 
   describe("trackScreenView", () => {
-    it("画面名をプロパティとしてSCREEN_VIEWイベントを送信できること", async () => {
-      // Arrange
-      const screenName = "ArticleDetail";
-
+    it("fetchを呼び出さずに正常に完了すること", async () => {
       // Act
-      await trackScreenView(screenName);
+      await trackScreenView("ArticleDetail");
 
       // Assert
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(AnalyticsEventName.SCREEN_VIEW);
-      expect(callBody.properties.screen).toBe(screenName);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
   describe("trackArticleView", () => {
-    it("記事IDをプロパティとしてARTICLE_VIEWイベントを送信できること", async () => {
-      // Arrange
-      const articleId = "article-456";
-
+    it("fetchを呼び出さずに正常に完了すること", async () => {
       // Act
-      await trackArticleView(articleId);
+      await trackArticleView("article-456");
 
       // Assert
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(AnalyticsEventName.ARTICLE_VIEW);
-      expect(callBody.properties.articleId).toBe(articleId);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
   describe("trackArticleSave", () => {
-    it("記事IDをプロパティとしてARTICLE_SAVEイベントを送信できること", async () => {
-      // Arrange
-      const articleId = "article-789";
-
+    it("fetchを呼び出さずに正常に完了すること", async () => {
       // Act
-      await trackArticleSave(articleId);
+      await trackArticleSave("article-789");
 
       // Assert
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(AnalyticsEventName.ARTICLE_SAVE);
-      expect(callBody.properties.articleId).toBe(articleId);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
   describe("trackArticleShare", () => {
-    it("記事IDをプロパティとしてARTICLE_SHAREイベントを送信できること", async () => {
-      // Arrange
-      const articleId = "article-101";
-
+    it("fetchを呼び出さずに正常に完了すること", async () => {
       // Act
-      await trackArticleShare(articleId);
+      await trackArticleShare("article-101");
 
       // Assert
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(AnalyticsEventName.ARTICLE_SHARE);
-      expect(callBody.properties.articleId).toBe(articleId);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
   describe("trackAiSummaryRequest", () => {
-    it("記事IDをプロパティとしてAI_SUMMARY_REQUESTイベントを送信できること", async () => {
-      // Arrange
-      const articleId = "article-202";
-
+    it("fetchを呼び出さずに正常に完了すること", async () => {
       // Act
-      await trackAiSummaryRequest(articleId);
+      await trackAiSummaryRequest("article-202");
 
       // Assert
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(AnalyticsEventName.AI_SUMMARY_REQUEST);
-      expect(callBody.properties.articleId).toBe(articleId);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 
   describe("trackSearch", () => {
-    it("検索クエリをプロパティとしてSEARCHイベントを送信できること", async () => {
-      // Arrange
-      const query = "typescript hooks";
-
+    it("fetchを呼び出さずに正常に完了すること", async () => {
       // Act
-      await trackSearch(query);
+      await trackSearch("typescript hooks");
 
       // Assert
-      const callBody = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
-      expect(callBody.event).toBe(AnalyticsEventName.SEARCH);
-      expect(callBody.properties.query).toBe(query);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -1,11 +1,3 @@
-import Constants from "expo-constants";
-
-/** アナリティクスイベントAPIのパス */
-const ANALYTICS_EVENTS_PATH = "/analytics/events";
-
-/** APIリクエストのタイムアウト（ミリ秒） */
-const ANALYTICS_REQUEST_TIMEOUT_MS = 5000;
-
 /**
  * アナリティクスイベント名の定数
  */
@@ -28,63 +20,22 @@ export const AnalyticsEventName = {
 export type AnalyticsEventNameType = (typeof AnalyticsEventName)[keyof typeof AnalyticsEventName];
 
 /**
- * アナリティクスイベントのペイロード型
- */
-type AnalyticsPayload = {
-  event: AnalyticsEventNameType;
-  properties: Record<string, unknown>;
-  timestamp: number;
-};
-
-/**
- * APIのベースURLを取得する
+ * アナリティクスイベントを記録する
+ * バックエンドの /analytics/events エンドポイントが未実装のため、
+ * 現時点では何も送信しない。実装時に復元すること。
  *
- * @returns Workers APIのベースURL
- */
-function getBaseUrl(): string {
-  const extra = Constants.expoConfig?.extra;
-  if (extra && typeof extra === "object" && "apiUrl" in extra) {
-    return extra.apiUrl as string;
-  }
-  return "http://localhost:8787";
-}
-
-/**
- * アナリティクスイベントをAPIに送信する
- * ネットワークエラーやAPIエラーは静かに無視する（アナリティクスでアプリを止めない）
- *
- * @param event - イベント名
- * @param properties - イベントプロパティ
+ * @param _event - イベント名
+ * @param _properties - イベントプロパティ
  */
 export async function trackEvent(
-  event: AnalyticsEventNameType,
-  properties: Record<string, unknown>,
+  _event: AnalyticsEventNameType,
+  _properties: Record<string, unknown>,
 ): Promise<void> {
-  const payload: AnalyticsPayload = {
-    event,
-    properties,
-    timestamp: Date.now(),
-  };
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), ANALYTICS_REQUEST_TIMEOUT_MS);
-
-  try {
-    await fetch(`${getBaseUrl()}${ANALYTICS_EVENTS_PATH}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      signal: controller.signal,
-    });
-  } catch {
-    /* アナリティクスのエラーはアプリの動作に影響させない */
-  } finally {
-    clearTimeout(timeoutId);
-  }
+  /* TODO: バックエンドに /analytics/events ルートを実装したら送信処理を復元する */
 }
 
 /**
- * 画面表示イベントを送信する
+ * 画面表示イベントを記録する
  *
  * @param screen - 画面名
  */
@@ -93,7 +44,7 @@ export async function trackScreenView(screen: string): Promise<void> {
 }
 
 /**
- * 記事閲覧イベントを送信する
+ * 記事閲覧イベントを記録する
  *
  * @param articleId - 記事ID
  */
@@ -102,7 +53,7 @@ export async function trackArticleView(articleId: string): Promise<void> {
 }
 
 /**
- * 記事保存イベントを送信する
+ * 記事保存イベントを記録する
  *
  * @param articleId - 記事ID
  */
@@ -111,7 +62,7 @@ export async function trackArticleSave(articleId: string): Promise<void> {
 }
 
 /**
- * 記事シェアイベントを送信する
+ * 記事シェアイベントを記録する
  *
  * @param articleId - 記事ID
  */
@@ -120,7 +71,7 @@ export async function trackArticleShare(articleId: string): Promise<void> {
 }
 
 /**
- * AI要約リクエストイベントを送信する
+ * AI要約リクエストイベントを記録する
  *
  * @param articleId - 記事ID
  */
@@ -129,7 +80,7 @@ export async function trackAiSummaryRequest(articleId: string): Promise<void> {
 }
 
 /**
- * 検索イベントを送信する
+ * 検索イベントを記録する
  *
  * @param query - 検索クエリ
  */


### PR DESCRIPTION
## 概要

モバイルのanalytics clientが存在しないAPIエンドポイント `/analytics/events` にリクエストを送信していた問題を修正。バックエンドにルートが実装されるまで `trackEvent` をno-opにする。

## 変更内容

- `apps/mobile/src/lib/analytics.ts`: `trackEvent` をno-opに変更。`fetch` 呼び出し・`getBaseUrl`・`AnalyticsPayload` 型・未使用import（`expo-constants`）を削除。全エクスポートは維持し呼び出し元に影響なし。TODOコメントで復元箇所を明示
- `apps/mobile/src/lib/analytics.test.ts`: `fetch` が呼ばれないことを検証するテストに更新

## テスト

- [x] Unit テスト追加・更新済み
- [x] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（9 passed）
- [x] `pnpm biome check` がエラーなしで通ること

## 関連Issue

Closes #426