### PR TITLE
fix: add jq/docker-client/eas-cli to flake.nix and automate dev setup #521

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,14 +38,14 @@
             fi
 
             # .env の自動コピー（存在しない場合のみ）
-            for env_example in apps/mobile/.env.example apps/api/.dev.vars.example; do
-              env_file="''${env_example%.example}"
-              env_file="''${env_file%.vars.example}.vars"
-              if [ -f "$env_example" ] && [ ! -f "$env_file" ]; then
-                cp "$env_example" "$env_file"
-                echo "Created $env_file from example"
-              fi
-            done
+            if [ -f "apps/mobile/.env.example" ] && [ ! -f "apps/mobile/.env" ]; then
+              cp apps/mobile/.env.example apps/mobile/.env
+              echo "Created apps/mobile/.env from example"
+            fi
+            if [ -f "apps/api/.dev.vars.example" ] && [ ! -f "apps/api/.dev.vars" ]; then
+              cp apps/api/.dev.vars.example apps/api/.dev.vars
+              echo "Created apps/api/.dev.vars from example"
+            fi
 
             echo ""
             echo "TechClip dev environment ready"


### PR DESCRIPTION
## 概要
nix developだけで開発環境が完成するようにflake.nixを改善。

## 変更内容
- jq追加（pre-pushフックで使用）
- docker-client追加（ZAPスキャンで使用）
- eas-cliをnpxラッパーで提供
- shellHookでpnpm install自動実行
- .envファイルの自動コピー
- 起動時にクイックスタートガイド表示

Closes #521