### PR TITLE
fix: flake.nix に claude-code-bin 追加と shellHook PATH 設定

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
             zap
             bats
             mailpit
+            claude-code-bin
           ];
 
           shellHook = ''
@@ -91,6 +92,12 @@
 
             # Claude 隔離 wrapper を PATH の先頭に追加（ホスト非依存で最新版を起動するため）
             export PATH="$PWD/.claude-isolated/bin:$PATH"
+
+            # Claude Code auto-updater は ~/.local/bin にインストールする
+            # /opt/homebrew/bin より優先するために先頭に追加
+            if [ -x "$HOME/.local/bin/claude" ]; then
+              export PATH="$HOME/.local/bin:$PATH"
+            fi
 
             # eas-cli は nixpkgs にないため npx ラッパーで提供
             # fish/zsh 互換のため export -f は使用しない（bash 専用構文）


### PR DESCRIPTION
## 概要

### #795: claude-code-bin を buildInputs に追加
nixpkgs-unstable の `claude-code-bin` を `buildInputs` に追加し、ホスト非依存で claude を提供。

### #794: shellHook に ~/.local/bin を PATH 先頭に追加
Claude Code auto-updater が `~/.local/bin` にインストールする最新 claude を `/opt/homebrew/bin` より優先させることで、常に最新版が使われるようにする。

## 変更ファイル
- `flake.nix`

Closes #795
Closes #794

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>