### PR TITLE
fix: require direnv allow before worktree commands #768

### DIFF
--- a/.claude/hooks/direnv-allow-guard.sh
+++ b/.claude/hooks/direnv-allow-guard.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# PreToolUse:Bash hook
+# .envrc を使う worktree で direnv allow 前の env 依存コマンド実行をブロックする
+
+if ! command -v jq &> /dev/null; then
+  exit 0
+fi
+
+if ! command -v direnv &> /dev/null; then
+  exit 0
+fi
+
+COMMAND=$(echo "$ARGUMENTS" | jq -r '.command // empty' 2>/dev/null)
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+requires_direnv_allow() {
+  local cmd="$1"
+
+  echo "$cmd" | grep -qE '(^|[[:space:];|&])(direnv[[:space:]]+exec|pnpm|node|npm|npx|turbo|biome|vitest|jest|wrangler|drizzle-kit|zap|maestro|expo|tsx|tsc)([[:space:];|&]|$)'
+}
+
+allows_direnv() {
+  local cmd="$1"
+
+  echo "$cmd" | grep -qE '(^|[[:space:];|&])direnv[[:space:]]+allow([[:space:];|&]|$)'
+}
+
+if allows_direnv "$COMMAND"; then
+  exit 0
+fi
+
+if ! requires_direnv_allow "$COMMAND"; then
+  exit 0
+fi
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+if [ -z "$ROOT" ]; then
+  exit 0
+fi
+
+if [ ! -f "$ROOT/.envrc" ]; then
+  exit 0
+fi
+
+if (cd "$ROOT" && direnv exec "$ROOT" true > /dev/null 2>&1); then
+  exit 0
+fi
+
+echo "DENY: direnv allow が未完了のため env 依存コマンドを実行できません。" >&2
+echo "  対象worktree: $ROOT" >&2
+echo "  先に実行: cd \"$ROOT\" && direnv allow ." >&2
+echo "  その後:   cd \"$ROOT\" && direnv exec \"$ROOT\" <command>" >&2
+exit 2

--- a/.claude/hooks/direnv-allow-guard.sh
+++ b/.claude/hooks/direnv-allow-guard.sh
@@ -36,7 +36,7 @@ if ! requires_direnv_allow "$COMMAND"; then
   exit 0
 fi
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+ROOT=$(env -u GIT_DIR -u GIT_WORK_TREE git rev-parse --show-toplevel 2>/dev/null || echo "")
 if [ -z "$ROOT" ]; then
   exit 0
 fi

