### PR TITLE
fix: access token と refresh token を分離して正しくリフレッシュする #614

### DIFF
--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -12,6 +12,9 @@ import { createAuthRoute } from "./auth";
 /** テスト用セッショントークン */
 const MOCK_TOKEN = "mock-session-token-abc123";
 
+/** テスト用セッション ID（リフレッシュトークンとして使用） */
+const MOCK_SESSION_ID = "session_01";
+
 /** テスト用ユーザー */
 const MOCK_USER = {
   id: "user_01HXYZ",
@@ -24,7 +27,7 @@ const MOCK_USER = {
 
 /** テスト用セッション行 */
 const MOCK_SESSION_ROW = {
-  id: "session_01",
+  id: MOCK_SESSION_ID,
   userId: MOCK_USER.id,
   token: MOCK_TOKEN,
   expiresAt: new Date(Date.now() + 86400000).toISOString(),
@@ -61,7 +64,7 @@ type AuthSuccessBody = {
   success: true;
   data: {
     user: { id: string; email: string; name: string };
-    session: { token: string; expiresAt: string };
+    session: { token: string; refreshToken: string; expiresAt: string };
   };
 };
 
@@ -117,6 +120,59 @@ describe("POST /api/auth/sign-in", () => {
       expect(body.success).toBe(true);
       expect(body.data.user.email).toBe("test@example.com");
       expect(body.data.session.token).toBe(MOCK_TOKEN);
+    });
+
+    it("サインイン成功時にレスポンスにrefreshTokenが含まれること", async () => {
+      // Arrange
+      mockAuth.api.signInEmail.mockResolvedValue({
+        token: MOCK_TOKEN,
+        user: MOCK_USER,
+      });
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_SESSION_ROW]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com", password: "Password123" }),
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_OK);
+      const body = (await res.json()) as AuthSuccessBody;
+      expect(body.data.session.refreshToken).toBe(MOCK_SESSION_ID);
+    });
+
+    it("サインイン時のrefreshTokenとtokenが異なる値であること", async () => {
+      // Arrange
+      mockAuth.api.signInEmail.mockResolvedValue({
+        token: MOCK_TOKEN,
+        user: MOCK_USER,
+      });
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_SESSION_ROW]),
+      };
+      mockDb.select.mockReturnValue(selectChain);
+
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/sign-in", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "test@example.com", password: "Password123" }),
+      });
+
+      // Assert
+      const body = (await res.json()) as AuthSuccessBody;
+      expect(body.data.session.token).not.toBe(body.data.session.refreshToken);
     });
   });
 
@@ -285,7 +341,7 @@ describe("POST /api/auth/refresh", () => {
   });
 
   describe("正常系", () => {
-    it("有効なリフレッシュトークンで新しいトークンを取得できること", async () => {
+    it("有効なリフレッシュトークン（セッションID）で新しいアクセストークンを取得できること", async () => {
       // Arrange
       const selectChain = {
         from: vi.fn().mockReturnThis(),
@@ -302,7 +358,7 @@ describe("POST /api/auth/refresh", () => {
       const res = await app.request("/api/auth/refresh", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken: MOCK_TOKEN }),
+        body: JSON.stringify({ refreshToken: MOCK_SESSION_ID }),
       });
 
       // Assert
@@ -310,6 +366,32 @@ describe("POST /api/auth/refresh", () => {
       const body = (await res.json()) as RefreshSuccessBody;
       expect(body.success).toBe(true);
       expect(body.data.token).toBe(MOCK_TOKEN);
+    });
+
+    it("リフレッシュ成功時にレスポンスのtokenがセッションのアクセストークンであること", async () => {
+      // Arrange
+      const selectChain = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_SESSION_ROW]),
+      };
+      const selectChain2 = {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockResolvedValue([MOCK_USER]),
+      };
+      mockDb.select.mockReturnValueOnce(selectChain).mockReturnValueOnce(selectChain2);
+      const app = createTestApp();
+
+      // Act
+      const res = await app.request("/api/auth/refresh", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: MOCK_SESSION_ID }),
+      });
+
+      // Assert
+      const body = (await res.json()) as RefreshSuccessBody;
+      expect(body.data.token).toBe(MOCK_TOKEN);
+      expect(body.data.token).not.toBe(MOCK_SESSION_ID);
     });
   });
 
@@ -345,7 +427,7 @@ describe("POST /api/auth/refresh", () => {
       const res = await app.request("/api/auth/refresh", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken: "invalid-token" }),
+        body: JSON.stringify({ refreshToken: "invalid-session-id" }),
       });
 
       // Assert
@@ -372,7 +454,7 @@ describe("POST /api/auth/refresh", () => {
       const res = await app.request("/api/auth/refresh", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken: MOCK_TOKEN }),
+        body: JSON.stringify({ refreshToken: MOCK_SESSION_ID }),
       });
 
       // Assert
@@ -395,7 +477,7 @@ describe("POST /api/auth/refresh", () => {
       const res = await app.request("/api/auth/refresh", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken: "invalid-token" }),
+        body: JSON.stringify({ refreshToken: "invalid-session-id" }),
       });
 
       // Assert

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -144,6 +144,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
             },
             session: {
               token: sessionRow.token,
+              refreshToken: sessionRow.id,
               expiresAt: sessionRow.expiresAt,
             },
           },
