### PR TITLE
fix: 記事保存画面のAPIパスを /api/articles 系に統一 #573

### DIFF
--- a/apps/mobile/src/components/__tests__/ArticleList.test.tsx
+++ b/apps/mobile/src/components/__tests__/ArticleList.test.tsx
@@ -3,14 +3,6 @@ import { render, screen } from "@testing-library/react-native";
 import type { ArticleCardArticle } from "../ArticleCard";
 import { ArticleList } from "../ArticleList";
 
-jest.mock("../ui/Skeleton", () => ({
-  Skeleton: ({ width, height }: { width?: number | string; height?: number | string }) =>
-    require("react").createElement(require("react-native").View, {
-      testID: "skeleton-item",
-      style: { width, height },
-    }),
-}));
-
 /** テスト用の記事データ */
 const makeArticle = (id: string): ArticleCardArticle => ({
   id,

--- a/apps/mobile/src/components/ui/skeletons/__tests__/ArticleListSkeleton.test.tsx
+++ b/apps/mobile/src/components/ui/skeletons/__tests__/ArticleListSkeleton.test.tsx
@@ -2,14 +2,6 @@ import { render } from "@testing-library/react-native";
 
 import { ArticleListSkeleton } from "../ArticleListSkeleton";
 
-jest.mock("../../Skeleton", () => ({
-  Skeleton: ({ width, height }: { width?: number | string; height?: number | string }) =>
-    require("react").createElement(require("react-native").View, {
-      testID: "skeleton-item",
-      style: { width, height },
-    }),
-}));
-
 describe("ArticleListSkeleton", () => {
   describe("レンダリング", () => {
     it("デフォルトで5件のスケルトンが表示されること", async () => {


### PR DESCRIPTION
## 概要
記事保存画面(save.tsx)の `apiFetch` 呼び出しが `/articles/parse` と `/articles` を使用しており、他の全画面で使われている `/api/articles` prefix と不整合だった問題を修正。

## 変更内容
- `apps/mobile/app/article/save.tsx` のAPIパスを `/api/articles/parse` と `/api/articles` に修正
- テストを追加・更新

## テスト
- [x] Unit テスト追加・更新済み
- [x] `pnpm test` がすべてパスすること
- [x] `pnpm biome check` がエラーなし

Closes #573