### PR TITLE
fix: pre-push hookのZAPスキャン後にwranglerプロセスが残留する #639

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -29,10 +29,12 @@ ZAP_DAEMON_PID=""
 
 zap_cleanup() {
   if [ -n "${ZAP_DAEMON_PID}" ]; then
+    pkill -P "${ZAP_DAEMON_PID}" 2>/dev/null
     kill "${ZAP_DAEMON_PID}" 2>/dev/null
     wait "${ZAP_DAEMON_PID}" 2>/dev/null || true
   fi
   if [ -n "${ZAP_SERVER_PID}" ]; then
+    pkill -P "${ZAP_SERVER_PID}" 2>/dev/null
     kill "${ZAP_SERVER_PID}" 2>/dev/null
     wait "${ZAP_SERVER_PID}" 2>/dev/null || true
   fi


### PR DESCRIPTION
## 概要

pre-push hookの `zap_cleanup` 関数で、wrangler devの子プロセスが残留してgit pushがハングする問題を修正。

## 変更内容

- `zap_cleanup` で `pkill -P $PID` を追加し、子プロセスを先に停止してから親プロセスを停止するように変更
- ZAP_DAEMON_PID と ZAP_SERVER_PID 両方に適用

## テスト

- [x] シェルスクリプトの変更のみ（TDD対象外）
- [x] `pkill -P` は macOS / Linux 両方で利用可能

Closes #639