### PR TITLE
feat: クローズ済みPRのworktreeをSessionStart hookで自動削除する #776

### DIFF
--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -72,7 +72,10 @@ while IFS= read -r wt_path; do
     fi
 
     # 未コミットの変更がある場合はスキップ
-    DIRTY=$(git -C "$wt_path" status --porcelain 2>/dev/null | grep -v '^??' | head -1)
+    DIRTY_OUTPUT=$(git -C "$wt_path" status --porcelain 2>/dev/null)
+    DIRTY_EXIT=$?
+    [ "$DIRTY_EXIT" -ne 0 ] && continue
+    DIRTY=$(echo "$DIRTY_OUTPUT" | grep -v '^??' | head -1)
     [ -n "$DIRTY" ] && continue
 
     branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
@@ -98,9 +101,9 @@ if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
 
     # リポジトリ特定できない場合はPass 1bをスキップ（不明なリポジトリへの誤操作を防ぐ）
     if [ -n "$REPO_SLUG" ]; then
-    # 削除後に最新のworktreeリストを取得
-    WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
-    while IFS= read -r wt_path; do
+        # 削除後に最新のworktreeリストを取得
+        WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
+        while IFS= read -r wt_path; do
         [ -z "$wt_path" ] && continue
         [ -d "$wt_path" ] || continue
         resolved_wt_path=$(cd "$wt_path" && pwd -P)

--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -69,24 +69,37 @@ while IFS= read -r wt_path; do
     [ -n "$DIRTY" ] && continue
 
     branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
-    wt_name=$(basename "$wt_path")
-    if git worktree remove --force "$wt_path" 2>/dev/null; then
-        if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
-            git branch -D "$branch" 2>/dev/null || true
-        fi
-        REMOVED_COUNT=$((REMOVED_COUNT + 1))
-        REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}"
+    if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+        continue
     fi
+    wt_name=$(basename "$wt_path")
+    if git worktree remove "$wt_path" 2>/dev/null; then
+        : # 成功
+    elif git worktree remove --force "$wt_path" 2>/dev/null; then
+        : # 強制削除成功
+    else
+        continue  # 削除できない場合はスキップ
+    fi
+    if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+        git branch -D "$branch" 2>/dev/null || true
+    fi
+    REMOVED_COUNT=$((REMOVED_COUNT + 1))
+    REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}"
 done <<< "$WORKTREE_PATHS"
 
 # Pass 1b: クローズ済みPR（マージなし）のworktreeを自動削除
 # gh コマンドが使えない・未認証の場合はスキップ（graceful degradation）
-if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
     # リポジトリを動的に取得（gh コマンドのスコープを限定）
     REPO_SLUG=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 
+    # リポジトリ特定できない場合はPass 1bをスキップ（不明なリポジトリへの誤操作を防ぐ）
+    if [ -z "$REPO_SLUG" ]; then
+        WORKTREE_PATHS_1B=""
+    else
     # 削除後に最新のworktreeリストを取得
     WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
+    fi
     while IFS= read -r wt_path; do
         [ -z "$wt_path" ] && continue
         [ -d "$wt_path" ] || continue
@@ -107,11 +120,7 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
         fi
 
         # PRがクローズされているか確認（stateがCLOSED、mergedAtがnull）
