### PR TITLE
docs: document all production secrets and add setup checklist #452

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -18,11 +18,28 @@ id = "d8dd77ff2e0a4ee69e0d780657b02473"
 binding = "AVATARS_BUCKET"
 bucket_name = "tech-clip-avatars"
 
-# [secrets]
-# TURSO_DATABASE_URL
-# TURSO_AUTH_TOKEN
-# RUNPOD_API_KEY
-# RUNPOD_ENDPOINT_ID
+# 本番/ステージング環境では以下の secrets を wrangler secret put で設定すること
+# （.dev.vars はローカル開発専用。本番には使用しない）
+#
+# 必須 secrets 一覧:
+#   TURSO_DATABASE_URL         - Turso libSQL データベース接続 URL
+#   TURSO_AUTH_TOKEN           - Turso 認証トークン
+#   BETTER_AUTH_SECRET         - Better Auth セッション署名キー（32文字以上）
+#   GOOGLE_CLIENT_ID           - Google OAuth クライアント ID
+#   GOOGLE_CLIENT_SECRET       - Google OAuth クライアントシークレット
+#   APPLE_CLIENT_ID            - Apple Sign In サービス ID
+#   APPLE_CLIENT_SECRET        - Apple Sign In JWT（6ヶ月ごとに更新）
+#   GITHUB_CLIENT_ID           - GitHub OAuth クライアント ID
+#   GITHUB_CLIENT_SECRET       - GitHub OAuth クライアントシークレット
+#   RUNPOD_API_KEY             - RunPod API キー（AI 推論）
+#   RUNPOD_ENDPOINT_ID         - RunPod サーバーレスエンドポイント ID
+#   REVENUECAT_WEBHOOK_SECRET  - RevenueCat Webhook 署名検証シークレット
+#   RESEND_API_KEY             - Resend メール送信 API キー
+#
+# 設定コマンド例（本番環境）:
+#   wrangler secret put TURSO_DATABASE_URL --env production
+#
+# 詳細手順: docs/SECRETS.md を参照
 
 [triggers]
 crons = ["0 0 1 * *"]

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -17,6 +17,8 @@
 | `GITHUB_CLIENT_SECRET` | API (Cloudflare Workers) | `apps/api/.dev.vars` |
 | `RUNPOD_API_KEY` | API (Cloudflare Workers) | `apps/api/.dev.vars` |
 | `RUNPOD_ENDPOINT_ID` | API (Cloudflare Workers) | `apps/api/.dev.vars` |
+| `REVENUECAT_WEBHOOK_SECRET` | API (Cloudflare Workers) | `apps/api/.dev.vars` |
+| `RESEND_API_KEY` | API (Cloudflare Workers) | `apps/api/.dev.vars` |
 | `EXPO_PUBLIC_REVENUECAT_IOS_API_KEY` | モバイル (Expo) | `apps/mobile/.env` |
 | `EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY` | モバイル (Expo) | `apps/mobile/.env` |
 
@@ -188,6 +190,39 @@ console.log(header + '.' + payload + '.' + signature);
 
 ---
 
+### REVENUECAT_WEBHOOK_SECRET
+
+**ダッシュボード:** https://app.revenuecat.com
+
+1. プロジェクトを選択する
+2. 左メニューの "Integrations" > "Webhooks" を開く
+3. "Add Webhook" から新しい Webhook を追加する
+4. Webhook URL に `https://api.techclip.app/api/webhooks/revenuecat` を設定する
+5. "Shared Secret" フィールドに表示されるシークレットを `REVENUECAT_WEBHOOK_SECRET` に設定する
+
+> **注意:** Webhook Secret はペイロードの署名検証に使用します。ステージングと本番で別々の Webhook を作成し、それぞれ異なるシークレットを使用してください。
+
+---
+
+### RESEND_API_KEY
+
+**ダッシュボード:** https://resend.com
+
+1. アカウント作成またはログインする
+2. 左メニューの "API Keys" を開く
+3. "Create API Key" をクリックし、名前（例: `tech-clip-production`）を入力する
+4. 権限は "Full Access" または "Sending Access" を選択する
+5. 発行された API キーを `RESEND_API_KEY` に設定する
+
+**ドメイン認証（本番環境で必須）:**
+
+1. 左メニューの "Domains" を開く
+2. "Add Domain" から `techclip.app` を追加する
+3. 表示された DNS レコード（MX, SPF, DKIM）をドメインプロバイダーに設定する
+4. 認証完了後、このドメインからメール送信が可能になる
+
+---
+
 ### EXPO_PUBLIC_REVENUECAT_IOS_API_KEY / EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY
 
 **ダッシュボード:** https://app.revenuecat.com
@@ -207,25 +242,93 @@ console.log(header + '.' + payload + '.' + signature);
 
 ローカル開発では `.dev.vars` を使用しますが、本番環境では Cloudflare Workers の Secrets 機能を使います。
 
-```bash
-# Cloudflare Workers にシークレットを設定する
-wrangler secret put TURSO_DATABASE_URL
-wrangler secret put TURSO_AUTH_TOKEN
-wrangler secret put BETTER_AUTH_SECRET
-wrangler secret put GOOGLE_CLIENT_ID
-wrangler secret put GOOGLE_CLIENT_SECRET
-wrangler secret put APPLE_CLIENT_ID
-wrangler secret put APPLE_CLIENT_SECRET
-wrangler secret put GITHUB_CLIENT_ID
-wrangler secret put GITHUB_CLIENT_SECRET
-wrangler secret put RUNPOD_API_KEY
-wrangler secret put RUNPOD_ENDPOINT_ID
+### ステージング環境
 
-# ステージング環境に設定する場合
+```bash
 wrangler secret put TURSO_DATABASE_URL --env staging
