### PR TITLE
fix: biome.json を Biome v1 互換に戻す

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
@@ -9,31 +9,23 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
-      "suspicious": {
-        "noUnknownAtRules": "off"
-      }
+      "recommended": true
     }
   },
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
+  "organizeImports": {
+    "enabled": true
   },
   "files": {
-    "includes": [
-      "**",
-      "!node_modules",
-      "!dist",
-      "!.turbo",
-      "!.wrangler",
-      "!.expo",
-      "!.claude",
-      "!drizzle",
-      "!.omc",
-      "!.worktrees"
+    "ignore": [
+      "node_modules",
+      "dist",
+      ".turbo",
+      ".wrangler",
+      ".expo",
+      ".claude",
+      "drizzle",
+      ".omc",
+      ".worktrees"
     ]
   },
   "javascript": {


### PR DESCRIPTION
## 概要

PR #624 で biome.json が Biome v2 スキーマに変更されたが、実際にインストールされている Biome は v1.9.4 のため、lint が全面的に失敗する状態になっていた。

## 変更内容

- `$schema` を `2.4.7` → `1.9.4` に戻す
- `assist` → `organizeImports` に戻す
- `files.includes` → `files.ignore` に戻す

## テスト

- [x] `npx biome check .` が設定エラーなしで動作すること

## 関連Issue

biome.json 互換性修正（ブロッカー）