### PR TITLE
feat: add Maestro E2E test setup #519

### DIFF
--- a/apps/mobile/.maestro/config.yaml
+++ b/apps/mobile/.maestro/config.yaml
@@ -1,0 +1,4 @@
+appId: com.techclip.app
+---
+# TechClip Maestro E2E テスト設定
+# 実行方法: maestro test .maestro/

--- a/apps/mobile/.maestro/home.yaml
+++ b/apps/mobile/.maestro/home.yaml
@@ -1,0 +1,21 @@
+appId: com.techclip.app
+---
+# ホーム画面 E2E テスト
+# 記事一覧の表示とフィルター操作を検証する
+# 前提: ログイン済みの状態で実行する
+
+- launchApp
+
+# ホーム画面のフィルターバーが表示されることを確認する
+- assertVisible: "すべて"
+- assertVisible: "Zenn"
+- assertVisible: "Qiita"
+
+# お気に入りフィルターが表示されることを確認する
+- assertVisible: "お気に入り"
+
+# Zennフィルターをタップする
+- tapOn: "Zenn"
+
+# すべてに戻す
+- tapOn: "すべて"

--- a/apps/mobile/.maestro/login.yaml
+++ b/apps/mobile/.maestro/login.yaml
@@ -1,0 +1,34 @@
+appId: com.techclip.app
+---
+# ログインフロー E2E テスト
+# メール・パスワード入力→ログインボタンの基本フローを検証する
+
+- launchApp:
+    clearState: true
+
+# オンボーディングをスキップしてログイン画面へ
+- tapOn:
+    id: "skip-button"
+
+# ログイン画面の表示確認
+- assertVisible:
+    id: "login-email-input"
+- assertVisible:
+    id: "login-password-input"
+- assertVisible:
+    id: "login-submit-button"
+
+# メールアドレスを入力する
+- tapOn:
+    id: "login-email-input"
+- inputText: "test@example.com"
+- assertVisible: "test@example.com"
+
+# パスワードを入力する
+- tapOn:
+    id: "login-password-input"
+- inputText: "Password123"
+
+# ログインボタンをタップする
+- tapOn:
+    id: "login-submit-button"

--- a/apps/mobile/.maestro/onboarding.yaml
+++ b/apps/mobile/.maestro/onboarding.yaml
@@ -1,0 +1,41 @@
+appId: com.techclip.app
+---
+# オンボーディングフロー E2E テスト
+# 初回起動時の4ページウォークスルーを検証する
+
+- launchApp:
+    clearState: true
+
+# ページ1: 技術記事をワンタップで保存
+- assertVisible:
+    id: "onboarding-title"
+- assertVisible: "技術記事をワンタップで保存"
+- assertVisible:
+    id: "page-indicator"
+- assertVisible:
+    id: "skip-button"
+- assertVisible:
+    id: "next-button"
+
+# ページ2へ進む
+- tapOn:
+    id: "next-button"
+- assertVisible: "AIが要約・翻訳"
+
+# ページ3へ進む
+- tapOn:
+    id: "next-button"
+- assertVisible: "お気に入り・タグで整理"
+
+# ページ4（最終ページ）へ進む
+- tapOn:
+    id: "next-button"
+- assertVisible: "さあ、始めましょう"
+- assertVisible:
+    id: "finish-button"
+
+# 「始める」をタップしてログイン画面へ
+- tapOn:
+    id: "finish-button"
+- assertVisible:
+    id: "login-submit-button"

--- a/apps/mobile/.maestro/settings.yaml
+++ b/apps/mobile/.maestro/settings.yaml
@@ -1,0 +1,34 @@
+appId: com.techclip.app
+---
+# 設定画面 E2E テスト
+# 設定画面への遷移と各セクションの表示を検証する
+# 前提: ログイン済みの状態で実行する
+
+- launchApp
+
+# 設定タブへ遷移する
+- tapOn: "設定"
+
+# アカウントセクションが表示されることを確認する
+- assertVisible: "アカウント"
+- assertVisible: "パスワード変更"
+
+# サブスクリプションセクションが表示されることを確認する
+- assertVisible: "サブスクリプション"
+- assertVisible: "プラン"
+
+# 一般セクションが表示されることを確認する
+- assertVisible: "一般"
+- assertVisible:
+    id: "settings-language-button"
+- assertVisible:
+    id: "settings-notification-switch"
+
+# ログアウトボタンが表示されることを確認する
+- assertVisible:
+    id: "settings-logout-button"
+
+# アカウント管理セクションが表示されることを確認する
+- assertVisible: "アカウント管理"
+- assertVisible:
+    id: "settings-delete-account-button"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,8 @@
     "test": "jest --passWithNoTests --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "lint": "echo 'lint configured in root'"
+    "lint": "echo 'lint configured in root'",
+    "e2e": "maestro test .maestro/"
   },
   "dependencies": {
     "@react-native-community/netinfo": "^12.0.1",


### PR DESCRIPTION
## 概要

Maestro E2EテストのセットアップをしてMobile アプリの主要フローをテストできるようにした。

## 変更内容

- `apps/mobile/.maestro/config.yaml`: Maestro設定ファイル（appId: `com.techclip.app`）
- `apps/mobile/.maestro/onboarding.yaml`: オンボーディング4ページフロー（スキップ・次へ・始めるボタン）
- `apps/mobile/.maestro/login.yaml`: メール・パスワード入力→ログインボタンのフロー
- `apps/mobile/.maestro/home.yaml`: ホーム画面のフィルターバー表示確認
- `apps/mobile/.maestro/settings.yaml`: 設定画面の各セクション（アカウント・サブスクリプション・一般・アカウント管理）表示確認
- `apps/mobile/package.json`: `"e2e": "maestro test .maestro/"` スクリプト追加

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [x] `pnpm test` がすべてパスすること（YAML設定ファイルのみのためTDD対象外）
- [x] `pnpm lint` がエラーなしで通ること

> 本issueはYAML設定ファイルのみの追加であり、CLAUDE.mdの「TDD対象外」（環境設定・インフラ構成のみの変更）に該当する。

## 関連Issue

Closes #519