### PR TITLE
fix: use sign-up API for registration screen #424

### DIFF
--- a/apps/mobile/__tests__/screens/register.test.tsx
+++ b/apps/mobile/__tests__/screens/register.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import RegisterScreen from "../../app/(auth)/register";
+
+const mockSignUp = jest.fn();
+
+jest.mock("../../src/stores/auth-store", () => ({
+  useAuthStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      signUp: mockSignUp,
+    }),
+  ),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("RegisterScreen", () => {
+  describe("新規登録フォーム送信", () => {
+    it("有効な入力でsignUpが呼ばれること", async () => {
+      // Arrange
+      mockSignUp.mockResolvedValue(undefined);
+      const { getByDisplayValue, getByAccessibilityHint } = render(<RegisterScreen />);
+
+      fireEvent.changeText(getByAccessibilityHint("お名前を入力してください"), "テストユーザー");
+      fireEvent.changeText(getByAccessibilityHint("メールアドレスを入力してください"), "test@example.com");
+      fireEvent.changeText(getByAccessibilityHint("8文字以上のパスワードを入力してください"), "Password123");
+
+      // Act
+      fireEvent.press(getByAccessibilityHint("入力した情報で新規アカウントを作成します"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockSignUp).toHaveBeenCalledTimes(1);
+        expect(mockSignUp).toHaveBeenCalledWith({
+          name: "テストユーザー",
+          email: "test@example.com",
+          password: "Password123",
+        });
+      });
+    });
+
+    it("名前が空の場合signUpが呼ばれないこと", async () => {
+      // Arrange
+      const { getByAccessibilityHint } = render(<RegisterScreen />);
+
+      fireEvent.changeText(getByAccessibilityHint("メールアドレスを入力してください"), "test@example.com");
+      fireEvent.changeText(getByAccessibilityHint("8文字以上のパスワードを入力してください"), "Password123");
+
+      // Act
+      fireEvent.press(getByAccessibilityHint("入力した情報で新規アカウントを作成します"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockSignUp).not.toHaveBeenCalled();
+      });
+    });
+
+    it("メールが空の場合signUpが呼ばれないこと", async () => {
+      // Arrange
+      const { getByAccessibilityHint } = render(<RegisterScreen />);
+
+      fireEvent.changeText(getByAccessibilityHint("お名前を入力してください"), "テストユーザー");
+      fireEvent.changeText(getByAccessibilityHint("8文字以上のパスワードを入力してください"), "Password123");
+
+      // Act
+      fireEvent.press(getByAccessibilityHint("入力した情報で新規アカウントを作成します"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockSignUp).not.toHaveBeenCalled();
+      });
+    });
+
+    it("パスワードが空の場合signUpが呼ばれないこと", async () => {
+      // Arrange
+      const { getByAccessibilityHint } = render(<RegisterScreen />);
+
+      fireEvent.changeText(getByAccessibilityHint("お名前を入力してください"), "テストユーザー");
+      fireEvent.changeText(getByAccessibilityHint("メールアドレスを入力してください"), "test@example.com");
+
+      // Act
+      fireEvent.press(getByAccessibilityHint("入力した情報で新規アカウントを作成します"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockSignUp).not.toHaveBeenCalled();
+      });
+    });
+
+    it("signUpが失敗した場合エラーメッセージが表示されること", async () => {
+      // Arrange
+      mockSignUp.mockRejectedValue(new Error("メールアドレスはすでに使用されています"));
+      const { getByAccessibilityHint, findByText } = render(<RegisterScreen />);
+
+      fireEvent.changeText(getByAccessibilityHint("お名前を入力してください"), "テストユーザー");
+      fireEvent.changeText(getByAccessibilityHint("メールアドレスを入力してください"), "test@example.com");
+      fireEvent.changeText(getByAccessibilityHint("8文字以上のパスワードを入力してください"), "Password123");
+
+      // Act
+      fireEvent.press(getByAccessibilityHint("入力した情報で新規アカウントを作成します"));
+
+      // Assert
+      const errorText = await findByText("メールアドレスはすでに使用されています");
+      expect(errorText).toBeTruthy();
+    });
+  });
+});