+wrangler secret put TURSO_AUTH_TOKEN --env staging
+wrangler secret put BETTER_AUTH_SECRET --env staging
+wrangler secret put GOOGLE_CLIENT_ID --env staging
+wrangler secret put GOOGLE_CLIENT_SECRET --env staging
+wrangler secret put APPLE_CLIENT_ID --env staging
+wrangler secret put APPLE_CLIENT_SECRET --env staging
+wrangler secret put GITHUB_CLIENT_ID --env staging
+wrangler secret put GITHUB_CLIENT_SECRET --env staging
+wrangler secret put RUNPOD_API_KEY --env staging
+wrangler secret put RUNPOD_ENDPOINT_ID --env staging
+wrangler secret put REVENUECAT_WEBHOOK_SECRET --env staging
+wrangler secret put RESEND_API_KEY --env staging
+```
+
+### 本番環境
+
+```bash
+wrangler secret put TURSO_DATABASE_URL --env production
+wrangler secret put TURSO_AUTH_TOKEN --env production
+wrangler secret put BETTER_AUTH_SECRET --env production
+wrangler secret put GOOGLE_CLIENT_ID --env production
+wrangler secret put GOOGLE_CLIENT_SECRET --env production
+wrangler secret put APPLE_CLIENT_ID --env production
+wrangler secret put APPLE_CLIENT_SECRET --env production
+wrangler secret put GITHUB_CLIENT_ID --env production
+wrangler secret put GITHUB_CLIENT_SECRET --env production
+wrangler secret put RUNPOD_API_KEY --env production
+wrangler secret put RUNPOD_ENDPOINT_ID --env production
+wrangler secret put REVENUECAT_WEBHOOK_SECRET --env production
+wrangler secret put RESEND_API_KEY --env production
 ```
 
 各コマンド実行後にプロンプトが表示されるので、値を入力してください。
+
+### 設定確認
+
+設定済みの secrets 一覧を確認するには:
+
+```bash
+# ステージング環境の確認
+wrangler secret list --env staging
+
+# 本番環境の確認
+wrangler secret list --env production
+```
+
+### 本番環境セットアップチェックリスト
+
+リリース前に以下を確認してください。
+
+#### Turso DB
+- [ ] 本番用 Turso データベースを作成済み（ステージングと別インスタンス）
+- [ ] `TURSO_DATABASE_URL` を本番用 URL に設定済み
+- [ ] `TURSO_AUTH_TOKEN` を本番用トークンに設定済み
+- [ ] 本番 DB へのマイグレーション適用済み (`pnpm drizzle-kit migrate`)
+
+#### Better Auth
+- [ ] `BETTER_AUTH_SECRET` に32文字以上のランダム文字列を設定済み
+- [ ] ステージングと本番で異なる値を使用している
+
+#### OAuth プロバイダー
+- [ ] Google: 本番用リダイレクト URI を Google Cloud Console に登録済み
+- [ ] Apple: 本番ドメイン (`api.techclip.app`) を Apple Developer に登録済み
+- [ ] Apple: `APPLE_CLIENT_SECRET` (JWT) の有効期限を確認済み（最大6ヶ月）
+- [ ] GitHub: 本番用コールバック URL を GitHub OAuth App に登録済み
+
+#### RunPod
+- [ ] 本番用 RunPod エンドポイントが起動・稼働中であることを確認済み
+- [ ] `RUNPOD_ENDPOINT_ID` が本番エンドポイントの ID であることを確認済み
+- [ ] エンドポイントのスケーリング設定が本番トラフィックに対応していることを確認済み
+
+#### RevenueCat
+- [ ] `REVENUECAT_WEBHOOK_SECRET` を RevenueCat ダッシュボードで発行済み
+- [ ] Webhook URL に `https://api.techclip.app/api/webhooks/revenuecat` を設定済み
+
+#### Resend
+- [ ] 本番用 Resend API キーを発行済み
+- [ ] 送信元ドメイン (`techclip.app`) を Resend で認証済み
+- [ ] `RESEND_API_KEY` を本番用キーに設定済み
+
+#### 最終確認
+- [ ] `wrangler secret list --env production` で全 secrets が揃っていることを確認済み
+- [ ] 本番デプロイ後に認証フローが正常に動作することを確認済み
 
 ---
 


### PR DESCRIPTION
## 概要

本番環境の Cloudflare Workers secrets 設定が未文書化だった問題を解消。wrangler.toml のコメントと docs/SECRETS.md に必要な全 secrets と本番セットアップ手順を追記した。

## 変更内容

- `apps/api/wrangler.toml`: secrets コメントを全13件の必須 secrets を明記した内容に更新（設定コマンド例・参照先も追記）
- `docs/SECRETS.md`: 概要テーブルに `REVENUECAT_WEBHOOK_SECRET` / `RESEND_API_KEY` を追加
- `docs/SECRETS.md`: ステージング・本番環境それぞれの `wrangler secret put --env` コマンド一覧を追加
- `docs/SECRETS.md`: `REVENUECAT_WEBHOOK_SECRET` / `RESEND_API_KEY` の取得手順を新規追加
- `docs/SECRETS.md`: 本番環境セットアップチェックリストを追加（Turso/BetterAuth/OAuth/RunPod/RevenueCat/Resend）

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [ ] `pnpm test` がすべてパスすること
- [ ] `pnpm lint` がエラーなしで通ること

> ドキュメント変更のみのため TDD 対象外。

## 関連Issue

Closes #452