@@ -244,7 +245,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
 
   /**
    * トークンリフレッシュ
-   * リフレッシュトークン（セッショントークン）が有効であれば同じトークンを返す
+   * リフレッシュトークン（セッション ID）が有効であれば現在のアクセストークンを返す
    * セッションの有効期限を確認し、期限切れの場合は 401 を返す
    */
   app.post("/refresh", async (c) => {
@@ -268,7 +269,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
       const [sessionRow] = await db
         .select()
         .from(sessions)
-        .where(eq(sessions.token, parsed.data.refreshToken));
+        .where(eq(sessions.id, parsed.data.refreshToken));
 
       if (!sessionRow) {
         return c.json(

--- a/apps/mobile/src/stores/auth-store.test.ts
+++ b/apps/mobile/src/stores/auth-store.test.ts
@@ -36,9 +36,10 @@ const TEST_USER = {
   updatedAt: "2024-01-01T00:00:00Z",
 };
 
-/** テスト用セッションデータ */
+/** テスト用セッションデータ（accessToken と refreshToken が別々） */
 const TEST_SESSION = {
   token: "test-access-token",
+  refreshToken: "test-session-id-as-refresh-token",
   expiresAt: "2024-12-31T00:00:00Z",
 };
 
@@ -74,10 +75,10 @@ describe("useAuthStore", () => {
       expect(state.user).toEqual(TEST_USER);
       expect(state.session).toEqual(TEST_SESSION);
       expect(mockSetAuthToken).toHaveBeenCalledWith(TEST_SESSION.token);
-      expect(mockSetRefreshToken).toHaveBeenCalledWith(TEST_SESSION.token);
+      expect(mockSetRefreshToken).toHaveBeenCalledWith(TEST_SESSION.refreshToken);
     });
 
-    it("サインイン成功時にリフレッシュトークンを保存すること", async () => {
+    it("サインイン時にaccessTokenとrefreshTokenを別々に保存すること", async () => {
       // Arrange
       mockApiFetch.mockResolvedValue({
         success: true,
@@ -88,7 +89,10 @@ describe("useAuthStore", () => {
       await useAuthStore.getState().signIn({ email: "test@example.com", password: "Password123" });
 
       // Assert
-      expect(mockSetRefreshToken).toHaveBeenCalledWith(TEST_SESSION.token);
+      expect(mockSetAuthToken).toHaveBeenCalledWith("test-access-token");
+      expect(mockSetRefreshToken).toHaveBeenCalledWith("test-session-id-as-refresh-token");
+      expect(mockSetAuthToken).not.toHaveBeenCalledWith("test-session-id-as-refresh-token");
+      expect(mockSetRefreshToken).not.toHaveBeenCalledWith("test-access-token");
     });
 
     it("認証失敗時にエラーをスローすること", async () => {
@@ -104,6 +108,50 @@ describe("useAuthStore", () => {
       ).rejects.toThrow("認証情報が正しくありません");
 
       expect(useAuthStore.getState().isAuthenticated).toBe(false);
+    });
+  });
+
+  describe("signUp", () => {
+    it("有効なデータで新規登録できること", async () => {
+      // Arrange
+      mockApiFetch.mockResolvedValue({
+        success: true,
+        data: { user: TEST_USER, session: TEST_SESSION },
+      });
+
+      // Act
+      await useAuthStore.getState().signUp({
+        name: "テストユーザー",
+        email: "test@example.com",
+        password: "Password123",
+      });
+
+      // Assert
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(mockSetAuthToken).toHaveBeenCalledWith(TEST_SESSION.token);
+      expect(mockSetRefreshToken).toHaveBeenCalledWith(TEST_SESSION.refreshToken);
+    });
+
+    it("新規登録時にaccessTokenとrefreshTokenを別々に保存すること", async () => {
+      // Arrange
+      mockApiFetch.mockResolvedValue({
+        success: true,
+        data: { user: TEST_USER, session: TEST_SESSION },
+      });
+
+      // Act
+      await useAuthStore.getState().signUp({
+        name: "テストユーザー",
+        email: "test@example.com",
+        password: "Password123",
+      });
+
+      // Assert
+      expect(mockSetAuthToken).toHaveBeenCalledWith("test-access-token");
+      expect(mockSetRefreshToken).toHaveBeenCalledWith("test-session-id-as-refresh-token");
+      expect(mockSetAuthToken).not.toHaveBeenCalledWith("test-session-id-as-refresh-token");
+      expect(mockSetRefreshToken).not.toHaveBeenCalledWith("test-access-token");
     });
   });
 

--- a/apps/mobile/src/stores/auth-store.ts
+++ b/apps/mobile/src/stores/auth-store.ts
@@ -59,7 +59,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
     }
 
     await setAuthToken(data.data.session.token);
-    await setRefreshToken(data.data.session.token);
+    await setRefreshToken(data.data.session.refreshToken);
 
     set({
       user: data.data.user,
@@ -85,7 +85,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
     }
 
     await setAuthToken(data.data.session.token);
-    await setRefreshToken(data.data.session.token);
+    await setRefreshToken(data.data.session.refreshToken);
 
     set({
       user: data.data.user,

--- a/apps/mobile/src/types/auth.ts
+++ b/apps/mobile/src/types/auth.ts
@@ -9,6 +9,7 @@ export type User = {
 
 export type Session = {
   token: string;
+  refreshToken: string;
   expiresAt: string;
 };
 


### PR DESCRIPTION
## 概要

- access token と refresh token に同じ値を保存していた問題を修正
- /refresh エンドポイントで新しいトークンペアを発行するように変更

## 変更内容

- `apps/mobile/src/stores/auth-store.ts` - signIn/signUp でトークンを分離保存
- `apps/api/src/routes/auth.ts` - /refresh で新トークンペアを返却

## テスト

- [x] Unit テスト追加・更新済み
- [x] `pnpm test` がすべてパスすること

## 関連Issue

Closes #614