-        if [ -n "$REPO_SLUG" ]; then
-            pr_state=$(gh pr list --repo "$REPO_SLUG" --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
-        else
-            pr_state=$(gh pr list --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
-        fi
+        pr_state=$(gh pr list --repo "$REPO_SLUG" --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
         if [ "$pr_state" != "CLOSED" ]; then
             continue
         fi
@@ -130,13 +139,18 @@ if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
             continue
         fi
 
-        if git worktree remove --force "$wt_path" 2>/dev/null; then
-            if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
-                git branch -D "$branch" 2>/dev/null || true
-            fi
-            REMOVED_COUNT=$((REMOVED_COUNT + 1))
-            REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}(closed)"
+        if git worktree remove "$wt_path" 2>/dev/null; then
+            : # 成功
+        elif git worktree remove --force "$wt_path" 2>/dev/null; then
+            : # 強制削除成功
+        else
+            continue  # 削除できない場合はスキップ
         fi
+        if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+            git branch -D "$branch" 2>/dev/null || true
+        fi
+        REMOVED_COUNT=$((REMOVED_COUNT + 1))
+        REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}(closed)"
     done <<< "$WORKTREE_PATHS_1B"
 fi
 
@@ -176,8 +190,12 @@ while IFS= read -r wt_path; do
     GIT_DIR=""
     if [ -f "$wt_path/.git" ]; then
         GIT_DIR=$(sed 's/^gitdir: //' "$wt_path/.git")
+        # パストラバーサル防止: gitdir に .. が含まれる場合は無効化
+        case "$GIT_DIR" in
+            *".."*) GIT_DIR="" ;;
+        esac
         # 相対パスを絶対パスに解決
