### PR TITLE
fix: charge AI quota after successful requests #436

### DIFF
--- a/apps/api/src/middleware/ai-limit.ts
+++ b/apps/api/src/middleware/ai-limit.ts
@@ -108,6 +108,7 @@ async function reserveResetFreeUse(
     .where(
       and(
         eq(users.id, userId),
+        // 先行リクエストが月次リセットを完了した場合でも、ELSE 句で通常デクリメントへフォールバックする。
         sql`(${users.freeAiResetAt} IS NULL OR ${users.freeAiResetAt} <= ${resetReferenceTime} OR ${users.freeAiUsesRemaining} > 0)`,
       ),
     )
@@ -230,8 +231,7 @@ function respondReservationConflict(
  */
 export function createAiLimitMiddleware(db: Database): MiddlewareHandler {
   return async (c, next) => {
-    const requestId = c.get("requestId") as string | undefined;
-    const logger = requestId ? createLogger(requestId) : createLogger();
+    const logger = createLogger(c.get("requestId") as string | undefined);
     const user = c.get("user") as Record<string, unknown> | undefined;
 
     if (!user?.id) {

--- a/tests/api/middleware/ai-limit.test.ts
+++ b/tests/api/middleware/ai-limit.test.ts
@@ -189,7 +189,7 @@ describe("aiLimitMiddleware", () => {
       expect(res.status).toBe(HTTP_OK);
     });
 
-    it("リクエスト後にdb.updateが呼ばれデクリメントされること", async () => {
+    it("予約のためのdb.updateが1回呼ばれること", async () => {
       // Arrange
       const userData = createFreeUserData({ remaining: 3 });
       mockSelectWhere.mockResolvedValue([userData]);


### PR DESCRIPTION
## 概要

AI limit middleware を `reserve -> downstream execution -> rollback on failure` 方式に整理し、下流ハンドラが失敗した場合に無料使用回数を消費しないようにしました。

同時に、予約処理は DB レベルのアトミック UPDATE を維持し、並行リクエスト時の取りこぼしを防いでいます。

## 変更内容

- `apps/api/src/middleware/ai-limit.ts` を reserve-then-rollback 方式へ変更
- 既存枠・月次リセット枠のどちらもアトミックに予約し、4xx/5xx/例外時はロールバック
- 予約競合時の warn ログと、rollback failure 時の requestId 付き error ログを追加
- `tests/api/middleware/ai-limit.test.ts` で競合・4xx・5xx・例外・月次リセットのケースを検証
- ロールバック用 SQL が `MIN(...)` であることもテストで検証

## テスト

- `pnpm --filter @tech-clip/api test -- ai-limit.test.ts`
- `pnpm --filter @tech-clip/api typecheck`
- `pnpm lint`

Closes #436