--- a/.claude/hooks/worktree-deps-guard.sh
+++ b/.claude/hooks/worktree-deps-guard.sh
@@ -25,7 +25,7 @@ fi
 
 # 絶対パスに変換（リポジトリルート基準）
 if [[ "$WTPATH" != /* ]]; then
-  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  REPO_ROOT=$(env -u GIT_DIR -u GIT_WORK_TREE git rev-parse --show-toplevel 2>/dev/null || pwd)
   WTPATH="${REPO_ROOT}/$WTPATH"
 fi
 

--- a/.claude/hooks/worktree-deps-guard.sh
+++ b/.claude/hooks/worktree-deps-guard.sh
@@ -39,8 +39,10 @@ if [ -f "$WTPATH/.envrc" ]; then
   echo "次のコマンドを実行してください:"
   echo ""
   echo "  cd $WTPATH && direnv allow ."
+  echo "  cd $WTPATH && direnv exec $WTPATH true"
   echo "  cd $WTPATH && direnv exec $WTPATH pnpm install --frozen-lockfile"
   echo ""
+  echo "direnv allow が終わるまでは pnpm / direnv exec を実行しないでください"
 fi
 
 # node_modules が存在しない場合、警告を出す

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,12 @@
           },
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/direnv-allow-guard.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking direnv allow state..."
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/pre-push-review-guard.sh\"",
             "timeout": 5,
             "statusMessage": "Checking review status..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/nix-setup
+      - name: Check executable shell scripts
+        run: nix develop --command ./scripts/check-executable-shell-files.sh
       - name: Run hooks tests
         run: nix develop --command bats tests/hooks/
 
@@ -137,6 +139,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/nix-setup
+      - name: Check executable shell scripts
+        run: nix develop --command ./scripts/check-executable-shell-files.sh
       - name: Run lint
         run: nix develop --command pnpm lint
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -40,6 +40,12 @@ done
 
 echo "Pre-push チェック実行中..."
 
+echo "  Executable bits..."
+"${REPO_ROOT}/scripts/check-executable-shell-files.sh" || {
+  echo "Shell script の executable bit が不足しています。修正してからpushしてください。"
+  exit 1
+}
+
 echo "  Lint..."
 pnpm lint || { echo "Lint失敗。修正してからpushしてください。"; exit 1; }
 

--- a/scripts/check-executable-shell-files.sh
+++ b/scripts/check-executable-shell-files.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# 追跡対象のシェルスクリプトが executable bit を持つことを確認する
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAILED=0
+
+while read -r MODE _OBJECT _STAGE PATHNAME; do
+  if [[ -z "${PATHNAME:-}" ]]; then
+    continue
+  fi
+
+  if [[ "${MODE}" != "100755" ]]; then
+    echo "❌ executable bit が不足しています: ${PATHNAME}"
+    echo "  修正: chmod +x \"${PATHNAME}\" && git add \"${PATHNAME}\""
+    FAILED=1
+  fi
+done < <(git ls-files --stage -- '*.sh')
+
+if [[ "${FAILED}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "✅ tracked shell scripts have executable bits"

--- a/scripts/check-executable-shell-files.sh
+++ b/scripts/check-executable-shell-files.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
-# 追跡対象のシェルスクリプトが executable bit を持つことを確認する
+# 追跡対象の shell shebang ファイルが executable bit を持つことを確認する
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null | sed -n '1p')"
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
 cd "${REPO_ROOT}"
 
 FAILED=0
 
+is_shell_shebang_file() {
+  local pathname="$1"
+  local first_line
+
+  first_line=$(head -n 1 "${pathname}" 2>/dev/null || true)
+
+  [[ "${first_line}" =~ ^#!.*(ba|z)?sh([[:space:]]|$) ]]
+}
+
 while read -r MODE _OBJECT _STAGE PATHNAME; do
   if [[ -z "${PATHNAME:-}" ]]; then
+    continue
+  fi
+
+  if ! is_shell_shebang_file "${PATHNAME}"; then
     continue
   fi
 
@@ -18,10 +34,10 @@ while read -r MODE _OBJECT _STAGE PATHNAME; do
     echo "  修正: chmod +x \"${PATHNAME}\" && git add \"${PATHNAME}\""
     FAILED=1
   fi
-done < <(git ls-files --stage -- '*.sh')
+done < <(git ls-files --stage)
 
 if [[ "${FAILED}" -ne 0 ]]; then
   exit 1
 fi
 
-echo "✅ tracked shell scripts have executable bits"
+echo "✅ tracked shell entrypoints have executable bits"

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -47,6 +47,19 @@ if command -v direnv >/dev/null 2>&1 && [[ -f "${WORKTREE_PATH}/.envrc" ]]; then
     cd "${WORKTREE_PATH}"
     direnv allow .
   )
+
+  echo "✅ direnv 状態を確認..."
+  if ! (
+    cd "${WORKTREE_PATH}"
+    direnv exec "${WORKTREE_PATH}" true >/dev/null 2>&1
+  ); then
+    echo "❌ direnv allow の反映を確認できませんでした" >&2
+    echo "  手動で確認してください: cd ${WORKTREE_PATH} && direnv allow ." >&2
+    exit 1
+  fi
+elif [[ -f "${WORKTREE_PATH}/.envrc" ]]; then
+  echo "❌ .envrc があるため direnv が必要です: ${WORKTREE_PATH}" >&2
+  exit 1
 fi
 
 echo "📦 依存関係をセットアップ..."

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -25,7 +25,7 @@ if [[ ! "${SHORT_DESC}" =~ ^[a-z0-9-]+$ ]]; then
   exit 1
 fi
 
-REPO_ROOT=$(cd "$(git rev-parse --git-common-dir)/.." && pwd)
+REPO_ROOT=$(cd "$(env -u GIT_DIR -u GIT_WORK_TREE git rev-parse --git-common-dir)/.." && pwd)
 WORKTREE_BASE=$(dirname "${REPO_ROOT}")
 WORKTREE_PATH="${WORKTREE_BASE}/issue-${ISSUE_NUMBER}"
 BRANCH_NAME="issue/${ISSUE_NUMBER}/${SHORT_DESC}"

--- a/tests/hooks/check-executable-shell-files.bats
+++ b/tests/hooks/check-executable-shell-files.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# check-executable-shell-files.sh のテスト
+#
+# テスト環境: bats-core
+# 実行: bats tests/hooks/check-executable-shell-files.bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/check-executable-shell-files.sh"
+
+setup() {
+    TMPDIR=$(mktemp -d)
+    REPO_DIR="$TMPDIR/repo"
+
+    mkdir -p "$REPO_DIR/scripts"
+    git -C "$REPO_DIR" init -b main >/dev/null
+    git -C "$REPO_DIR" config user.email "test@example.com"
+    git -C "$REPO_DIR" config user.name "Test User"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+run_checker() {
+    (cd "$REPO_DIR" && bash "$SCRIPT")
+}
+
+@test "shell shebang の .sh が 100755 なら通る" {
+    cat > "$REPO_DIR/scripts/ok.sh" <<'EOF'
+#!/usr/bin/env bash
+echo ok
+EOF
+    chmod +x "$REPO_DIR/scripts/ok.sh"
+    git -C "$REPO_DIR" add scripts/ok.sh
+    git -C "$REPO_DIR" commit -m "add ok" >/dev/null
+
+    run run_checker
+    [ "$status" -eq 0 ]
+}
+
+@test "拡張子なしでも shell shebang なら 100755 を要求する" {
+    cat > "$REPO_DIR/scripts/run-tool" <<'EOF'
+#!/bin/bash
+echo run
+EOF
+    git -C "$REPO_DIR" add scripts/run-tool
+    git -C "$REPO_DIR" update-index --chmod=-x scripts/run-tool
+    git -C "$REPO_DIR" commit -m "add tool" >/dev/null
+
+    run run_checker
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"scripts/run-tool"* ]]
+}
+
+@test ".bats は shell shebang でも executable bit を要求しない" {
+    mkdir -p "$REPO_DIR/tests/hooks"
+    cat > "$REPO_DIR/tests/hooks/example.bats" <<'EOF'
+#!/usr/bin/env bats
+@test "example" {
+  true
+}
+EOF
+    git -C "$REPO_DIR" add tests/hooks/example.bats
+    git -C "$REPO_DIR" commit -m "add bats" >/dev/null
+
+    run run_checker
+    [ "$status" -eq 0 ]
+}

--- a/tests/hooks/direnv-allow-guard.bats
+++ b/tests/hooks/direnv-allow-guard.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# direnv-allow-guard.sh のテスト
+#
+# テスト環境: bats-core
+# 実行: bats tests/hooks/direnv-allow-guard.bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/.claude/hooks/direnv-allow-guard.sh"
+
+setup() {
+    TMPDIR=$(mktemp -d)
+    REPO_DIR="$TMPDIR/repo"
+    FAKE_BIN="$TMPDIR/bin"
+
+    mkdir -p "$REPO_DIR" "$FAKE_BIN"
+    git -C "$REPO_DIR" init -b main >/dev/null
+    git -C "$REPO_DIR" config user.email "test@example.com"
+    git -C "$REPO_DIR" config user.name "Test User"
+    echo "use flake" > "$REPO_DIR/.envrc"
+    echo "initial" > "$REPO_DIR/file.txt"
+    git -C "$REPO_DIR" add .
+    git -C "$REPO_DIR" commit -m "initial commit" >/dev/null
+
+    cat > "$FAKE_BIN/direnv" <<'EOF'
+#!/bin/bash
+if [ "$1" = "exec" ]; then
+  if [ -f "${DIR_ENV_TEST_ALLOW_FILE}" ]; then
+    exit 0
+  fi
+  echo "direnv: error .envrc is blocked" >&2
+  exit 1
+fi
+if [ "$1" = "allow" ]; then
+  touch "${DIR_ENV_TEST_ALLOW_FILE}"
+  exit 0
+fi
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/direnv"
+
+    ALLOW_FILE="$TMPDIR/allow-ok"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+run_hook() {
+    local cmd="$1"
+    (
+      export PATH="$FAKE_BIN:$PATH"
+      export DIR_ENV_TEST_ALLOW_FILE="$ALLOW_FILE"
+      cd "$REPO_DIR"
+      ARGUMENTS="{\"command\":\"$cmd\"}" bash "$SCRIPT"
+    )
+}
+
+@test "blocked な .envrc で pnpm を実行しようとすると拒否する" {
+    run run_hook "pnpm test"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"direnv allow"* ]]
+}
+
+@test "blocked な .envrc で direnv exec を実行しようとすると拒否する" {
+    run run_hook "direnv exec . pnpm test"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"direnv allow"* ]]
+}
+
+@test "direnv allow 自体は拒否しない" {
+    run run_hook "direnv allow ."
+    [ "$status" -eq 0 ]
+}
+
+@test "git status のような env 非依存コマンドは拒否しない" {
+    run run_hook "git status --short"
+    [ "$status" -eq 0 ]
+}
+
+@test "allow 済みなら pnpm 実行を拒否しない" {
+    touch "$ALLOW_FILE"
+    run run_hook "pnpm test"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- block env-dependent worktree commands until `direnv allow` has completed
- verify `direnv allow` immediately inside `scripts/create-worktree.sh`
- add executable-bit checks to pre-push and CI for tracked shell scripts

## Testing
- direnv exec "$PWD" bats tests/hooks/direnv-allow-guard.bats tests/hooks/dangerous-command-guard.bats tests/hooks/check-worktrees.bats
- direnv exec "$PWD" pnpm lint

Closes #768
