### PR TITLE
fix: pre-push テスト出力をエラーのみに限定する #791

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
+import { shouldSuppressTestLog } from "./vitest.utils";
 
 export default defineConfig({
   resolve: {
@@ -12,6 +13,9 @@ export default defineConfig({
     environment: "node",
     setupFiles: ["../../tests/api/setup.ts"],
     include: ["../../tests/api/**/*.test.ts"],
+    onConsoleLog(log) {
+      return shouldSuppressTestLog(log);
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],

--- a/apps/api/vitest.utils.ts
+++ b/apps/api/vitest.utils.ts
@@ -1,0 +1,49 @@
+/** テスト出力に表示しないログレベル */
+export const SUPPRESSED_LOG_LEVELS = new Set(["info", "warn", "debug"]);
+
+/**
+ * ロガーが出力するJSON文字列かどうかを判定する
+ *
+ * @param log - console.log に渡された文字列
+ * @returns ロガーのJSONログであれば true
+ */
+export function isLoggerJsonOutput(log: string): boolean {
+  if (!log.startsWith("{")) return false;
+  try {
+    const parsed = JSON.parse(log) as Record<string, unknown>;
+    return typeof parsed.level === "string" && typeof parsed.message === "string";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 抑制対象のログレベルかどうかを判定する
+ *
+ * @param log - console.log に渡された文字列
+ * @returns 抑制対象であれば true
+ */
+export function isSuppressedLogLevel(log: string): boolean {
+  try {
+    const parsed = JSON.parse(log) as Record<string, unknown>;
+    return typeof parsed.level === "string" && SUPPRESSED_LOG_LEVELS.has(parsed.level);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * テスト出力を抑制するかどうかを判定する
+ *
+ * info/warn/debug レベルのロガー出力はテスト時のノイズになるため抑制する。
+ * error レベルは障害検知に重要なため常に表示する。
+ *
+ * @param log - console.log に渡された文字列
+ * @returns 抑制する場合は false、表示する場合は undefined
+ */
+export function shouldSuppressTestLog(log: string): false | undefined {
+  if (isLoggerJsonOutput(log) && isSuppressedLogLevel(log)) {
+    return false;
+  }
+  return undefined;
+}

--- a/tests/api/lib/vitest-utils.test.ts
+++ b/tests/api/lib/vitest-utils.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLoggerJsonOutput,
+  isSuppressedLogLevel,
+  shouldSuppressTestLog,
+} from "../../../apps/api/vitest.utils";
+
+describe("isLoggerJsonOutput", () => {
+  it("levelとmessageを持つJSONはロガー出力と判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({
+      level: "warn",
+      message: "テスト警告",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    // Act
+    const result = isLoggerJsonOutput(log);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("{で始まらない文字列はロガー出力ではないと判定できること", () => {
+    // Arrange
+    const log = "通常のログ出力";
+
+    // Act
+    const result = isLoggerJsonOutput(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("levelがないJSONはロガー出力ではないと判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({ message: "テスト", timestamp: "2024-01-01T00:00:00.000Z" });
+
+    // Act
+    const result = isLoggerJsonOutput(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("messageがないJSONはロガー出力ではないと判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({ level: "info", timestamp: "2024-01-01T00:00:00.000Z" });
+
+    // Act
+    const result = isLoggerJsonOutput(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("不正なJSONはロガー出力ではないと判定できること", () => {
+    // Arrange
+    const log = "{ invalid json }";
+
+    // Act
+    const result = isLoggerJsonOutput(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("isSuppressedLogLevel", () => {
+  it("warnレベルは抑制対象と判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({ level: "warn", message: "警告" });
+
+    // Act
+    const result = isSuppressedLogLevel(log);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("infoレベルは抑制対象と判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({ level: "info", message: "情報" });
+
+    // Act
+    const result = isSuppressedLogLevel(log);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("debugレベルは抑制対象と判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({ level: "debug", message: "デバッグ" });
+
+    // Act
+    const result = isSuppressedLogLevel(log);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("errorレベルは抑制対象でないと判定できること", () => {
+    // Arrange
+    const log = JSON.stringify({ level: "error", message: "エラー" });
+
+    // Act
+    const result = isSuppressedLogLevel(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("不正なJSONは抑制対象でないと判定できること", () => {
+    // Arrange
+    const log = "{ invalid json }";
+
+    // Act
+    const result = isSuppressedLogLevel(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("shouldSuppressTestLog", () => {
+  it("warnレベルのロガー出力は抑制されること", () => {
+    // Arrange
+    const log = JSON.stringify({
+      level: "warn",
+      message: "リフレッシュトークンの再利用を検知しました",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    // Act
+    const result = shouldSuppressTestLog(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("infoレベルのロガー出力は抑制されること", () => {
+    // Arrange
+    const log = JSON.stringify({
+      level: "info",
+      message: "ユーザーログイン",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    // Act
+    const result = shouldSuppressTestLog(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("debugレベルのロガー出力は抑制されること", () => {
+    // Arrange
+    const log = JSON.stringify({
+      level: "debug",
+      message: "デバッグ情報",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    // Act
+    const result = shouldSuppressTestLog(log);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("errorレベルのロガー出力は抑制されないこと", () => {
+    // Arrange
+    const log = JSON.stringify({
+      level: "error",
+      message: "重大なエラー",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    // Act
+    const result = shouldSuppressTestLog(log);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("通常のconsole出力は抑制されないこと", () => {
+    // Arrange
+    const log = "通常のコンソール出力";
+
+    // Act
+    const result = shouldSuppressTestLog(log);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要

pre-push 実行時のテスト出力の冗長さを解消する。

- vitest の `onConsoleLog` フックを使い、info/warn/debug レベルのロガー出力をテスト実行時に抑制
- error レベルは障害検知に重要なため引き続き表示
- フィルタリングロジックを `apps/api/vitest.utils.ts` に切り出してテスト可能にした

## 変更ファイル

- `apps/api/vitest.config.ts` — `onConsoleLog` を追加し、suppression ロジックを呼び出す
- `apps/api/vitest.utils.ts` — ログ抑制判定ヘルパー関数（新規）
- `tests/api/lib/vitest-utils.test.ts` — ヘルパー関数のユニットテスト（新規）

Closes #791

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>