### PR TITLE
fix: claude コマンドが nix develop で実行できない問題を修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ bash ./.codex/run-stop.sh
 - 詳細な実装ルール: [`.claude/rules/`](./.claude/rules)
 - 既存 hook 実装: [`.claude/hooks/`](./.claude/hooks)
 
+## エージェント使用ルール
+
+エージェントを使う場合は `.claude/agents/` 配下で定義されたもののみを使用する。
+oh-my-claudecode やその他のプラグイン由来のエージェントは使用しない。
+
 ## 絶対ルール
 
 - GitHub Issue がない状態で作業を始めない

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,39 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
+        # claude: shellHook の command -v に頼らず、呼び出し時に検出するラッパー
+        # HOME を .claude-isolated に差し替えて ~/.claude/CLAUDE.md を隠す（OMC 分離）
+        # CLAUDE_CONFIG_DIR は shellHook で設定済みのものを引き継ぐ（二重設定しない）
+        claude-wrapper = pkgs.writeShellScriptBin "claude" ''
+          _root=$(git rev-parse --show-toplevel 2>/dev/null)
+          if [ -z "$_root" ]; then
+            echo "claude-wrapper: git リポジトリ外では実行できません" >&2
+            exit 1
+          fi
+          mkdir -p "$_root/.claude-isolated/.claude"
+          # 自分自身を呼び出す再帰ループを防ぐため、ラッパー自身のパスを取得
+          _self=$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")
+          for _dir in \
+            "/opt/homebrew/bin" \
+            "$HOME/.npm/bin" \
+            "$HOME/.npm-global/bin" \
+            "''${NVM_BIN:-}" \
+            "''${VOLTA_HOME:-$HOME/.volta}/bin" \
+            "''${PNPM_HOME:-}" \
+            "$HOME/.local/bin" \
+            "/usr/local/bin" \
+            "/usr/bin"; do
+            [ -n "$_dir" ] || continue
+            [ -x "$_dir/claude" ] || continue
+            _candidate=$(readlink -f "$_dir/claude" 2>/dev/null || echo "$_dir/claude")
+            [ "$_candidate" = "$_self" ] && continue
+            exec env HOME="$_root/.claude-isolated" \
+              "$_dir/claude" "$@"
+          done
+          echo "claude: not found. Install: pnpm add -g @anthropic-ai/claude-code" >&2
+          exit 127
+        '';
+
         # OWASP ZAP: クロスプラットフォーム版で macOS/Linux 両対応
         zap = pkgs.stdenv.mkDerivation {
           pname = "zap";
@@ -80,6 +113,7 @@
             maestro
             zap
             bats
+            claude-wrapper
           ];
 
           shellHook = ''
@@ -95,28 +129,6 @@
                   cp "$f" "$CLAUDE_USER_DIR/" 2>/dev/null || true
                 fi
               done
-            fi
-
-            # OMC 分離: claude プロセスの HOME を差し替えて ~/.claude/CLAUDE.md を見えなくする
-            # - HOME 変更は claude プロセスのみに限定され、現在のシェルには影響しない
-            # - ~/.claude/CLAUDE.md  → 読み込まれない（HOME が偽装されているため）
-            # - .claude-user/        → CLAUDE_CONFIG_DIR 経由で auth/settings が読み込まれる
-            # - プロジェクト CLAUDE.md → CWD ベースなので影響なし
-            # bash/zsh/fish すべてで動作するようシェル関数ではなくラッパースクリプトを PATH に置く
-            _CLAUDE_REAL=$(command -v claude 2>/dev/null || echo "")
-            if [ -n "$_CLAUDE_REAL" ]; then
-              _CLAUDE_FAKE_HOME="$PWD/.claude-isolated"
-              # .claude/ は空でよい（settings は CLAUDE_CONFIG_DIR 経由で読み込まれる）
-              mkdir -p "$_CLAUDE_FAKE_HOME/.claude"
-              _CLAUDE_WRAPPER_BIN="$_CLAUDE_FAKE_HOME/bin"
-              mkdir -p "$_CLAUDE_WRAPPER_BIN"
-              cat > "$_CLAUDE_WRAPPER_BIN/claude" <<WRAPPER
-#!/usr/bin/env bash
-exec env HOME="$_CLAUDE_FAKE_HOME" "$_CLAUDE_REAL" "\$@"
-WRAPPER
-              chmod +x "$_CLAUDE_WRAPPER_BIN/claude"
-              export PATH="$_CLAUDE_WRAPPER_BIN:$PATH"
-              unset _CLAUDE_REAL _CLAUDE_FAKE_HOME _CLAUDE_WRAPPER_BIN
             fi
 
             # eas-cli は nixpkgs にないため npx ラッパーで提供


### PR DESCRIPTION
## Summary

- `nix develop` 環境で `claude` コマンドが実行できない問題を修正
- `shellHook` の bash 実行タイミングでは fish/nvm/fnm 等のパスが未設定であるため `command -v claude` が空になる根本原因を解消
- `pkgs.writeShellScriptBin` で nix パッケージとして `claude-wrapper` を作成し、コマンド呼び出し時（実行時）にパスを検索するよう変更
- エージェント使用ルールを `CLAUDE.md` に追加（`.claude/agents/` 配下のみ使用）

## Changes

- `flake.nix`: `claude-wrapper` nix derivation を追加、`shellHook` の bash 依存コードを削除
- `AGENTS.md` / `CLAUDE.md`: エージェント使用ルールを追記

## Test plan

- [ ] `nix develop` 後に `claude --version` が実行できることを確認
- [ ] git リポジトリ外で `claude` を実行するとエラーメッセージが出ることを確認
- [ ] `nix develop` 環境でのホーム分離（`.claude-isolated`）が機能することを確認

Closes #770