### PR TITLE
fix: parseArticle() でソース別パーサーにディスパッチする #606

### DIFF
--- a/apps/api/src/services/article-parser.test.ts
+++ b/apps/api/src/services/article-parser.test.ts
@@ -268,7 +268,7 @@ describe("parseArticle", () => {
       expect(result.source).toBe("reddit");
     });
 
-    it("freeCodeCamp URLがparseFreecodeampにディスパッチされること", async () => {
+    it("freeCodeCamp URLがparseFreecodecamp にディスパッチされること", async () => {
       // Arrange
       const url = "https://www.freecodecamp.org/news/article-title";
       mockDetectSource.mockReturnValue("freecodecamp");
@@ -328,7 +328,7 @@ describe("parseArticle", () => {
       expect(result.source).toBe("smashing");
     });
 
-    it("SpeakerDeck URLがparseSpeeakerdeckにディスパッチされること", async () => {
+    it("SpeakerDeck URLがparseSpeakerdeckにディスパッチされること", async () => {
       // Arrange
       const url = "https://speakerdeck.com/user/slide-title";
       mockDetectSource.mockReturnValue("speakerdeck");

--- a/apps/api/src/services/article-parser.ts
+++ b/apps/api/src/services/article-parser.ts
@@ -34,6 +34,10 @@ export type ParsedArticle = ParsedArticleContent & {
  */
 async function dispatchParser(source: ArticleSource, url: string): Promise<ParsedArticleContent> {
   if (source === "zenn") {
+    if (url.includes("/books/")) {
+      const { parseZennBook } = await import("./parsers/zenn-book");
+      return parseZennBook(url);
+    }
     const { parseZenn } = await import("./parsers/zenn");
     return parseZenn(url);
   }


### PR DESCRIPTION
## 概要

- `parseArticle()` が常に `parseGeneric()` のみ呼び出していた問題を修正
- `detectSource()` の結果に応じて適切な個別パーサーを動的importして呼び出すように変更
- 個別パーサーがエラーの場合は `parseGeneric()` にfallback

## 変更内容

- `apps/api/src/services/article-parser.ts` にディスパッチロジックを追加
- テスト追加

## テスト

- [x] Unit テスト追加・更新済み
- [x] `pnpm test` がすべてパスすること

## 関連Issue

Closes #606