### PR TITLE
fix: pass -Duser.home to ZAP JVM via JAVA_TOOL_OPTIONS #723

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
               echo "<version>${"$"}{version_tag}</version>" >> "\$ZAP_HOME/config.xml"
               tail -n +3 $out/share/zap/xml/config.xml >> "\$ZAP_HOME/config.xml"
             fi
-            export JAVA_TOOL_OPTIONS="\${JAVA_TOOL_OPTIONS:-} -Duser.home=\$HOME"
+            export JAVA_TOOL_OPTIONS="\${"$"}{JAVA_TOOL_OPTIONS:-} -Duser.home=\$HOME"
             exec "$out/share/zap/zap.sh" "\$@"
             WRAPPER
 


### PR DESCRIPTION
## 概要

ZAPのJavaプロセスがHOME環境変数を無視し、JVMの`user.home`プロパティ（デフォルト`/home/runner`）を使うため、CIでPermission deniedが発生していた。`JAVA_TOOL_OPTIONS`で`-Duser.home`を渡すことで解決。

## 変更内容

- flake.nix のZAPラッパーに `JAVA_TOOL_OPTIONS` で `-Duser.home=$HOME` を設定

## テスト

- [x] CI/インフラ変更のためTDD対象外

## 関連Issue

Closes #723