### PR TITLE
chore: AI自動承認をAIレビュー+ラベル付与に変更

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -13,7 +13,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -29,8 +28,8 @@ jobs:
 
             レビュー完了後、以下のルールに従いラベルを操作してください（gh pr edit コマンドを使用）。
             - 重大な問題（🔴）が0件かつ軽微な問題（🟡）が0件かつ改善提案（💡）が0件の場合:
-              gh pr edit <PR番号> --add-label "AI Review: PASS" --remove-label "AI Review: NEEDS WORK"
+              gh pr edit ${{ github.event.pull_request.number }} --add-label "AI Review: PASS" --remove-label "AI Review: NEEDS WORK"
             - 1つでも問題や改善提案がある場合:
-              gh pr edit <PR番号> --add-label "AI Review: NEEDS WORK" --remove-label "AI Review: PASS"
+              gh pr edit ${{ github.event.pull_request.number }} --add-label "AI Review: NEEDS WORK" --remove-label "AI Review: PASS"
 
             重要: gh pr review --approve は絶対に実行しないでください。最終承認は人間が行います。


### PR DESCRIPTION
## 概要

`.github/workflows/auto-approve.yml` で AI の判断結果が直接 `gh pr review --approve` に接続されており、AI の判断ミスがそのまま PR 承認に繋がるリスクがあった。AIレビュー結果をラベルとして記録し、最終承認は人間が行う設計に変更する。

## 変更内容

- `gh pr review --approve` の実行を削除し、AI による自動承認を廃止
- AIレビューで問題0件の場合は `AI Review: PASS` ラベルを付与
- 1件でも問題がある場合は `AI Review: NEEDS WORK` ラベルを付与
- `allowedTools` から `Bash(gh pr review:*)` を削除し `Bash(gh pr comment:*)` と `Bash(gh pr edit:*)` に変更
- ジョブ名を `review-and-approve` から `review-and-label` に変更
- `issues: write` 権限を追加（ラベル操作に必要）

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [ ] `pnpm test` がすべてパスすること
- [ ] `pnpm lint` がエラーなしで通ること

> CI/CD 変更のため TDD 対象外

## 関連Issue

Closes #619