### PR TITLE
feat: configure real-device API base URL via EXPO_PUBLIC_API_URL #432

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -19,3 +19,12 @@
 
 EXPO_PUBLIC_REVENUECAT_IOS_API_KEY=your-revenuecat-ios-api-key
 EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY=your-revenuecat-android-api-key
+
+# -----------------------------------------------------------------------------
+# API サーバー URL
+# -----------------------------------------------------------------------------
+# 実機・本番ビルド時は本番 API の URL を設定する
+# ローカル開発時は省略可（デフォルト: http://localhost:8787）
+# 例: https://api.techclip.app
+
+EXPO_PUBLIC_API_URL=https://api.techclip.app

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,0 +1,13 @@
+// @ts-check
+const baseConfig = require("./app.json");
+
+/** @type {import('expo/config').ExpoConfig} */
+const config = {
+  ...baseConfig.expo,
+  extra: {
+    ...baseConfig.expo.extra,
+    apiUrl: process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8787",
+  },
+};
+
+module.exports = { expo: config };

--- a/apps/mobile/src/lib/api.test.ts
+++ b/apps/mobile/src/lib/api.test.ts
@@ -1,3 +1,5 @@
+import Constants from "expo-constants";
+
 jest.mock("expo-constants", () => ({
   __esModule: true,
   default: {
@@ -177,6 +179,48 @@ describe("apiFetch", () => {
       expect(error).toBeInstanceOf(Error);
       expect(error).toBeInstanceOf(SessionExpiredError);
       expect(error.message).toBe("セッションの有効期限が切れました。再度ログインしてください");
+    });
+  });
+
+  describe("getBaseUrl", () => {
+    it("extra.apiUrlが設定されている場合はその値をベースURLとして使用すること", async () => {
+      // Arrange（モックは上部でhttp://test-api.example.comを返すよう設定済み）
+      mockGetAuthToken.mockResolvedValue(null);
+      mockFetch.mockResolvedValue(createFetchResponse({ success: true, data: [] }));
+
+      // Act
+      await apiFetch("/test");
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://test-api.example.com/test",
+        expect.any(Object),
+      );
+    });
+
+    it("extra.apiUrlが未設定の場合はlocalhost:8787をフォールバックとして使用すること", async () => {
+      // Arrange
+      const originalConfig = Constants.expoConfig;
+      Object.defineProperty(Constants, "expoConfig", {
+        value: { extra: {} },
+        writable: true,
+        configurable: true,
+      });
+      mockGetAuthToken.mockResolvedValue(null);
+      mockFetch.mockResolvedValue(createFetchResponse({ success: true, data: [] }));
+
+      // Act
+      await apiFetch("/test");
+
+      // Assert
+      expect(mockFetch).toHaveBeenCalledWith("http://localhost:8787/test", expect.any(Object));
+
+      // Cleanup
+      Object.defineProperty(Constants, "expoConfig", {
+        value: originalConfig,
+        writable: true,
+        configurable: true,
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

実機でAPIに到達できない問題を修正。`EXPO_PUBLIC_API_URL` 環境変数から本番API URLを設定できるようにした。

## 変更内容

- `apps/mobile/app.config.js` を新規作成。`EXPO_PUBLIC_API_URL` 環境変数を読み込み `Constants.expoConfig.extra.apiUrl` に注入する（既存の `getBaseUrl()` はすでにこのパスを読む実装済み）
- 環境変数未設定時は `http://localhost:8787` にフォールバック
- `apps/mobile/.env.example` に `EXPO_PUBLIC_API_URL` を追加（例: `https://api.techclip.app`）
- `apps/mobile/src/lib/api.test.ts` に `getBaseUrl()` の正常系・フォールバック両パスのテストを追加

## テスト

- [x] Unit テスト追加・更新済み
- [x] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（10 tests passed）
- [x] `pnpm lint` がエラーなしで通ること

## 関連Issue

Closes #432