### PR TITLE
fix: store push token in users.pushToken and fix API route prefix #431

### DIFF
--- a/apps/api/src/routes/notifications.test.ts
+++ b/apps/api/src/routes/notifications.test.ts
@@ -475,28 +475,16 @@ describe("GET /api/notifications", () => {
 describe("POST /api/notifications/register", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockInsertValues.mockReturnValue({
-      onConflictDoUpdate: mockInsertOnConflict,
+    mockUpdateSet.mockReturnValue({
+      where: mockUpdateWhere,
     });
-    mockInsertOnConflict.mockReturnValue({
-      returning: mockInsertReturning,
-    });
+    mockUpdateWhere.mockResolvedValue(undefined);
   });
 
   describe("正常系", () => {
     it("有効なプッシュトークンを登録して201を返すこと", async () => {
       // Arrange
       const app = createMutationTestApp();
-      mockInsertReturning.mockResolvedValue([
-        {
-          id: "token_01",
-          userId: MOCK_USER.id,
-          token: "ExponentPushToken[xxxxxx]",
-          platform: "ios",
-          createdAt: "2024-01-15T00:00:00Z",
-          updatedAt: "2024-01-15T00:00:00Z",
-        },
-      ]);
 
       // Act
       const res = await app.request("/api/notifications/register", {
@@ -521,16 +509,6 @@ describe("POST /api/notifications/register", () => {
     it("androidプラットフォームでも登録できること", async () => {
       // Arrange
       const app = createMutationTestApp();
-      mockInsertReturning.mockResolvedValue([
-        {
-          id: "token_02",
-          userId: MOCK_USER.id,
-          token: "fcm-token-android",
-          platform: "android",
-          createdAt: "2024-01-15T00:00:00Z",
-          updatedAt: "2024-01-15T00:00:00Z",
-        },
-      ]);
 
       // Act
       const res = await app.request("/api/notifications/register", {
@@ -669,16 +647,6 @@ describe("POST /api/notifications/register", () => {
     it("成功レスポンスがAPI設計規約に従った形式であること", async () => {
       // Arrange
       const app = createMutationTestApp();
-      mockInsertReturning.mockResolvedValue([
-        {
-          id: "token_01",
-          userId: MOCK_USER.id,
-          token: "ExponentPushToken[xxxxxx]",
-          platform: "ios",
-          createdAt: "2024-01-15T00:00:00Z",
-          updatedAt: "2024-01-15T00:00:00Z",
-        },
-      ]);
 
       // Act
       const res = await app.request("/api/notifications/register", {

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 
 import type { Database } from "../db";
-import { notifications } from "../db/schema";
+import { notifications, users } from "../db/schema";
 
 /** デフォルトのページサイズ */
 const DEFAULT_LIMIT = 20;
@@ -202,35 +202,12 @@ export function createNotificationsRoute(options: NotificationsRouteOptions) {
     const { token, platform } = validation.data;
 
     try {
-      const now = new Date().toISOString();
-      const id = crypto.randomUUID();
-
-      const [inserted] = await db
-        .insert(notifications)
-        .values({
-          id,
-          userId,
-          type: "push_token",
-          title: "プッシュトークン登録",
-          body: token,
-          data: JSON.stringify({ token, platform }),
-          isRead: false,
-          createdAt: now,
-        })
-        .onConflictDoUpdate({
-          target: [notifications.id],
-          set: {
-            body: token,
-            data: JSON.stringify({ token, platform }),
-          },
-        })
-        .returning();
+      await db.update(users).set({ pushToken: token }).where(eq(users.id, userId));
 
       return c.json(
         {
           success: true,
           data: {
-            ...inserted,
             token,
             platform,
           },


### PR DESCRIPTION
## 概要

プッシュトークン登録に関する2つのバグを修正します。

## 変更内容

- **API**: `POST /api/notifications/register` ハンドラが `notifications` テーブルに insert していたのを、正しく `users.pushToken` カラムを `update` する実装に修正
- **Mobile**: `registerTokenWithApi` が `/notifications/register` を呼んでいたのを、正しいプレフィックス `/api/notifications/register` に修正
- **Tests**: `db.insert` モックチェーンを `db.update(users)` チェーン（`mockUpdateSet` / `mockUpdateWhere`）に合わせて更新

## テスト

- [x] Unit テスト追加・更新済み
- [x] Integration テスト追加・更新済み
- [x] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（82 test files, 1177 tests passed）
- [x] `pnpm lint` がエラーなしで通ること

## 関連Issue

Closes #431