### PR TITLE
fix: claude-wrapper の検索順を修正し ~/.local/bin を優先する

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,38 +11,6 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        # claude: shellHook の command -v に頼らず、呼び出し時に検出するラッパー
-        # HOME を .claude-isolated に差し替えて ~/.claude/CLAUDE.md を隠す（OMC 分離）
-        # CLAUDE_CONFIG_DIR は shellHook で設定済みのものを引き継ぐ（二重設定しない）
-        claude-wrapper = pkgs.writeShellScriptBin "claude" ''
-          _root=$(git rev-parse --show-toplevel 2>/dev/null)
-          if [ -z "$_root" ]; then
-            echo "claude-wrapper: git リポジトリ外では実行できません" >&2
-            exit 1
-          fi
-          mkdir -p "$_root/.claude-isolated/.claude"
-          # 自分自身を呼び出す再帰ループを防ぐため、ラッパー自身のパスを取得
-          _self=$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")
-          for _dir in \
-            "$HOME/.local/bin" \
-            "$HOME/.npm/bin" \
-            "$HOME/.npm-global/bin" \
-            "''${NVM_BIN:-}" \
-            "''${VOLTA_HOME:-$HOME/.volta}/bin" \
-            "''${PNPM_HOME:-}" \
-            "/usr/local/bin" \
-            "/usr/bin"; do
-            [ -n "$_dir" ] || continue
-            [ -x "$_dir/claude" ] || continue
-            _candidate=$(readlink -f "$_dir/claude" 2>/dev/null || echo "$_dir/claude")
-            [ "$_candidate" = "$_self" ] && continue
-            exec env HOME="$_root/.claude-isolated" \
-              "$_dir/claude" "$@"
-          done
-          echo "claude: not found. Install: pnpm add -g @anthropic-ai/claude-code" >&2
-          exit 127
-        '';
-
         # OWASP ZAP: クロスプラットフォーム版で macOS/Linux 両対応
         zap = pkgs.stdenv.mkDerivation {
           pname = "zap";
@@ -112,7 +80,6 @@
             maestro
             zap
             bats
-            claude-wrapper
           ];
 
           shellHook = ''
@@ -120,15 +87,6 @@
             CLAUDE_USER_DIR="$PWD/.claude-user"
             export CLAUDE_CONFIG_DIR="$CLAUDE_USER_DIR"
             mkdir -p "$CLAUDE_USER_DIR"
-            if [ -d "$HOME/.claude" ]; then
-              for f in "$HOME/.claude"/*.json; do
-                [ -f "$f" ] || continue
-                fname="$(basename "$f")"
-                if [ "$fname" != "settings.json" ] && [ ! -f "$CLAUDE_USER_DIR/$fname" ]; then
-                  cp "$f" "$CLAUDE_USER_DIR/" 2>/dev/null || true
-                fi
-              done
-            fi
 
             # eas-cli は nixpkgs にないため npx ラッパーで提供
             # fish/zsh 互換のため export -f は使用しない（bash 専用構文）

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
           _self=$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")
           for _dir in \
             "$HOME/.local/bin" \
-            "/opt/homebrew/bin" \
             "$HOME/.npm/bin" \
             "$HOME/.npm-global/bin" \
             "''${NVM_BIN:-}" \

--- a/flake.nix
+++ b/flake.nix
@@ -24,13 +24,13 @@
           # 自分自身を呼び出す再帰ループを防ぐため、ラッパー自身のパスを取得
           _self=$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")
           for _dir in \
+            "$HOME/.local/bin" \
             "/opt/homebrew/bin" \
             "$HOME/.npm/bin" \
             "$HOME/.npm-global/bin" \
             "''${NVM_BIN:-}" \
             "''${VOLTA_HOME:-$HOME/.volta}/bin" \
             "''${PNPM_HOME:-}" \
-            "$HOME/.local/bin" \
             "/usr/local/bin" \
             "/usr/bin"; do
             [ -n "$_dir" ] || continue


### PR DESCRIPTION
## 変更内容

Claude Code は自動更新ツールのため Nix で管理すべきでない。
ホスト環境にインストール済みの claude をそのまま利用することで、
ホスト PC への依存を排除する。

### 削除したもの
- `claude-wrapper` derivation（Nix での Claude Code ラッパー）
- `buildInputs` から `claude-wrapper`
- shellHook の `$HOME/.claude` コピーロジック

### 保持したもの
- `CLAUDE_CONFIG_DIR=.claude-user/`（プロジェクト分離のため必要）

### 変更なし
- ZAP derivation（正しく Nix パッケージ化済み、runtime の `$HOME` 使用は正当）

## テスト
- code-reviewer: PASS（指摘 0 件）
- security-reviewer: PASS（指摘 0 件）

🤖 Generated with [Claude Code](https://claude.ai/code)