### PR TITLE
fix: orchestrator-direct-edit-guard.sh のセキュリティ強化 #783

### DIFF
--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -25,10 +25,13 @@ if [ -z "$FILE_PATH" ]; then
 fi
 
 # シンボリックリンクや .. を正規化（ファイルが存在しなくても動作）
+# realpath -m が失敗した場合はブロック方向に倒す（未正規化パスを使わない）
 if [[ "$FILE_PATH" = /* ]]; then
-  FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+  FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null)
+  [ -z "$FILE_PATH" ] && exit 2
 else
-  FILE_PATH=$(realpath -m "$(pwd)/$FILE_PATH" 2>/dev/null || echo "$(pwd)/$FILE_PATH")
+  FILE_PATH=$(realpath -m "$(pwd)/$FILE_PATH" 2>/dev/null)
+  [ -z "$FILE_PATH" ] && exit 2
 fi
 
 # orchestratorが直接編集できないファイル（明示的ブロック対象）
@@ -36,9 +39,10 @@ is_blocked_file() {
   local path="$1"
 
   # .review-passed はレビュープロセスのみが作成する（orchestratorの迂回を防止）
-  echo "$path" | grep -qE "(^|/)\.claude/\.review-passed$" && return 0
+  # case-insensitive: macOS の大文字小文字を区別しないFSでの迂回を防止
+  echo "$path" | grep -iqE "(^|/)\.claude/\.review-passed$" && return 0
   # .omc/state/ は実行フロー状態ファイル（直接編集による動作操作を防止）
-  echo "$path" | grep -qE "(^|/)\.omc/state/" && return 0
+  echo "$path" | grep -iqE "(^|/)\.omc/state/" && return 0
 
   return 1
 }
@@ -56,7 +60,10 @@ is_orchestration_file() {
   echo "$path" | grep -qE "(^|/)\.env\.example$" && return 0
   echo "$path" | grep -qE "(^|/)turbo\.json$" && return 0
   # ルートの package.json のみ許可（apps/api/package.json 等のサブパッケージは除外）
-  echo "$path" | grep -qE "^(\./)?package\.json$" && return 0
+  # realpath -m で絶対パスに正規化されるため、git root との比較で判定する
+  local repo_root
+  repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || echo "")
+  [ -n "$repo_root" ] && [ "$path" = "$repo_root/package.json" ] && return 0
   echo "$path" | grep -qE "(^|/)pnpm-workspace\.yaml$" && return 0
 
   return 1

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -108,11 +108,13 @@ is_source_file() {
 if is_blocked_file "$FILE_PATH"; then
   echo "DENY: このファイルはorchestratorによる直接編集が禁止されています。" >&2
   echo "  対象ファイル: $FILE_PATH" >&2
+  shopt -s nocasematch
   if [[ "$FILE_PATH" == *"/.review-passed" ]]; then
     echo "  理由: レビュープロセスのみが作成可能なファイルです。" >&2
   else
     echo "  理由: 実行フロー状態ファイルです（直接編集による動作操作を防止）。" >&2
   fi
+  shopt -u nocasematch
   exit 2
 fi
 

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -51,20 +51,20 @@ is_blocked_file() {
 is_orchestration_file() {
   local path="$1"
 
-  echo "$path" | grep -qE "(^|/)\.claude/" && return 0
-  echo "$path" | grep -qE "(^|/)\.omc/" && return 0
-  echo "$path" | grep -qE "(^|/)CLAUDE\.md$" && return 0
-  echo "$path" | grep -qE "(^|/)AGENTS\.md$" && return 0
-  echo "$path" | grep -qE "(^|/)flake\.nix$" && return 0
-  echo "$path" | grep -qE "(^|/)\.gitignore$" && return 0
-  echo "$path" | grep -qE "(^|/)\.env\.example$" && return 0
-  echo "$path" | grep -qE "(^|/)turbo\.json$" && return 0
+  echo "$path" | grep -iqE "(^|/)\.claude/" && return 0
+  echo "$path" | grep -iqE "(^|/)\.omc/" && return 0
+  echo "$path" | grep -iqE "(^|/)CLAUDE\.md$" && return 0
+  echo "$path" | grep -iqE "(^|/)AGENTS\.md$" && return 0
+  echo "$path" | grep -iqE "(^|/)flake\.nix$" && return 0
+  echo "$path" | grep -iqE "(^|/)\.gitignore$" && return 0
+  echo "$path" | grep -iqE "(^|/)\.env\.example$" && return 0
+  echo "$path" | grep -iqE "(^|/)turbo\.json$" && return 0
   # ルートの package.json のみ許可（apps/api/package.json 等のサブパッケージは除外）
   # realpath -m で絶対パスに正規化されるため、git root との比較で判定する
   local repo_root
   repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || echo "")
   [ -n "$repo_root" ] && [ "$path" = "$repo_root/package.json" ] && return 0
-  echo "$path" | grep -qE "(^|/)pnpm-workspace\.yaml$" && return 0
+  echo "$path" | grep -iqE "(^|/)pnpm-workspace\.yaml$" && return 0
 
   return 1
 }

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # PreToolUse:Edit/Write hook: orchestratorによるソースファイルの直接編集をブロック
 #
-# orchestration/config ファイル（.claude/hooks/, .claude/skills/, .claude/agents/,
-# CLAUDE.md, flake.nix, .gitignore 等）は許可する。
+# orchestration/config ファイル（.claude/**, .omc/**, CLAUDE.md, AGENTS.md,
+# flake.nix, .gitignore 等）は許可する（確認スキップ）。
 # ソースファイル（apps/, packages/, tests/ 配下）は coder agent 経由を強制する。
 
 TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
@@ -25,8 +25,8 @@ fi
 is_orchestration_file() {
   local path="$1"
 
-  echo "$path" | grep -qE "(^|/)\.claude/(hooks|skills|agents|rules|plans)/" && return 0
-  echo "$path" | grep -qE "(^|/)\.claude/settings\.json$" && return 0
+  echo "$path" | grep -qE "(^|/)\.claude/" && return 0
+  echo "$path" | grep -qE "(^|/)\.omc/" && return 0
   echo "$path" | grep -qE "(^|/)CLAUDE\.md$" && return 0
   echo "$path" | grep -qE "(^|/)AGENTS\.md$" && return 0
   echo "$path" | grep -qE "(^|/)flake\.nix$" && return 0

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -24,6 +24,13 @@ if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# シンボリックリンクや .. を正規化（ファイルが存在しなくても動作）
+if [[ "$FILE_PATH" = /* ]]; then
+  FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+else
+  FILE_PATH=$(realpath -m "$(pwd)/$FILE_PATH" 2>/dev/null || echo "$(pwd)/$FILE_PATH")
+fi
+
 # orchestratorが直接編集できないファイル（明示的ブロック対象）
 is_blocked_file() {
   local path="$1"

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PreToolUse:Edit/Write hook: orchestratorによるソースファイルの直接編集をブロック
 #
 # orchestration/config ファイル（.claude/**, .omc/**, CLAUDE.md, AGENTS.md,
@@ -17,59 +17,83 @@ fi
 if command -v jq &> /dev/null; then
   FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty' 2>/dev/null)
 else
-  FILE_PATH=$(echo "$TOOL_INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
+  exit 2  # jq がない環境ではブロック方向に倒す
 fi
 
 if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
 
+# 相対パスは安全でないとして拒否
+if [[ "$FILE_PATH" != /* ]]; then
+  exit 2
+fi
+
 # シンボリックリンクや .. を正規化（ファイルが存在しなくても動作）
 # realpath -m が失敗した場合はブロック方向に倒す（未正規化パスを使わない）
-if [[ "$FILE_PATH" = /* ]]; then
-  FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null)
-  [ -z "$FILE_PATH" ] && exit 2
-else
-  FILE_PATH=$(realpath -m "$(pwd)/$FILE_PATH" 2>/dev/null)
-  [ -z "$FILE_PATH" ] && exit 2
+FILE_PATH=$(realpath -m "$FILE_PATH" 2>/dev/null)
+[ -z "$FILE_PATH" ] && exit 2
+
+# repo_root を正規化済み絶対パスから上方向に探索して取得する
+# パス自体が存在しない場合でも親ディレクトリを遡って git root を見つける
+_find_repo_root() {
+  local path="$1"
+  local dir
+  dir=$(dirname "$path")
+  while [ "$dir" != "/" ]; do
+    if git -C "$dir" rev-parse --show-toplevel &>/dev/null; then
+      git -C "$dir" rev-parse --show-toplevel 2>/dev/null
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+REPO_ROOT=$(_find_repo_root "$FILE_PATH")
+if [ -z "$REPO_ROOT" ]; then
+  exit 2
 fi
 
 # orchestratorが直接編集できないファイル（明示的ブロック対象）
 is_blocked_file() {
   local path="$1"
 
+  # macOS case-insensitive FS 対策
+  shopt -s nocasematch
+  local matched=1
   # .review-passed はレビュープロセスのみが作成する（orchestratorの迂回を防止）
-  # case-insensitive: macOS の大文字小文字を区別しないFSでの迂回を防止
-  echo "$path" | grep -iqE "(^|/)\.claude/\.review-passed$" && return 0
+  [[ "$path" == "$REPO_ROOT/.claude/.review-passed" ]] && matched=0
   # .omc/state/ は実行フロー状態ファイル（直接編集による動作操作を防止）
-  echo "$path" | grep -iqE "(^|/)\.omc/state/" && return 0
-
-  return 1
+  [[ "$path" == "$REPO_ROOT/.omc/state" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/.omc/state/"* ]] && matched=0
+  shopt -u nocasematch
+  return $matched
 }
 
-# orchestration/config ファイルかどうかを判定する
+# orchestration/config ファイルかどうかを判定する（repo_root 直下のみ許可）
 is_orchestration_file() {
   local path="$1"
 
-  echo "$path" | grep -iqE "(^|/)\.claude/" && return 0
-  echo "$path" | grep -iqE "(^|/)\.omc/" && return 0
-  echo "$path" | grep -iqE "(^|/)CLAUDE\.md$" && return 0
-  echo "$path" | grep -iqE "(^|/)AGENTS\.md$" && return 0
-  echo "$path" | grep -iqE "(^|/)flake\.nix$" && return 0
-  echo "$path" | grep -iqE "(^|/)\.gitignore$" && return 0
-  echo "$path" | grep -iqE "(^|/)\.env\.example$" && return 0
-  echo "$path" | grep -iqE "(^|/)turbo\.json$" && return 0
-  # ルートの package.json のみ許可（apps/api/package.json 等のサブパッケージは除外）
-  # realpath -m で絶対パスに正規化されるため、git root との比較で判定する
-  local repo_root
-  repo_root=$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null || echo "")
-  [ -n "$repo_root" ] && [ "$path" = "$repo_root/package.json" ] && return 0
-  echo "$path" | grep -iqE "(^|/)pnpm-workspace\.yaml$" && return 0
-
-  return 1
+  # macOS case-insensitive FS 対策
+  shopt -s nocasematch
+  local matched=1
+  [[ "$path" == "$REPO_ROOT/.claude/"* ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/.omc/"* ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/CLAUDE.md" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/AGENTS.md" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/flake.nix" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/.gitignore" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/.env.example" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/turbo.json" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/package.json" ]] && matched=0
+  [[ "$path" == "$REPO_ROOT/pnpm-workspace.yaml" ]] && matched=0
+  shopt -u nocasematch
+  return $matched
 }
 
 # ソースファイルかどうかを判定する（ブロック対象）
+# apps/, packages/, tests/ 配下のファイルは coder agent 経由を強制
 is_source_file() {
   local path="$1"
 
@@ -84,6 +108,11 @@ is_source_file() {
 if is_blocked_file "$FILE_PATH"; then
   echo "DENY: このファイルはorchestratorによる直接編集が禁止されています。" >&2
   echo "  対象ファイル: $FILE_PATH" >&2
+  if [[ "$FILE_PATH" == *"/.review-passed" ]]; then
+    echo "  理由: レビュープロセスのみが作成可能なファイルです。" >&2
+  else
+    echo "  理由: 実行フロー状態ファイルです（直接編集による動作操作を防止）。" >&2
+  fi
   exit 2
 fi
 

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -3,6 +3,9 @@
 #
 # orchestration/config ファイル（.claude/**, .omc/**, CLAUDE.md, AGENTS.md,
 # flake.nix, .gitignore 等）は許可する（確認スキップ）。
+# ただし以下は明示的にブロック:
+#   - .claude/.review-passed: レビュープロセスのみが作成可能
+#   - .omc/state/**:          実行フロー状態ファイル（直接編集によるフロー操作を防止）
 # ソースファイル（apps/, packages/, tests/ 配下）は coder agent 経由を強制する。
 
 TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
@@ -20,6 +23,18 @@ fi
 if [ -z "$FILE_PATH" ]; then
   exit 0
 fi
+
+# orchestratorが直接編集できないファイル（明示的ブロック対象）
+is_blocked_file() {
+  local path="$1"
+
+  # .review-passed はレビュープロセスのみが作成する（orchestratorの迂回を防止）
+  echo "$path" | grep -qE "(^|/)\.claude/\.review-passed$" && return 0
+  # .omc/state/ は実行フロー状態ファイル（直接編集による動作操作を防止）
+  echo "$path" | grep -qE "(^|/)\.omc/state/" && return 0
+
+  return 1
+}
 
 # orchestration/config ファイルかどうかを判定する
 is_orchestration_file() {
@@ -50,6 +65,13 @@ is_source_file() {
 
   return 1
 }
+
+# 明示ブロック対象を先に評価（orchestration 許可より優先）
+if is_blocked_file "$FILE_PATH"; then
+  echo "DENY: このファイルはorchestratorによる直接編集が禁止されています。" >&2
+  echo "  対象ファイル: $FILE_PATH" >&2
+  exit 2
+fi
 
 if is_orchestration_file "$FILE_PATH"; then
   exit 0

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -315,6 +315,30 @@ run_script_with_file() {
     [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
 }
 
+@test "大文字パスの.CLAUDE/.review-passedはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.CLAUDE/.review-passed"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
+}
+
+@test "大文字パスの.OMC/STATE/配下のファイルはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.OMC/STATE/autopilot-state.json"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
+}
+
 @test "パストラバーサル経由の.review-passedはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.claude/hooks/../.review-passed"

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -229,8 +229,6 @@ run_script_with_file() {
     [ "$status" -eq 0 ]
 }
 
-# --- エラーメッセージの確認 ---
-
 # --- package.json の許可・ブロック判定 ---
 
 @test "ルートのpackage.jsonは許可されること" {
@@ -308,6 +306,30 @@ run_script_with_file() {
 @test ".omc/state/配下のファイルはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.omc/state/autopilot-state.json"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
+}
+
+@test "パストラバーサル経由の.review-passedはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.claude/hooks/../.review-passed"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
+}
+
+@test "パストラバーサル経由の.omc/state/配下のファイルはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.omc/logs/../state/autopilot-state.json"
 
     # Act
     run run_script_with_file "$file_path"

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -466,3 +466,27 @@ run_script_with_file() {
     # Assert
     [ "$status" -eq 2 ]
 }
+
+@test "大文字パスの.claude/.REVIEW-PASSEDで正しい理由メッセージが出ること" {
+    # Arrange
+    local file_path="$REPO_DIR/.claude/.REVIEW-PASSED"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"レビュープロセスのみが作成可能"* ]]
+}
+
+@test "大文字パスの.OMC/STATEで正しい理由メッセージが出ること" {
+    # Arrange
+    local file_path="$REPO_DIR/.OMC/STATE/x.json"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"実行フロー状態ファイル"* ]]
+}

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -397,3 +397,14 @@ run_script_with_file() {
     # Assert
     [ "$status" -eq 0 ]
 }
+
+@test "大文字パスの.CLAUDE/hooks/配下のファイルは許可されること" {
+    # Arrange
+    local file_path="$REPO_DIR/.CLAUDE/hooks/new-hook.sh"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
+}

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -290,3 +290,64 @@ run_script_with_file() {
     [ "$status" -eq 2 ]
     [[ "${output}" == *"coder"* ]] || [[ "${lines[*]}" == *"coder"* ]]
 }
+
+# --- 明示的ブロック対象（is_blocked_file）---
+
+@test ".claude/.review-passedはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.claude/.review-passed"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
+}
+
+@test ".omc/state/配下のファイルはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.omc/state/autopilot-state.json"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]] || [[ "${lines[*]}" == *"DENY"* ]]
+}
+
+# --- .claude/ 全体と .omc/ 全体の許可 ---
+
+@test ".claude/配下の任意ファイルは許可されること" {
+    # Arrange
+    local file_path="$REPO_DIR/.claude/some-config.yaml"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
+}
+
+@test ".omc/notepad.mdは許可されること" {
+    # Arrange
+    local file_path="$REPO_DIR/.omc/notepad.md"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
+}
+
+@test ".omc/project-memory.jsonは許可されること" {
+    # Arrange
+    local file_path="$REPO_DIR/.omc/project-memory.json"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
+}

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -28,7 +28,7 @@ run_script_with_file() {
     local file_path="$1"
     local run_dir="${2:-$REPO_DIR}"
     local tool_input
-    tool_input=$(printf '{"file_path": "%s"}' "$file_path")
+    tool_input=$(jq -n --arg p "$file_path" '{file_path: $p}')
     (cd "$run_dir" && CLAUDE_TOOL_INPUT="$tool_input" bash "$SCRIPT")
 }
 
@@ -242,15 +242,16 @@ run_script_with_file() {
     [ "$status" -eq 0 ]
 }
 
-@test "./package.jsonは許可されること" {
+@test "./package.jsonは相対パスのためブロックされること" {
     # Arrange
+    # 相対パスは安全でないとして拒否される（MEDIUM-1修正）
     local file_path="./package.json"
 
     # Act
     run run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
 @test "apps/api/package.jsonはブロックされること" {
@@ -407,4 +408,61 @@ run_script_with_file() {
 
     # Assert
     [ "$status" -eq 0 ]
+}
+
+# --- サブディレクトリの設定ファイル名偽装はブロックされること ---
+
+@test "apps/api/flake.nixはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/apps/api/flake.nix"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+}
+
+@test "apps/api/CLAUDE.mdはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/apps/api/CLAUDE.md"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+}
+
+@test "apps/api/turbo.jsonはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/apps/api/turbo.json"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+}
+
+@test "apps/api/src/.claude/foo.tsはブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/apps/api/src/.claude/foo.ts"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+}
+
+@test ".omc/stateディレクトリ自体はブロックされること" {
+    # Arrange
+    local file_path="$REPO_DIR/.omc/state"
+
+    # Act
+    run run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
 }


### PR DESCRIPTION
## Summary

- `is_orchestration_file` / `is_blocked_file` を repo_root 限定 + `shopt nocasematch` に変更し、サブディレクトリ偽装バイパス（例: `apps/api/src/.claude/foo.ts`）を防止
- `.omc/state` ディレクトリ自体もブロック対象に追加
- jq 非インストール環境では `exit 2`（ブロック方向）に変更
- 相対パスを `exit 2` で明示拒否し `$(pwd)` 依存を排除
- `shebang` を `#!/usr/bin/env bash` に変更
- ブロック理由メッセージの case-insensitive 比較を修正
- bats テストを 25 件 → 39 件に拡充（バイパス検出テスト含む）

## Test plan

- [x] `bats tests/hooks/orchestrator-direct-edit-guard.bats` 全 39 件 PASS
- [x] code-reviewer PASS（CRITICAL 2 / HIGH 3 / MEDIUM 3 / LOW 6 全指摘対応確認）
- [x] security-reviewer PASS（パストラバーサル・case-insensitive・jq フォールバック等全確認）
- [x] pre-push チェック通過（lint / typecheck / test）

🤖 Generated with [Claude Code](https://claude.ai/code)