### PR TITLE
fix: save refresh token on sign-in to enable token refresh flow #433

### DIFF
--- a/apps/mobile/src/stores/auth-store.test.ts
+++ b/apps/mobile/src/stores/auth-store.test.ts
@@ -11,17 +11,19 @@ jest.mock("@/lib/api", () => ({
 jest.mock("@/lib/secure-store", () => ({
   getAuthToken: jest.fn(),
   setAuthToken: jest.fn(),
+  setRefreshToken: jest.fn(),
   clearAuthTokens: jest.fn(),
 }));
 
 import { SessionExpiredError, apiFetch } from "@/lib/api";
-import { clearAuthTokens, getAuthToken, setAuthToken } from "@/lib/secure-store";
+import { clearAuthTokens, getAuthToken, setAuthToken, setRefreshToken } from "@/lib/secure-store";
 import { useAuthStore } from "./auth-store";
 
 /** モック型キャスト */
 const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
 const mockGetAuthToken = getAuthToken as jest.MockedFunction<typeof getAuthToken>;
 const mockSetAuthToken = setAuthToken as jest.MockedFunction<typeof setAuthToken>;
+const mockSetRefreshToken = setRefreshToken as jest.MockedFunction<typeof setRefreshToken>;
 const mockClearAuthTokens = clearAuthTokens as jest.MockedFunction<typeof clearAuthTokens>;
 
 /** テスト用ユーザーデータ */
@@ -51,6 +53,7 @@ describe("useAuthStore", () => {
       sessionExpiredMessage: null,
     });
     mockSetAuthToken.mockResolvedValue(undefined);
+    mockSetRefreshToken.mockResolvedValue(undefined);
     mockClearAuthTokens.mockResolvedValue(undefined);
   });
 
@@ -71,6 +74,21 @@ describe("useAuthStore", () => {
       expect(state.user).toEqual(TEST_USER);
       expect(state.session).toEqual(TEST_SESSION);
       expect(mockSetAuthToken).toHaveBeenCalledWith(TEST_SESSION.token);
+      expect(mockSetRefreshToken).toHaveBeenCalledWith(TEST_SESSION.token);
+    });
+
+    it("サインイン成功時にリフレッシュトークンを保存すること", async () => {
+      // Arrange
+      mockApiFetch.mockResolvedValue({
+        success: true,
+        data: { user: TEST_USER, session: TEST_SESSION },
+      });
+
+      // Act
+      await useAuthStore.getState().signIn({ email: "test@example.com", password: "Password123" });
+
+      // Assert
+      expect(mockSetRefreshToken).toHaveBeenCalledWith(TEST_SESSION.token);
     });
 
     it("認証失敗時にエラーをスローすること", async () => {

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -1,16 +1,8 @@
 import { create } from "zustand";
 
 import { SessionExpiredError, apiFetch } from "@/lib/api";
-import { clearAuthTokens, getAuthToken, setAuthToken } from "@/lib/secure-store";
-import type {
-  AuthErrorResponse,
-  Session,
-  SignInParams,
-  SignInResponse,
-  SignUpParams,
-  SignUpResponse,
-  User,
-} from "@/types/auth";
+import { clearAuthTokens, getAuthToken, setAuthToken, setRefreshToken } from "@/lib/secure-store";
+import type { AuthErrorResponse, Session, SignInParams, SignInResponse, User } from "@/types/auth";
 
 /** セッション期限切れメッセージ */
 const SESSION_EXPIRED_MESSAGE = "セッションの有効期限が切れました。再度ログインしてください";
@@ -59,6 +51,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
     }
 
     await setAuthToken(data.data.session.token);
+    await setRefreshToken(data.data.session.token);
 
     set({
       user: data.data.user,


### PR DESCRIPTION
## 概要
サインイン時にリフレッシュトークンをSecure Storeに保存し、トークンリフレッシュフローを機能させる

## 変更内容
- auth-store.ts: signIn成功後にsetRefreshTokenを呼び出す
- セッション期限切れ時のリフレッシュフローが正常に動作するよう修正

Closes #433