### PR TITLE
ci: add review-gate to block merge when NEEDS WORK label exists

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -34,3 +34,21 @@ jobs:
               gh pr edit ${{ github.event.pull_request.number }} --add-label "AI Review: NEEDS WORK" --remove-label "AI Review: PASS"
 
             重要: gh pr review --approve は絶対に実行しないでください。最終承認は人間が行います。
+
+  review-gate:
+    name: Review Gate
+    needs: review-and-label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check review label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          LABELS=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} --jq '.labels[].name')
+          if echo "$LABELS" | grep -q "AI Review: NEEDS WORK"; then
+            echo "::error::AIレビューで問題または改善提案があります。修正してください。"
+            exit 1
+          fi
+          echo "AIレビュー: PASS"


### PR DESCRIPTION
## 概要

AIレビューで問題・改善提案がある場合にCIチェックをfailさせる `review-gate` ジョブを追加。

## 変更内容

- `auto-approve.yml` に `review-gate` ジョブを追加
- `review-and-label` ジョブ完了後に `AI Review: NEEDS WORK` ラベルをチェック
- ラベルが存在する場合は `exit 1` でジョブを fail させる

## 手動設定（マージ後に必要）

GitHub Settings → Branches → Branch protection rules で `Review Gate` を required status check に追加する。

## テスト

- [ ] NEEDS WORK ラベル付きPRで review-gate が fail することを確認
- [ ] PASS ラベル付きPRで review-gate が pass することを確認

## 関連Issue

Closes #692