### PR TITLE
fix: persist settings toggles to API and AsyncStorage #427

### DIFF
--- a/apps/mobile/__tests__/screens/settings.test.tsx
+++ b/apps/mobile/__tests__/screens/settings.test.tsx
@@ -7,6 +7,10 @@ import SettingsScreen from "../../app/(tabs)/settings";
 
 const mockSignOut = jest.fn();
 const mockDeleteAccount = jest.fn();
+const mockSetLanguage = jest.fn();
+const mockLoadLanguage = jest.fn().mockResolvedValue(undefined);
+const mockFetchNotificationSettings = jest.fn().mockResolvedValue(undefined);
+const mockUpdateNotificationEnabled = jest.fn().mockResolvedValue(undefined);
 
 jest.mock("../../src/stores/auth-store", () => ({
   useAuthStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
@@ -18,10 +22,36 @@ jest.mock("../../src/stores/auth-store", () => ({
   ),
 }));
 
+jest.mock("../../src/stores/settings-store", () => ({
+  useSettingsStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      language: "日本語",
+      isLanguageLoaded: true,
+      notificationSettings: {
+        id: "ns_01",
+        newArticle: true,
+        aiComplete: true,
+        follow: true,
+        system: true,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+      isNotificationSettingsLoaded: true,
+      setLanguage: mockSetLanguage,
+      loadLanguage: mockLoadLanguage,
+      fetchNotificationSettings: mockFetchNotificationSettings,
+      updateNotificationEnabled: mockUpdateNotificationEnabled,
+    }),
+  ),
+}));
+
 jest.spyOn(Alert, "alert");
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockLoadLanguage.mockResolvedValue(undefined);
+  mockFetchNotificationSettings.mockResolvedValue(undefined);
+  mockUpdateNotificationEnabled.mockResolvedValue(undefined);
 });
 
 describe("SettingsScreen", () => {
@@ -146,5 +176,75 @@ describe("SettingsScreen", () => {
       const confirmButton = buttons.find((b: { style: string }) => b.style === "destructive");
       expect(confirmButton).toBeDefined();
     });
+  });
+});
+
+describe("言語設定の永続化", () => {
+  it("画面表示時にloadLanguageが呼ばれること", () => {
+    // Arrange & Act
+    render(<SettingsScreen />);
+
+    // Assert
+    expect(mockLoadLanguage).toHaveBeenCalledTimes(1);
+  });
+
+  it("言語選択ダイアログで日本語を選択するとsetLanguageが呼ばれること", () => {
+    // Arrange
+    const { UNSAFE_root } = render(<SettingsScreen />);
+    fireEvent.press(findByTestId(UNSAFE_root, "settings-language-button"));
+
+    // Act
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    const jaButton = buttons.find((b: { text: string }) => b.text === "日本語");
+    jaButton.onPress();
+
+    // Assert
+    expect(mockSetLanguage).toHaveBeenCalledWith("日本語");
+  });
+
+  it("言語選択ダイアログでEnglishを選択するとsetLanguageが呼ばれること", () => {
+    // Arrange
+    const { UNSAFE_root } = render(<SettingsScreen />);
+    fireEvent.press(findByTestId(UNSAFE_root, "settings-language-button"));
+
+    // Act
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    const enButton = buttons.find((b: { text: string }) => b.text === "English");
+    enButton.onPress();
+
+    // Assert
+    expect(mockSetLanguage).toHaveBeenCalledWith("English");
+  });
+});
+
+describe("通知設定の永続化", () => {
+  it("画面表示時にfetchNotificationSettingsが呼ばれること", () => {
+    // Arrange & Act
+    render(<SettingsScreen />);
+
+    // Assert
+    expect(mockFetchNotificationSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("通知スイッチをOFFにするとupdateNotificationEnabledが呼ばれること", () => {
+    // Arrange
+    const { UNSAFE_root } = render(<SettingsScreen />);
+
+    // Act
+    fireEvent(findByTestId(UNSAFE_root, "settings-notification-switch"), "valueChange", false);
+
+    // Assert
+    expect(mockUpdateNotificationEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("通知スイッチをONにするとupdateNotificationEnabledが呼ばれること", () => {
+    // Arrange
+    const { UNSAFE_root } = render(<SettingsScreen />);
+
+    // Act
+    fireEvent(findByTestId(UNSAFE_root, "settings-notification-switch"), "valueChange", true);
+
+    // Assert
+    expect(mockUpdateNotificationEnabled).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -9,12 +9,13 @@ import {
   User,
 } from "lucide-react-native";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useEffect } from "react";
 import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
 
 import { confirm } from "@/components/ConfirmDialog";
 import { useRouter } from "expo-router";
 import { useAuthStore } from "../../src/stores/auth-store";
+import { useSettingsStore } from "../../src/stores/settings-store";
 
 /** 設定セクションの区切り線コンポーネント */
 function SectionDivider() {
@@ -82,12 +83,6 @@ function SettingsRow({ icon, label, value, onPress, trailing, testID }: Settings
   return content;
 }
 
-/** 言語選択肢 */
-const LANGUAGE_OPTIONS = ["日本語", "English"] as const;
-
-/** 言語選択肢の型 */
-type Language = (typeof LANGUAGE_OPTIONS)[number];
-
 /**
  * 設定画面
  *
@@ -99,8 +94,26 @@ export default function SettingsScreen() {
   const deleteAccount = useAuthStore((s) => s.deleteAccount);
   const user = useAuthStore((s) => s.user);
 
-  const [isNotificationsEnabled, setIsNotificationsEnabled] = useState(true);
-  const [selectedLanguage, setSelectedLanguage] = useState<Language>("日本語");
+  const language = useSettingsStore((s) => s.language);
+  const setLanguage = useSettingsStore((s) => s.setLanguage);
+  const loadLanguage = useSettingsStore((s) => s.loadLanguage);
+  const notificationSettings = useSettingsStore((s) => s.notificationSettings);
+  const fetchNotificationSettings = useSettingsStore((s) => s.fetchNotificationSettings);
+  const updateNotificationEnabled = useSettingsStore((s) => s.updateNotificationEnabled);
+
+  /** 通知が有効かどうか（全通知がONの場合にtrue） */
+  const isNotificationsEnabled =
+    notificationSettings !== null
+      ? notificationSettings.newArticle &&
+        notificationSettings.aiComplete &&
+        notificationSettings.follow &&
+        notificationSettings.system
+      : true;
+
+  useEffect(() => {
+    loadLanguage();
+    fetchNotificationSettings();
+  }, [loadLanguage, fetchNotificationSettings]);
 
   /**
    * ログアウト確認ダイアログを表示し、確認後にサインアウトを実行する
@@ -144,14 +157,29 @@ export default function SettingsScreen() {
     Alert.alert("言語設定", "表示言語を選択してください", [
       {
         text: "日本語",
-        onPress: () => setSelectedLanguage("日本語"),
+        onPress: () => {
+          setLanguage("日本語");
+        },
       },
       {
         text: "English",
-        onPress: () => setSelectedLanguage("English"),
+        onPress: () => {
+          setLanguage("English");
+        },
       },
       { text: "キャンセル", style: "cancel" },
     ]);
+  }
+
+  /**
+   * 通知トグルの変更を処理する
+   *
+   * @param enabled - trueで全通知ON、falseで全通知OFF
+   */
+  function handleNotificationToggle(enabled: boolean) {
+    updateNotificationEnabled(enabled).catch(() => {
+      Alert.alert("エラー", "通知設定の更新に失敗しました。もう一度お試しください。");
+    });
   }
 
   return (
@@ -192,9 +220,10 @@ export default function SettingsScreen() {
       <SectionTitle title="一般" />
       <View className="bg-surface mx-4 rounded-xl border border-border">
         <SettingsRow
+          testID="settings-language-button"
           icon={<Globe size={ICON_SIZE} color={ICON_COLOR} />}
           label="言語"
-          value={selectedLanguage}
+          value={language}
           onPress={handleLanguageSelect}
         />
         <SectionDivider />
@@ -203,8 +232,9 @@ export default function SettingsScreen() {
           label="通知"
           trailing={
             <Switch
+              testID="settings-notification-switch"
               value={isNotificationsEnabled}
-              onValueChange={setIsNotificationsEnabled}
+              onValueChange={handleNotificationToggle}
               trackColor={{ false: "#2d2d44", true: "#6366f1" }}
               thumbColor="#ffffff"
               accessibilityLabel="通知"

--- a/apps/mobile/src/stores/index.ts
+++ b/apps/mobile/src/stores/index.ts
@@ -1,3 +1,4 @@
 export { useAuthStore } from "./auth-store";
+export { useSettingsStore } from "./settings-store";
 export { useSubscriptionStore } from "./subscription-store";
 export { useUIStore } from "./ui-store";

--- a/apps/mobile/src/stores/settings-store.test.ts
+++ b/apps/mobile/src/stores/settings-store.test.ts
@@ -1,0 +1,212 @@
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  apiFetch: jest.fn(),
+}));
+
+import * as SecureStore from "expo-secure-store";
+import { apiFetch } from "@/lib/api";
+import { useSettingsStore } from "./settings-store";
+
+/** モック型キャスト */
+const mockGetItemAsync = SecureStore.getItemAsync as jest.MockedFunction<
+  typeof SecureStore.getItemAsync
+>;
+const mockSetItemAsync = SecureStore.setItemAsync as jest.MockedFunction<
+  typeof SecureStore.setItemAsync
+>;
+const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
+
+/** テスト用通知設定データ */
+const TEST_NOTIFICATION_SETTINGS = {
+  id: "ns_01HXYZ",
+  newArticle: true,
+  aiComplete: true,
+  follow: true,
+  system: true,
+  createdAt: "2024-01-15T00:00:00Z",
+  updatedAt: "2024-01-15T00:00:00Z",
+};
+
+describe("useSettingsStore", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSettingsStore.setState({
+      language: "日本語",
+      isLanguageLoaded: false,
+      notificationSettings: null,
+      isNotificationSettingsLoaded: false,
+    });
+    mockSetItemAsync.mockResolvedValue(undefined);
+  });
+
+  describe("言語設定", () => {
+    describe("loadLanguage", () => {
+      it("保存済みの言語設定を読み込めること", async () => {
+        // Arrange
+        mockGetItemAsync.mockResolvedValue('"English"');
+
+        // Act
+        await useSettingsStore.getState().loadLanguage();
+
+        // Assert
+        const state = useSettingsStore.getState();
+        expect(state.language).toBe("English");
+        expect(state.isLanguageLoaded).toBe(true);
+      });
+
+      it("保存済みの言語設定がない場合はデフォルト値（日本語）になること", async () => {
+        // Arrange
+        mockGetItemAsync.mockResolvedValue(null);
+
+        // Act
+        await useSettingsStore.getState().loadLanguage();
+
+        // Assert
+        const state = useSettingsStore.getState();
+        expect(state.language).toBe("日本語");
+        expect(state.isLanguageLoaded).toBe(true);
+      });
+    });
+
+    describe("setLanguage", () => {
+      it("言語設定を変更してSecureStoreに永続化できること", async () => {
+        // Arrange
+        const newLanguage = "English" as const;
+
+        // Act
+        await useSettingsStore.getState().setLanguage(newLanguage);
+
+        // Assert
+        expect(useSettingsStore.getState().language).toBe("English");
+        expect(mockSetItemAsync).toHaveBeenCalledWith(
+          "settings_language",
+          JSON.stringify("English"),
+        );
+      });
+
+      it("日本語に変更してSecureStoreに永続化できること", async () => {
+        // Arrange
+        useSettingsStore.setState({ language: "English" });
+
+        // Act
+        await useSettingsStore.getState().setLanguage("日本語");
+
+        // Assert
+        expect(useSettingsStore.getState().language).toBe("日本語");
+        expect(mockSetItemAsync).toHaveBeenCalledWith(
+          "settings_language",
+          JSON.stringify("日本語"),
+        );
+      });
+    });
+  });
+
+  describe("通知設定", () => {
+    describe("fetchNotificationSettings", () => {
+      it("APIから通知設定を取得できること", async () => {
+        // Arrange
+        mockApiFetch.mockResolvedValue({
+          success: true,
+          data: TEST_NOTIFICATION_SETTINGS,
+        });
+
+        // Act
+        await useSettingsStore.getState().fetchNotificationSettings();
+
+        // Assert
+        const state = useSettingsStore.getState();
+        expect(state.notificationSettings).toEqual(TEST_NOTIFICATION_SETTINGS);
+        expect(state.isNotificationSettingsLoaded).toBe(true);
+      });
+
+      it("APIが失敗した場合でもisNotificationSettingsLoadedがtrueになること", async () => {
+        // Arrange
+        mockApiFetch.mockRejectedValue(new Error("ネットワークエラー"));
+
+        // Act
+        await useSettingsStore.getState().fetchNotificationSettings();
+
+        // Assert
+        expect(useSettingsStore.getState().isNotificationSettingsLoaded).toBe(true);
+      });
+    });
+
+    describe("updateNotificationEnabled", () => {
+      it("通知をOFFにしてAPIに保存できること", async () => {
+        // Arrange
+        useSettingsStore.setState({ notificationSettings: TEST_NOTIFICATION_SETTINGS });
+        mockApiFetch.mockResolvedValue({
+          success: true,
+          data: { ...TEST_NOTIFICATION_SETTINGS, newArticle: false },
+        });
+
+        // Act
+        await useSettingsStore.getState().updateNotificationEnabled(false);
+
+        // Assert
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          "/api/users/me/notification-settings",
+          expect.objectContaining({
+            method: "PATCH",
+            body: JSON.stringify({
+              newArticle: false,
+              aiComplete: false,
+              follow: false,
+              system: false,
+            }),
+          }),
+        );
+        expect(useSettingsStore.getState().notificationSettings?.newArticle).toBe(false);
+      });
+
+      it("通知をONにしてAPIに保存できること", async () => {
+        // Arrange
+        const offSettings = {
+          ...TEST_NOTIFICATION_SETTINGS,
+          newArticle: false,
+          aiComplete: false,
+          follow: false,
+          system: false,
+        };
+        useSettingsStore.setState({ notificationSettings: offSettings });
+        mockApiFetch.mockResolvedValue({
+          success: true,
+          data: { ...TEST_NOTIFICATION_SETTINGS },
+        });
+
+        // Act
+        await useSettingsStore.getState().updateNotificationEnabled(true);
+
+        // Assert
+        expect(mockApiFetch).toHaveBeenCalledWith(
+          "/api/users/me/notification-settings",
+          expect.objectContaining({
+            method: "PATCH",
+            body: JSON.stringify({
+              newArticle: true,
+              aiComplete: true,
+              follow: true,
+              system: true,
+            }),
+          }),
+        );
+      });
+
+      it("API失敗時にローカルの楽観的更新がロールバックされること", async () => {
+        // Arrange
+        useSettingsStore.setState({ notificationSettings: TEST_NOTIFICATION_SETTINGS });
+        mockApiFetch.mockRejectedValue(new Error("ネットワークエラー"));
+
+        // Act & Assert
+        await expect(
+          useSettingsStore.getState().updateNotificationEnabled(false),
+        ).rejects.toThrow("通知設定の更新に失敗しました");
+        expect(useSettingsStore.getState().notificationSettings?.newArticle).toBe(true);
+      });
+    });
+  });
+});

--- a/apps/mobile/src/stores/settings-store.ts
+++ b/apps/mobile/src/stores/settings-store.ts
@@ -1,0 +1,123 @@
+import * as SecureStore from "expo-secure-store";
+import { create } from "zustand";
+
+import { apiFetch } from "@/lib/api";
+
+/** SecureStoreキー: 言語設定 */
+const LANGUAGE_KEY = "settings_language";
+
+/** 言語選択肢 */
+const LANGUAGE_OPTIONS = ["日本語", "English"] as const;
+
+/** 言語選択肢の型 */
+export type Language = (typeof LANGUAGE_OPTIONS)[number];
+
+/** 通知設定の型 */
+export type NotificationSettings = {
+  id: string;
+  newArticle: boolean;
+  aiComplete: boolean;
+  follow: boolean;
+  system: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/** 通知設定APIレスポンスの型 */
+type NotificationSettingsResponse = {
+  success: true;
+  data: NotificationSettings;
+};
+
+type SettingsStore = {
+  /** 表示言語 */
+  language: Language;
+  /** 言語設定の読み込み完了フラグ */
+  isLanguageLoaded: boolean;
+  /** 通知設定 */
+  notificationSettings: NotificationSettings | null;
+  /** 通知設定の読み込み完了フラグ */
+  isNotificationSettingsLoaded: boolean;
+  /** SecureStoreから言語設定を読み込む */
+  loadLanguage: () => Promise<void>;
+  /** 言語設定を変更してSecureStoreに永続化する */
+  setLanguage: (language: Language) => Promise<void>;
+  /** APIから通知設定を取得する */
+  fetchNotificationSettings: () => Promise<void>;
+  /** 全通知のON/OFFをAPIに保存する */
+  updateNotificationEnabled: (enabled: boolean) => Promise<void>;
+};
+
+export const useSettingsStore = create<SettingsStore>((set, get) => ({
+  language: "日本語",
+  isLanguageLoaded: false,
+  notificationSettings: null,
+  isNotificationSettingsLoaded: false,
+
+  /**
+   * SecureStoreから言語設定を読み込む
+   * アプリ起動時に呼び出す
+   */
+  loadLanguage: async () => {
+    const stored = await SecureStore.getItemAsync(LANGUAGE_KEY);
+    const language: Language = stored !== null ? (JSON.parse(stored) as Language) : "日本語";
+    set({ language, isLanguageLoaded: true });
+  },
+
+  /**
+   * 言語設定を変更してSecureStoreに永続化する
+   *
+   * @param language - 設定する言語
+   */
+  setLanguage: async (language: Language) => {
+    await SecureStore.setItemAsync(LANGUAGE_KEY, JSON.stringify(language));
+    set({ language });
+  },
+
+  /**
+   * APIから通知設定を取得する
+   * 取得失敗時もisNotificationSettingsLoadedをtrueにする
+   */
+  fetchNotificationSettings: async () => {
+    try {
+      const data = await apiFetch<NotificationSettingsResponse>(
+        "/api/users/me/notification-settings",
+      );
+      set({ notificationSettings: data.data, isNotificationSettingsLoaded: true });
+    } catch {
+      set({ isNotificationSettingsLoaded: true });
+    }
+  },
+
+  /**
+   * 全通知のON/OFFをAPIに保存する
+   * 楽観的更新を行い、失敗時はロールバックする
+   *
+   * @param enabled - trueで全通知ON、falseで全通知OFF
+   * @throws Error - API更新失敗時
+   */
+  updateNotificationEnabled: async (enabled: boolean) => {
+    const previous = get().notificationSettings;
+
+    const updatePayload = {
+      newArticle: enabled,
+      aiComplete: enabled,
+      follow: enabled,
+      system: enabled,
+    };
+
+    try {
+      const data = await apiFetch<NotificationSettingsResponse>(
+        "/api/users/me/notification-settings",
+        {
+          method: "PATCH",
+          body: JSON.stringify(updatePayload),
+        },
+      );
+      set({ notificationSettings: data.data });
+    } catch {
+      set({ notificationSettings: previous });
+      throw new Error("通知設定の更新に失敗しました");
+    }
+  },
+}));


### PR DESCRIPTION
## 概要
設定画面の言語・通知トグルをAPI/AsyncStorageに永続化

Closes #427