### PR TITLE
fix: dangerous-command-guard.sh に git revert / git reset --soft/--mixed を追加 #793

### DIFF
--- a/.claude/hooks/dangerous-command-guard.sh
+++ b/.claude/hooks/dangerous-command-guard.sh
@@ -81,6 +81,9 @@ check_dangerous() {
   echo "$cmd" | grep -qE "^rm " && return 0
 
   # git 破壊的コマンド
+  echo "$cmd" | grep -qE "git revert " && return 0
+  echo "$cmd" | grep -qE "git reset --soft" && return 0
+  echo "$cmd" | grep -qE "git reset --mixed" && return 0
   echo "$cmd" | grep -qE "git reset --hard" && return 0
   echo "$cmd" | grep -qE "git push.*--force" && return 0
   echo "$cmd" | grep -qE "git push.*-f[ $]" && return 0


### PR DESCRIPTION
## 概要

`dangerous-command-guard.sh` に以下の禁止コマンドを追加:
- `git revert` — コミット履歴の書き換えを防止
- `git reset --soft` — HEAD のみ移動（インデックス・作業ツリーは保持）を防止
- `git reset --mixed` — HEAD とインデックスを移動（作業ツリーは保持）を防止

## 変更ファイル
- `.claude/hooks/dangerous-command-guard.sh`

Closes #793

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>