### PR TITLE
fix: check-worktrees.sh のreflogチェックがworktree固有のHEADを参照しているバグを修正

### DIFF
--- a/.claude/hooks/check-worktrees.sh
+++ b/.claude/hooks/check-worktrees.sh
@@ -65,9 +65,15 @@ while IFS= read -r wt_path; do
     # HEADがmain系参照の祖先でなければスキップ（未マージ）
     git -C "$REPO_ROOT" merge-base --is-ancestor "$wt_head" "$MAIN_REF" 2>/dev/null || continue
 
+    branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    # 防御的バリデーション: 異常なブランチ名は処理対象外にする
+    if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
+        continue
+    fi
+
     # branch作成直後の「まだ何も積んでいない worktree」は自動削除しない
     # main が先に進んだだけの branch まで掃除対象にすると behind 検知前に消えてしまう
-    if ! git -C "$wt_path" reflog --format='%gs' 2>/dev/null | grep -q '^commit:'; then
+    if ! git -C "$REPO_ROOT" reflog "refs/heads/$branch" --format='%gs' 2>/dev/null | grep -q '^commit:'; then
         continue
     fi
 
@@ -77,12 +83,6 @@ while IFS= read -r wt_path; do
     [ "$DIRTY_EXIT" -ne 0 ] && continue
     DIRTY=$(echo "$DIRTY_OUTPUT" | grep -v '^??' | head -1)
     [ -n "$DIRTY" ] && continue
-
-    branch=$(git -C "$wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null)
-    # 防御的バリデーション: 異常なブランチ名は処理対象外にする
-    if [[ ! "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
-        continue
-    fi
     wt_name=$(basename "$wt_path")
     remove_worktree_safely "$wt_path" || continue
     if [ -n "$branch" ] && [ "$branch" != "HEAD" ]; then


### PR DESCRIPTION
## Summary

- `check-worktrees.sh` Pass 1 のreflogチェックをworktree固有HEADからブランチreflogに変更
- 別worktreeでコミットした場合もマージ済みworktreeを正しく自動削除できるように修正
- `branch` 変数の抽出をreflogチェックより前に移動

## 原因

```bash
# 変更前: worktree固有のHEAD reflogを参照
git -C "$wt_path" reflog --format='%gs' | grep -q '^commit:'
```

別のworktreeでコミットした場合、このworktreeのHEAD reflogには `commit:` エントリが存在せず、マージ済みでも削除されなかった。

## 修正

```bash
# 変更後: ブランチreflogを参照
git -C "$REPO_ROOT" reflog "refs/heads/$branch" --format='%gs' | grep -q '^commit:'
```

## Test plan

- [ ] マージ済みworktreeが次回SessionStart時に自動削除されることを確認
- [ ] 別worktreeでコミットしたブランチでも正しく動作することを確認

Closes #782

🤖 Generated with [Claude Code](https://claude.ai/code)