### PR TITLE
fix: show actual subscription plan in settings #502

### DIFF
--- a/apps/mobile/__tests__/screens/settings.test.tsx
+++ b/apps/mobile/__tests__/screens/settings.test.tsx
@@ -12,6 +12,10 @@ const mockLoadLanguage = jest.fn().mockResolvedValue(undefined);
 const mockFetchNotificationSettings = jest.fn().mockResolvedValue(undefined);
 const mockUpdateNotificationEnabled = jest.fn().mockResolvedValue(undefined);
 
+jest.mock("../../src/hooks/use-subscription", () => ({
+  useSubscription: () => ({ isSubscribed: false }),
+}));
+
 jest.mock("../../src/stores/auth-store", () => ({
   useAuthStore: jest.fn((selector: (state: Record<string, unknown>) => unknown) =>
     selector({

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -14,6 +14,7 @@ import { Alert, Pressable, ScrollView, Switch, Text, View } from "react-native";
 
 import { confirm } from "@/components/ConfirmDialog";
 import { useRouter } from "expo-router";
+import { useSubscription } from "../../src/hooks/use-subscription";
 import { useAuthStore } from "../../src/stores/auth-store";
 import { useSettingsStore } from "../../src/stores/settings-store";
 
@@ -93,6 +94,7 @@ export default function SettingsScreen() {
   const signOut = useAuthStore((s) => s.signOut);
   const deleteAccount = useAuthStore((s) => s.deleteAccount);
   const user = useAuthStore((s) => s.user);
+  const { isSubscribed } = useSubscription();
 
   const language = useSettingsStore((s) => s.language);
   const setLanguage = useSettingsStore((s) => s.setLanguage);
@@ -213,7 +215,7 @@ export default function SettingsScreen() {
         <SettingsRow
           icon={<CreditCard size={ICON_SIZE} color={ICON_COLOR} />}
           label="プラン"
-          value="Free"
+          value={isSubscribed ? "Premium" : "Free"}
         />
       </View>
 


### PR DESCRIPTION
## 概要
設定画面のプラン表示がFree固定だったのを、useSubscriptionフックからisSubscribed状態を取得して動的に表示するように修正。

## 変更内容
- settings.tsxにuseSubscriptionフック追加
- プラン表示をisSubscribed ? Premium : Freeに変更
- テストにuseSubscriptionモック追加

Closes #502