### PR TITLE
fix: mailpit を使ったメール送信テストの整備 #796

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -80,3 +80,16 @@ RUNPOD_ENDPOINT_ID=your-runpod-endpoint-id
 # ローカル開発では ngrok 等でトンネルを作成し、そのURLを設定すること
 
 REVENUECAT_WEBHOOK_SECRET=your-revenuecat-webhook-secret
+
+# -----------------------------------------------------------------------------
+# Resend (メール送信)
+# -----------------------------------------------------------------------------
+# Resend ダッシュボード (https://resend.com) で API キーを発行する
+# ローカル開発・テスト時は mailpit (localhost:1025) を使用する：
+#   - mailpit 起動: mailpit コマンド（nix develop で自動起動）
+#   - tests/api/setup.ts が Resend API 呼び出しを mailpit SMTP に転送する
+#   - mailpit 未起動時はテスト内で自動的にモックレスポンスにフォールバックする
+# FROM_EMAIL は Resend で検証済みのドメインのアドレスを指定すること
+
+RESEND_API_KEY=your-resend-api-key
+FROM_EMAIL=no-reply@example.com

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,9 +31,11 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250321.0",
+    "@types/nodemailer": "^6.4.0",
     "@types/turndown": "^5.0.6",
     "@vitest/coverage-v8": "^4.1.1",
     "drizzle-kit": "^0.31.0",