--- a/apps/mobile/app/(auth)/register.tsx
+++ b/apps/mobile/app/(auth)/register.tsx
@@ -16,7 +16,7 @@ import { useAuthStore } from "../../src/stores/auth-store";
 
 export default function RegisterScreen() {
   const { t } = useTranslation();
-  const signIn = useAuthStore((s) => s.signIn);
+  const signUp = useAuthStore((s) => s.signUp);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -26,7 +26,6 @@ export default function RegisterScreen() {
 
   /**
    * 新規登録フォームを送信する
-   * Phase 0ではsignInを呼び出すプレースホルダー実装
    */
   async function handleRegister() {
     setErrorMessage("");
@@ -47,7 +46,7 @@ export default function RegisterScreen() {
     setIsSubmitting(true);
 
     try {
-      await signIn({ email: email.trim(), password });
+      await signUp({ name: name.trim(), email: email.trim(), password });
     } catch (error: unknown) {
       if (error instanceof Error) {
         setErrorMessage(error.message);

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -2,7 +2,15 @@ import { create } from "zustand";
 
 import { SessionExpiredError, apiFetch } from "@/lib/api";
 import { clearAuthTokens, getAuthToken, setAuthToken } from "@/lib/secure-store";
-import type { AuthErrorResponse, Session, SignInParams, SignInResponse, User } from "@/types/auth";
+import type {
+  AuthErrorResponse,
+  Session,
+  SignInParams,
+  SignInResponse,
+  SignUpParams,
+  SignUpResponse,
+  User,
+} from "@/types/auth";
 
 /** セッション期限切れメッセージ */
 const SESSION_EXPIRED_MESSAGE = "セッションの有効期限が切れました。再度ログインしてください";
@@ -15,6 +23,7 @@ type AuthStore = {
   /** セッション期限切れ時に表示するメッセージ。nullの場合は表示しない */
   sessionExpiredMessage: string | null;
   signIn: (params: SignInParams) => Promise<void>;
+  signUp: (params: SignUpParams) => Promise<void>;
   signOut: () => Promise<void>;
   checkSession: () => Promise<void>;
   /** セッション期限切れを処理する。トークンをクリアしてログイン画面へ誘導する */
@@ -41,6 +50,31 @@ export const useAuthStore = create<AuthStore>((set) => ({
    */
   signIn: async (params: SignInParams) => {
     const data = await apiFetch<SignInResponse | AuthErrorResponse>("/api/auth/sign-in", {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+
+    if (!data.success) {
+      throw new Error(data.error.message);
+    }
+
+    await setAuthToken(data.data.session.token);
+
+    set({
+      user: data.data.user,
+      session: data.data.session,
+      isAuthenticated: true,
+    });
+  },
+
+  /**
+   * メール・パスワード・名前で新規アカウントを作成してサインインする
+   *
+   * @param params - 名前、メールアドレス、パスワード
+   * @throws Error - 登録失敗時
+   */
+  signUp: async (params: SignUpParams) => {
+    const data = await apiFetch<SignUpResponse | AuthErrorResponse>("/api/auth/sign-up/email", {
       method: "POST",
       body: JSON.stringify(params),
     });

--- a/apps/mobile/src/types/auth.ts
+++ b/apps/mobile/src/types/auth.ts
@@ -32,6 +32,20 @@ export type SignInResponse = {
   };
 };
 
+export type SignUpParams = {
+  name: string;
+  email: string;
+  password: string;
+};
+
+export type SignUpResponse = {
+  success: true;
+  data: {
+    user: User;
+    session: Session;
+  };
+};
+
 export type AuthErrorResponse = {
   success: false;
   error: {


### PR DESCRIPTION
## 概要
登録画面でサインアップAPIを呼ぶよう修正

## 変更内容
- register.tsx: signIn → signUp API呼び出しに変更
- auth-store.ts: signUp関数を追加
- auth.ts: SignUpResponse型を追加

Closes #424