### PR TITLE
fix: PRレビュー時にGitHubレビューコメントの確認を必須化するガードレール #559

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -392,7 +392,7 @@ PRマージは CI（GitHub Actions auto-approve workflow）のみが行う。Cla
 
 1. 実装エージェントが PR を作成（**マージはしない**）
 2. code-reviewer エージェントが PR をレビュー
-3. **GitHub レビューコメントを確認**（必須）: `gh pr view <PR番号> --json reviews,reviewRequests` を実行し、GitHub 側のレビューコメントをすべて取得する
+3. **GitHub レビューコメントを確認**（必須）: `gh pr view <PR番号> --json reviews,reviewRequests` および `gh pr view <PR番号> --comments` を実行し、GitHub 側のレビューコメントをすべて取得する（詳細は「GitHub レビューコメント確認ルール」を参照）
 4. ローカルレビューと GitHub レビューの両方で指摘が1つでもあれば **該当 PR 内で** 全て修正 → 再 push → 再レビュー
 5. 全件 PASS になるまで 4 を繰り返す
 6. CI（auto-approve.yml）が自動で Approve → マージ
@@ -459,7 +459,7 @@ coder (実装)
   ├── コミット・push・PR作成（/finish スキル）
   ├── Agent(code-reviewer) を起動（/review/code-review スキル）
   │     └── レビュー結果を返す
-  ├── gh pr view <PR番号> --json reviews,reviewRequests でGitHub レビューを確認（必須）
+  ├── gh pr view <PR番号> --json reviews,reviewRequests && gh pr view <PR番号> --comments でGitHub レビューを確認（必須）
   ├── 問題・改善提案が1つでもあれば → 全て修正→再push→再レビュー（0件になるまで繰り返す）
   └── 全件 PASS を確認して報告（マージは CI が自動で行う）
 ```


### PR DESCRIPTION
## 概要

ローカルの code-reviewer エージェントのレビューだけで完了とみなし、GitHub CI が投稿したレビューコメントを無視していた問題を修正する。

## 変更内容

- CLAUDE.md のマージフロー「フロー」セクションに GitHub レビューコメント確認ステップを追加
- `gh pr view <PR番号> --json reviews,reviewRequests` の実行を必須化
- 改善提案（💡）・軽微な問題（🟡）も含め全指摘修正必須のルールを明記
- 「GitHub レビューコメント確認ルール」セクションを新設
- 実装→レビュー→マージフロー図に GitHub レビュー確認ステップを追加

## テスト

- [ ] Unit テスト追加・更新済み
- [ ] Integration テスト追加・更新済み
- [ ] カバレッジ 80% 以上を確認済み
- [ ] `pnpm test` がすべてパスすること
- [ ] `pnpm lint` がエラーなしで通ること

> 本変更はドキュメント（CLAUDE.md）のみの変更のため TDD 対象外。

## 関連Issue

Closes #559