### PR TITLE
chore: Codex 用ハーネス設定を追加 #675

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,29 @@
+# Codex ローカルハーネス
+
+このディレクトリは、Codex でも Claude と同じリポジトリガードを使えるようにするためのものです。
+
+## 入口
+
+- `bash ./.codex/run-session-start.sh`
+  - リモートとの差分確認
+  - worktree 健全性チェック
+  - 実装順序チェック
+- `bash ./.codex/run-pre-command.sh '<command>'`
+  - シークレット混入チェックを実行
+  - 危険コマンドチェックを実行
+- `bash ./.codex/run-pre-edit.sh`
+  - `main` での編集を防止
+- `bash ./.codex/run-stop.sh`
+  - 未コミット変更の警告
+
+## 設計方針
+
+- ルールロジックはここに重複実装しない
+- 実際のチェック本体は [`.claude/hooks/`](../.claude/hooks) に置く
+- Codex 側はそれを呼び出すラッパーだけを持つ
+
+## なぜ settings.json をそのまま置かないのか
+
+Codex は Claude の `settings.json` 形式をそのまま解釈する前提ではありません。見た目だけ同じファイルを置いても、実際には何も実行されない可能性があります。
+
+このため、このディレクトリでは「Codex から実行できるシェルラッパー」を正として、既存の Claude hook を再利用しています。

--- a/.codex/run-pre-command.sh
+++ b/.codex/run-pre-command.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+command_text="${1:-}"
+
+if [[ -z "$command_text" ]]; then
+  echo "usage: ./.codex/run-pre-command.sh '<command>'" >&2
+  exit 1
+fi
+
+bash "$repo_root/.claude/hooks/secret-guard.sh" "$command_text"
+bash "$repo_root/.claude/hooks/dangerous-command-guard.sh" "$command_text"

--- a/.codex/run-pre-edit.sh
+++ b/.codex/run-pre-edit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+bash "$repo_root/.claude/hooks/main-edit-guard.sh"

--- a/.codex/run-session-start.sh
+++ b/.codex/run-session-start.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+bash "$repo_root/.claude/hooks/session-start.sh"
+bash "$repo_root/.claude/hooks/check-worktrees.sh"
+bash "$repo_root/.claude/hooks/implementation-order-guard.sh"

--- a/.codex/run-stop.sh
+++ b/.codex/run-stop.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+bash "$repo_root/.claude/hooks/uncommitted-warn.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Codex ハーネス
+
+このリポジトリでは、プロジェクト全体のルールは [`CLAUDE.md`](./CLAUDE.md) を正とします。Codex もこのルールに従って作業してください。
+
+## 必須の起動手順
+
+コーディング作業を始める前に、必ず以下を実行します。
+
+```bash
+bash ./.codex/run-session-start.sh
+```
+
+ファイルを編集する前に、必ず以下を実行します。
+
+```bash
+bash ./.codex/run-pre-edit.sh
+```
+
+リポジトリを変更しうるシェルコマンドを実行する前に、必ず以下を実行します。
+
+```bash
+bash ./.codex/run-pre-command.sh '<command>'
+```
+
+作業終了時には、必要に応じて以下を実行します。
+
+```bash
+bash ./.codex/run-stop.sh
+```
+
+## 参照元
+
+- 全体ルール: [`CLAUDE.md`](./CLAUDE.md)
+- 詳細な実装ルール: [`.claude/rules/`](./.claude/rules)
+- 既存 hook 実装: [`.claude/hooks/`](./.claude/hooks)
+
+## 絶対ルール
+
+- GitHub Issue がない状態で作業を始めない
+- Issue ごとに専用 worktree を使う
+- `main` で直接編集しない
+- 可能な限り TDD で進める
+- Lint / Format は Biome を使う
+- 破壊的な Git コマンドを使わない
+- レビューが通る前にマージ提案をしない
+
+## 目的
+
+[`.codex/`](./.codex) 配下のファイルは、Claude 用に既に存在する hook とルールを Codex からも同じように使えるようにするための薄いラッパーです。ルール本体を二重管理しないことを優先します。


### PR DESCRIPTION
## 概要

Codex でもこのリポジトリの開発ルールと既存 hook をそのまま使えるように、Codex 用ハーネスを追加しました。

## 変更内容

- `AGENTS.md` を追加し、Codex が参照するプロジェクトルールの入口を用意
- `.codex/README.md` を追加し、Codex 側の使い方を日本語で整理
- `.codex/run-session-start.sh` を追加し、既存の `.claude/hooks` を順に実行できるようにした
- `.codex/run-pre-command.sh` / `run-pre-edit.sh` / `run-stop.sh` を追加し、Codex から既存ガードを呼べるようにした
- Claude 側の hook 実装を再利用する構成にして、ルールの二重管理を避けた

## 確認内容

- [x] `bash ./.codex/run-session-start.sh`
- [x] `bash ./.codex/run-pre-command.sh 'git status -sb'`
- [x] `bash ./.codex/run-pre-edit.sh`
- [x] `bash ./.codex/run-stop.sh`

## 関連Issue

Closes #675