+    "nodemailer": "^6.9.0",
     "sharp": "^0.34.5",
     "typescript": "^5.8.2",
     "vite": "8.0.7",

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    setupFiles: ["../../tests/api/setup.ts"],
     include: ["../../tests/api/**/*.test.ts"],
     coverage: {
       provider: "v8",

--- a/tests/api/setup.ts
+++ b/tests/api/setup.ts
@@ -1,0 +1,106 @@
+/**
+ * API テスト共通セットアップ
+ *
+ * global fetch を横断インターセプトし、Resend API 宛ての呼び出しを
+ * mailpit SMTP に転送する。mailpit 未起動時はモック成功レスポンスを返す。
+ */
+import nodemailer from "nodemailer";
+import { afterAll, beforeAll, vi } from "vitest";
+
+/** mailpit SMTP ホスト */
+const MAILPIT_SMTP_HOST = "localhost";
+
+/** mailpit SMTP ポート */
+const MAILPIT_SMTP_PORT = 1025;
+
+/** インターセプト対象 URL プレフィックス */
+const RESEND_EMAILS_ENDPOINT = "https://api.resend.com/emails";
+
+/** mailpit 未起動時のフォールバック messageId */
+const FALLBACK_MESSAGE_ID = "test_mock_email_id";
+
+let nativeFetch: typeof globalThis.fetch;
+
+/**
+ * RequestInfo | URL から URL 文字列を解決する
+ */
+function resolveUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+/**
+ * URL が Resend メール送信エンドポイントかどうかを判定する
+ */
+function isResendEmailsUrl(url: string): boolean {
+  return url.startsWith(RESEND_EMAILS_ENDPOINT);
+}
+
+/**
+ * Resend API リクエストを mailpit SMTP に転送する。
+ * mailpit 未起動の場合はモック成功レスポンスを返す。
+ */
+async function handleResendIntercept(init: RequestInit | undefined): Promise<Response> {
+  const transport = nodemailer.createTransport({
+    host: MAILPIT_SMTP_HOST,
+    port: MAILPIT_SMTP_PORT,
+    secure: false,
+    ignoreTLS: true,
+    connectionTimeout: 500,
+    greetingTimeout: 500,
+  });
+
+  try {
+    await transport.verify();
+
+    const bodyStr = typeof init?.body === "string" ? init.body : null;
+    const body = bodyStr !== null ? (JSON.parse(bodyStr) as Record<string, unknown>) : {};
+
+    const from = typeof body.from === "string" ? body.from : "test@example.com";
+    const to = Array.isArray(body.to)
+      ? (body.to as string[])
+      : typeof body.to === "string"
+        ? [body.to]
+        : ["test@example.com"];
+    const subject = typeof body.subject === "string" ? body.subject : "(no subject)";
+    const html = typeof body.html === "string" ? body.html : "";
+
+    const info = await transport.sendMail({ from, to, subject, html });
+
+    return new Response(
+      JSON.stringify({ id: info.messageId ?? "mailpit_test" }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch {
+    return new Response(
+      JSON.stringify({ id: FALLBACK_MESSAGE_ID }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+}
+
+beforeAll(() => {
+  nativeFetch = globalThis.fetch.bind(globalThis);
+
+  vi.stubGlobal(
+    "fetch",
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = resolveUrl(input);
+      if (!isResendEmailsUrl(url)) {
+        return nativeFetch(input, init);
+      }
+      return handleResendIntercept(init);
+    },
+  );
+});
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});

--- a/tests/api/setup.ts
+++ b/tests/api/setup.ts
@@ -75,21 +75,15 @@ async function handleResendIntercept(init: RequestInit | undefined): Promise<Res
 
     const info = await transport.sendMail({ from, to, subject, html });
 
-    return new Response(
-      JSON.stringify({ id: info.messageId ?? "mailpit_test" }),
-      {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return new Response(JSON.stringify({ id: info.messageId ?? "mailpit_test" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   } catch {
-    return new Response(
-      JSON.stringify({ id: FALLBACK_MESSAGE_ID }),
-      {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return new Response(JSON.stringify({ id: FALLBACK_MESSAGE_ID }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 }
 

--- a/tests/api/setup.ts
+++ b/tests/api/setup.ts
@@ -38,6 +38,17 @@ function isResendEmailsUrl(url: string): boolean {
 }
 
 /**
+ * Resend ペイロードの to フィールドを string[] に正規化する
+ */
+function normalizeRecipients(to: unknown): string[] {
+  if (Array.isArray(to)) {
+    return to.filter((v): v is string => typeof v === "string");
+  }
+  if (typeof to === "string") return [to];
+  return ["test@example.com"];
+}
+
+/**
  * Resend API リクエストを mailpit SMTP に転送する。
  * mailpit 未起動の場合はモック成功レスポンスを返す。
  */
@@ -58,11 +69,7 @@ async function handleResendIntercept(init: RequestInit | undefined): Promise<Res
     const body = bodyStr !== null ? (JSON.parse(bodyStr) as Record<string, unknown>) : {};
 
     const from = typeof body.from === "string" ? body.from : "test@example.com";
-    const to = Array.isArray(body.to)
-      ? (body.to as string[])
-      : typeof body.to === "string"
-        ? [body.to]
-        : ["test@example.com"];
+    const to = normalizeRecipients(body.to);
     const subject = typeof body.subject === "string" ? body.subject : "(no subject)";
     const html = typeof body.html === "string" ? body.html : "";
 


### PR DESCRIPTION
## Summary

- `tests/api/setup.ts` を新規作成。vitest setupFile として global `fetch` を横断インターセプトし、Resend API 宛ての呼び出しを mailpit SMTP（localhost:1025）に転送する
- mailpit 未起動時はモック成功レスポンスにフォールバックするため、ローカル環境に依存しない
- 無限再帰防止のため `nativeFetch = globalThis.fetch.bind(globalThis)` を事前保存してから `vi.stubGlobal` を適用
- `apps/api/vitest.config.ts` に `setupFiles` を追加
- `apps/api/package.json` に `nodemailer` / `@types/nodemailer` を devDependencies 追加
- `apps/api/.dev.vars.example` に Resend / mailpit の利用説明コメントを追記

## Test plan

- [ ] `pnpm --filter @tech-clip/api test` — 1342 tests pass（退行なし）
- [ ] `pnpm typecheck` — 型エラー 0 件
- [ ] `pnpm lint` — lint エラー 0 件
- [ ] mailpit 起動時に Resend API 宛て fetch が SMTP 転送されることを手動確認（任意）

Closes #796

🤖 Generated with [Claude Code](https://claude.ai/code)