### PR TITLE
fix: テストのact() warningとstderr出力を解消 #640

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -41,6 +41,7 @@ zap_cleanup() {
   rm -f "${ZAP_DB_FILE}"
   rm -f "/tmp/zap-api-server-${ZAP_API_PORT}.log"
   rm -f "/tmp/zap-daemon-${ZAP_PORT}.log"
+  return 0
 }
 trap zap_cleanup EXIT INT TERM
 


### PR DESCRIPTION
## 概要

mobile テストの React 19 act() warning と API テストの stderr 出力を解消。
biome.json の .omc 除外パターンも修正。

## 変更内容

- `apps/mobile/jest.setup.js`: React 19 の act() warning をフィルタリング
- `apps/api/src/middleware/sentry.test.ts`: 意図的エラーの console.error/log をモック
- `apps/api/src/auth/auth.test.ts`: rateLimit 関連の console.error/warn をモック
- `biome.json`: `.omc` 除外パターンを `**/.omc` に修正
- `.husky/pre-push`: zap_cleanup に return 0 を追加して EXIT trap の非ゼロ終了を防止

## テスト

- [x] mobile テスト全パス（act() warning 0件）
- [x] API テスト全パス（1295 tests）
- [x] `pnpm lint` エラーなし

Closes #640