### PR TITLE
fix: main-edit-guard.sh の GIT_DIR 汚染による誤判定を修正

### DIFF
--- a/.claude/hooks/dangerous-command-guard.sh
+++ b/.claude/hooks/dangerous-command-guard.sh
@@ -35,7 +35,7 @@ check_worktree_path() {
     echo "⚠️ 未展開の変数が含まれています。絶対パスに展開してから実行してください"
     return 0
   fi
-  repo_root=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." && pwd)
+  repo_root=$(cd "$(env -u GIT_DIR -u GIT_WORK_TREE git rev-parse --git-common-dir 2>/dev/null)/.." && pwd)
   local worktree_base
   worktree_base=$(dirname "$repo_root")
   expected_prefix="${worktree_base}/"
@@ -101,7 +101,7 @@ check_dangerous() {
   if echo "$cmd" | grep -qE "git checkout [^-]"; then
     local target
     target=$(echo "$cmd" | sed 's/.*git checkout //; s/ *[&|;].*//')
-    if ! git rev-parse --verify "$target" &>/dev/null; then
+    if ! env -u GIT_DIR -u GIT_WORK_TREE git rev-parse --verify "$target" &>/dev/null; then
       return 0
     fi
   fi

--- a/.claude/hooks/main-edit-guard.sh
+++ b/.claude/hooks/main-edit-guard.sh
@@ -3,12 +3,12 @@
 # PreToolUse (Edit, Write) で実行される
 set -euo pipefail
 
-ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+ROOT=$(env -u GIT_DIR -u GIT_WORK_TREE git rev-parse --show-toplevel 2>/dev/null || echo "")
 if [ -z "$ROOT" ]; then
   exit 0
 fi
 
-CURRENT_BRANCH=$(git -C "$ROOT" branch --show-current 2>/dev/null || echo "")
+CURRENT_BRANCH=$(env -u GIT_DIR -u GIT_WORK_TREE git -C "$ROOT" branch --show-current 2>/dev/null || echo "")
 
 if [ "$CURRENT_BRANCH" = "main" ]; then
   TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"


### PR DESCRIPTION
## Summary
- main-edit-guard.sh の全 git コマンドに env -u GIT_DIR -u GIT_WORK_TREE を追加
- dangerous-command-guard.sh の全 git コマンドも同様に修正

## Test plan
- [ ] worktree内でEdit/Writeが正常に通過することを確認
- [ ] mainブランチでEditを試みると正しくブロックされることを確認

Closes #742

🤖 Generated with [Claude Code](https://claude.ai/code)