### PR TITLE
fix: enable husky pre-push hook #494

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "deploy:staging": "turbo run deploy:staging --filter=@tech-clip/api",
-    "deploy:production": "turbo run deploy:production --filter=@tech-clip/api"
+    "deploy:production": "turbo run deploy:production --filter=@tech-clip/api",
+    "prepare": "husky"
   },
   "pnpm": {
     "overrides": {
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
+    "husky": "^9.1.7",
     "turbo": "^2.5.0",
     "typescript": "^5.8.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.0
         version: 1.9.4
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       turbo:
         specifier: ^2.5.0
         version: 2.8.20
@@ -4028,6 +4031,11 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   hyphenate-style-name@1.1.0:
     resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
@@ -10831,6 +10839,8 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  husky@9.1.7: {}
 
   hyphenate-style-name@1.1.0: {}
 


### PR DESCRIPTION
## 概要
huskyのpre-pushフックを有効化。push前にlint/typecheck/testを自動実行する。

## 変更内容
- huskyをdevDependenciesに追加
- package.jsonにprepareスクリプト追加

Closes #494