-        if [[ "$GIT_DIR" != /* ]]; then
+        if [ -n "$GIT_DIR" ] && [[ "$GIT_DIR" != /* ]]; then
             GIT_DIR="$wt_path/$GIT_DIR"
         fi
     elif [ -d "$wt_path/.git" ]; then

--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -104,51 +104,51 @@ if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
         # 削除後に最新のworktreeリストを取得
         WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
         while IFS= read -r wt_path; do
-        [ -z "$wt_path" ] && continue
-        [ -d "$wt_path" ] || continue
-        resolved_wt_path=$(cd "$wt_path" && pwd -P)
+            [ -z "$wt_path" ] && continue
+            [ -d "$wt_path" ] || continue
+            resolved_wt_path=$(cd "$wt_path" && pwd -P)
 
-        # WORKTREE_BASE直下でない（ネストworktree・不正パス）はスキップ
-        [[ "$resolved_wt_path" != "${EXPECTED_PREFIX}"* ]] && continue
-        [[ "$resolved_wt_path" == "${REPO_ROOT}" || "$resolved_wt_path" == "${REPO_ROOT}/"* ]] && continue
+            # WORKTREE_BASE直下でない（ネストworktree・不正パス）はスキップ
+            [[ "$resolved_wt_path" != "${EXPECTED_PREFIX}"* ]] && continue
+            [[ "$resolved_wt_path" == "${REPO_ROOT}" || "$resolved_wt_path" == "${REPO_ROOT}/"* ]] && continue
 
-        branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
-        if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
-            continue
-        fi
+            branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+            if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+                continue
+            fi
 
-        # ブランチ名のバリデーション（英数字、ハイフン、スラッシュ、アンダースコア、ドットのみ許可）
-        if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
-            continue
-        fi
+            # ブランチ名のバリデーション（英数字、ハイフン、スラッシュ、アンダースコア、ドットのみ許可）
+            if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+                continue
+            fi
 
-        # PRがクローズされているか確認（stateがCLOSED、mergedAtがnull）
-        pr_state=$(gh pr list --repo "$REPO_SLUG" --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
-        if [ "$pr_state" != "CLOSED" ]; then
-            continue
-        fi
+            # PRがクローズされているか確認（stateがCLOSED、mergedAtがnull）
+            pr_state=$(gh pr list --repo "$REPO_SLUG" --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
+            if [ "$pr_state" != "CLOSED" ]; then
+                continue
+            fi
 
-        wt_name=$(basename "$wt_path")
-        # 未コミットの変更がある場合はスキップして警告
-        DIRTY_OUTPUT=$(git -C "$wt_path" status --porcelain 2>/dev/null)
-        DIRTY_EXIT=$?
-        if [ "$DIRTY_EXIT" -ne 0 ]; then
-            continue  # git status 失敗時はスキップ（安全側に倒す）
-        fi
-        DIRTY=$(echo "$DIRTY_OUTPUT" | grep -v '^??' | head -1)
-        if [ -n "$DIRTY" ]; then
-            PROBLEMS="${PROBLEMS}[クローズ済みPR] ${wt_name}: PRはクローズ済みだが未コミットの変更がある -> 変更を確認してから手動で削除: git worktree remove ${wt_path} | "
-            PROBLEM_COUNT=$((PROBLEM_COUNT + 1))
-            continue
-        fi
+            wt_name=$(basename "$wt_path")
+            # 未コミットの変更がある場合はスキップして警告
+            DIRTY_OUTPUT=$(git -C "$wt_path" status --porcelain 2>/dev/null)
+            DIRTY_EXIT=$?
+            if [ "$DIRTY_EXIT" -ne 0 ]; then
+                continue  # git status 失敗時はスキップ（安全側に倒す）
+            fi
+            DIRTY=$(echo "$DIRTY_OUTPUT" | grep -v '^??' | head -1)
+            if [ -n "$DIRTY" ]; then
+                PROBLEMS="${PROBLEMS}[クローズ済みPR] ${wt_name}: PRはクローズ済みだが未コミットの変更がある -> 変更を確認してから手動で削除: git worktree remove ${wt_path} | "
+                PROBLEM_COUNT=$((PROBLEM_COUNT + 1))
+                continue
+            fi
 
-        remove_worktree_safely "$wt_path" || continue
-        if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
-            git branch -D "$branch" 2>/dev/null || true
-        fi
-        REMOVED_COUNT=$((REMOVED_COUNT + 1))
-        REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}(closed)"
-    done <<< "$WORKTREE_PATHS_1B"
+            remove_worktree_safely "$wt_path" || continue
+            if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+                git branch -D "$branch" 2>/dev/null || true
+            fi
+            REMOVED_COUNT=$((REMOVED_COUNT + 1))
+            REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}(closed)"
+        done <<< "$WORKTREE_PATHS_1B"
     fi  # [ -n "$REPO_SLUG" ]
 fi  # gh auth token
 

--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -79,6 +79,50 @@ while IFS= read -r wt_path; do
     fi
 done <<< "$WORKTREE_PATHS"
 
+# Pass 1b: クローズ済みPR（マージなし）のworktreeを自動削除
+# gh コマンドが使えない場合はスキップ（graceful degradation）
+if command -v gh >/dev/null 2>&1; then
+    # 削除後に最新のworktreeリストを取得
+    WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
+    while IFS= read -r wt_path; do
+        [ -z "$wt_path" ] && continue
+        [ -d "$wt_path" ] || continue
+        resolved_wt_path=$(cd "$wt_path" && pwd -P)
+
+        # WORKTREE_BASE直下でない（ネストworktree・不正パス）はスキップ
+        [[ "$resolved_wt_path" != "${EXPECTED_PREFIX}"* ]] && continue
+        [[ "$resolved_wt_path" == "${REPO_ROOT}" || "$resolved_wt_path" == "${REPO_ROOT}/"* ]] && continue
+
+        branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+        if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+            continue
+        fi
+
+        # PRがクローズされているか確認（stateがCLOSED、mergedAtがnull）
+        pr_state=$(gh pr list --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
+        if [ "$pr_state" != "CLOSED" ]; then
+            continue
+        fi
+
+        wt_name=$(basename "$wt_path")
+        # 未コミットの変更がある場合はスキップして警告
+        DIRTY=$(git -C "$wt_path" status --porcelain 2>/dev/null | grep -v '^??' | head -1)
+        if [ -n "$DIRTY" ]; then
+            PROBLEMS="${PROBLEMS}[クローズ済みPR] ${wt_name}: PRはクローズ済みだが未コミットの変更がある -> 変更を確認してから手動で削除: git worktree remove ${wt_path} | "
+            PROBLEM_COUNT=$((PROBLEM_COUNT + 1))
+            continue
+        fi
+
+        if git worktree remove --force "$wt_path" 2>/dev/null; then
+            if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
+                git branch -D "$branch" 2>/dev/null || true
+            fi
+            REMOVED_COUNT=$((REMOVED_COUNT + 1))
+            REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}(closed)"
+        fi
+    done <<< "$WORKTREE_PATHS_1B"
+fi
+
 # Pass 2: 残りのworktreeの健全性チェック（削除後に再取得）
 WORKTREE_PATHS=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
 

--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -80,8 +80,11 @@ while IFS= read -r wt_path; do
 done <<< "$WORKTREE_PATHS"
 
 # Pass 1b: クローズ済みPR（マージなし）のworktreeを自動削除
-# gh コマンドが使えない場合はスキップ（graceful degradation）
-if command -v gh >/dev/null 2>&1; then
+# gh コマンドが使えない・未認証の場合はスキップ（graceful degradation）
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    # リポジトリを動的に取得（gh コマンドのスコープを限定）
+    REPO_SLUG=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+
     # 削除後に最新のworktreeリストを取得
     WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
     while IFS= read -r wt_path; do
@@ -98,15 +101,29 @@ if command -v gh >/dev/null 2>&1; then
             continue
         fi
 
+        # ブランチ名のバリデーション（英数字、ハイフン、スラッシュ、アンダースコア、ドットのみ許可）
+        if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+            continue
+        fi
+
         # PRがクローズされているか確認（stateがCLOSED、mergedAtがnull）
-        pr_state=$(gh pr list --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
+        if [ -n "$REPO_SLUG" ]; then
+            pr_state=$(gh pr list --repo "$REPO_SLUG" --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
+        else
+            pr_state=$(gh pr list --head "$branch" --state closed --json state,mergedAt --jq '.[0] | select(.mergedAt == null) | .state' 2>/dev/null)
+        fi
         if [ "$pr_state" != "CLOSED" ]; then
             continue
         fi
 
         wt_name=$(basename "$wt_path")
         # 未コミットの変更がある場合はスキップして警告
-        DIRTY=$(git -C "$wt_path" status --porcelain 2>/dev/null | grep -v '^??' | head -1)
+        DIRTY_OUTPUT=$(git -C "$wt_path" status --porcelain 2>/dev/null)
+        DIRTY_EXIT=$?
+        if [ "$DIRTY_EXIT" -ne 0 ]; then
+            continue  # git status 失敗時はスキップ（安全側に倒す）
+        fi
+        DIRTY=$(echo "$DIRTY_OUTPUT" | grep -v '^??' | head -1)
         if [ -n "$DIRTY" ]; then
             PROBLEMS="${PROBLEMS}[クローズ済みPR] ${wt_name}: PRはクローズ済みだが未コミットの変更がある -> 変更を確認してから手動で削除: git worktree remove ${wt_path} | "
             PROBLEM_COUNT=$((PROBLEM_COUNT + 1))
@@ -201,7 +218,7 @@ done <<< "$WORKTREE_PATHS"
 # 結果を出力（削除情報 + 健全性チェック）
 SUMMARY=""
 if [ "$REMOVED_COUNT" -gt 0 ]; then
-    SUMMARY="マージ済みworktree ${REMOVED_COUNT}件を自動削除: ${REMOVED_NAMES} | "
+    SUMMARY="worktree ${REMOVED_COUNT}件を自動削除（マージ済みまたはクローズ済み）: ${REMOVED_NAMES} | "
 fi
 if [ "$PROBLEM_COUNT" -gt 0 ]; then
     SUMMARY="${SUMMARY}Worktree health: ${PROBLEM_COUNT} issues found. ${PROBLEMS}Fix before starting new issues."

--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -15,6 +15,13 @@
 PROBLEMS=""
 PROBLEM_COUNT=0
 
+# worktreeを安全に削除（通常削除→forceフォールバック）
+remove_worktree_safely() {
+    local wt_path="$1"
+    git worktree remove "$wt_path" 2>/dev/null && return 0
+    git worktree remove --force "$wt_path" 2>/dev/null
+}
+
 # git worktree list で全worktreeを取得（main以外）
 WORKTREE_PATHS=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
 
@@ -69,17 +76,12 @@ while IFS= read -r wt_path; do
     [ -n "$DIRTY" ] && continue
 
     branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    # 防御的バリデーション: 異常なブランチ名は処理対象外にする
     if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
         continue
     fi
     wt_name=$(basename "$wt_path")
-    if git worktree remove "$wt_path" 2>/dev/null; then
-        : # 成功
-    elif git worktree remove --force "$wt_path" 2>/dev/null; then
-        : # 強制削除成功
-    else
-        continue  # 削除できない場合はスキップ
-    fi
+    remove_worktree_safely "$wt_path" || continue
     if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
         git branch -D "$branch" 2>/dev/null || true
     fi
@@ -89,17 +91,15 @@ done <<< "$WORKTREE_PATHS"
 
 # Pass 1b: クローズ済みPR（マージなし）のworktreeを自動削除
 # gh コマンドが使えない・未認証の場合はスキップ（graceful degradation）
+# gh auth token を使用（gh auth status と異なりネットワークアクセスなしで認証確認可能）
 if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
     # リポジトリを動的に取得（gh コマンドのスコープを限定）
     REPO_SLUG=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
 
     # リポジトリ特定できない場合はPass 1bをスキップ（不明なリポジトリへの誤操作を防ぐ）
-    if [ -z "$REPO_SLUG" ]; then
-        WORKTREE_PATHS_1B=""
-    else
+    if [ -n "$REPO_SLUG" ]; then
     # 削除後に最新のworktreeリストを取得
     WORKTREE_PATHS_1B=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)
-    fi
     while IFS= read -r wt_path; do
         [ -z "$wt_path" ] && continue
         [ -d "$wt_path" ] || continue
@@ -139,20 +139,15 @@ if command -v gh >/dev/null 2>&1 && gh auth token >/dev/null 2>&1; then
             continue
         fi
 
-        if git worktree remove "$wt_path" 2>/dev/null; then
-            : # 成功
-        elif git worktree remove --force "$wt_path" 2>/dev/null; then
-            : # 強制削除成功
-        else
-            continue  # 削除できない場合はスキップ
-        fi
+        remove_worktree_safely "$wt_path" || continue
         if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then
             git branch -D "$branch" 2>/dev/null || true
         fi
         REMOVED_COUNT=$((REMOVED_COUNT + 1))
         REMOVED_NAMES="${REMOVED_NAMES:+${REMOVED_NAMES}, }${wt_name}(closed)"
     done <<< "$WORKTREE_PATHS_1B"
-fi
+    fi  # [ -n "$REPO_SLUG" ]
+fi  # gh auth token
 
 # Pass 2: 残りのworktreeの健全性チェック（削除後に再取得）
 WORKTREE_PATHS=$(git worktree list --porcelain 2>/dev/null | grep '^worktree ' | sed 's/^worktree //' | tail -n +2)


### PR DESCRIPTION
## Summary

- SessionStart hookの `check-worktrees.sh` にクローズ済みPR（マージなし）のworktreeを自動削除する機能を追加
- `gh` CLIを使いPRのstateを確認し、CLOSEDかつmergedAtがnullのブランチのworktreeを削除
- セキュリティ修正を5件実施（ブランチ名バリデーション、git status終了コードチェック、--repoフラグ、gh authチェック、サマリーメッセージ統一）

## Changes

- `.claude/hooks/check-worktrees.sh`: Pass 1bを追加（クローズ済みPR worktree自動削除）
  - ブランチ名バリデーション（英数字・ハイフン・スラッシュ・アンダースコア・ドットのみ許可）
  - `git status` 終了コードチェック（失敗時は安全側でスキップ）
  - `gh pr list` に `--repo` フラグ追加（スコープ限定）
  - `gh auth status` チェック追加（未認証時はgraceful degradation）
  - サマリーメッセージを「マージ済みまたはクローズ済み」に統一

## Test plan

- [ ] マージ済みworktreeが自動削除されること（既存機能）
- [ ] クローズ済みPR（マージなし）のworktreeが自動削除されること
- [ ] 未コミット変更があるクローズ済みworktreeは警告のみで削除されないこと
- [ ] `gh` 未インストール・未認証時はスキップされること
- [ ] 不正なブランチ名のworktreeはスキップされること

🤖 Generated with [Claude Code](https://claude.ai/code)