### PR TITLE
feat: Gemma4 モデル切り替え + YouTube 動画要約対応 #806

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -67,9 +67,14 @@ GITHUB_CLIENT_SECRET=your-github-client-secret
 # -----------------------------------------------------------------------------
 # RunPod (https://www.runpod.io) でアカウントを作成し、API キーを発行する
 # ENDPOINT_ID はデプロイ済みエンドポイントの ID
+# モデルは Gemma 3 12B IT をデフォルトとし、infra/runpod の Dockerfile を参照する
 
 RUNPOD_API_KEY=your-runpod-api-key
 RUNPOD_ENDPOINT_ID=your-runpod-endpoint-id
+
+# データベースの summaries/translations.model カラムに保存するタグ
+# 未設定の場合は gemma3-12b が使用される
+# GEMMA_MODEL_NAME=gemma3-12b
 
 # -----------------------------------------------------------------------------
 # RevenueCat Webhook

--- a/apps/api/src/app/articles-subapp.ts
+++ b/apps/api/src/app/articles-subapp.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { Auth } from "../auth";
 import type { Database } from "../db";
 import { articles, users } from "../db/schema";
+import { resolveGemmaModelTag } from "../lib/ai-model";
 import { getRunPodEndpointId } from "../lib/config";
 import { toRecordArray } from "../lib/db-cast";
 import { createAiLimitMiddleware } from "../middleware/ai-limit";
@@ -102,6 +103,8 @@ export async function handleArticles(
     },
   });
 
+  const gemmaModelTag = resolveGemmaModelTag(env.GEMMA_MODEL_NAME);
+
   const summaryRoute = createSummaryRoute({
     db,
     summarizeFn: summarizeArticle,
@@ -110,6 +113,7 @@ export async function handleArticles(
     runpodConfig: {
       apiKey: env.RUNPOD_API_KEY,
       endpointId: getRunPodEndpointId(env),
+      modelTag: gemmaModelTag,
     },
   });
 
@@ -121,6 +125,7 @@ export async function handleArticles(
     runpodConfig: {
       apiKey: env.RUNPOD_API_KEY,
       endpointId: getRunPodEndpointId(env),
+      modelTag: gemmaModelTag,
     },
   });
 

--- a/apps/api/src/lib/ai-model.ts
+++ b/apps/api/src/lib/ai-model.ts
@@ -6,12 +6,6 @@
  */
 
 /**
- * HuggingFace準拠のGemmaモデル参照名
- * RunPod側の vLLM ハンドラーに渡すモデル識別子。
- */
-export const DEFAULT_GEMMA_MODEL = "gemma-3-12b-it";
-
-/**
  * データベース保存用の短縮タグ
  * summaries/translations.model カラムに保存する値。
  */

--- a/apps/api/src/lib/ai-model.ts
+++ b/apps/api/src/lib/ai-model.ts
@@ -1,0 +1,31 @@
+/**
+ * AIモデル設定定数
+ *
+ * Gemmaモデルのデフォルト識別子を集約する。
+ * 環境変数 GEMMA_MODEL_NAME で上書き可能。
+ */
+
+/**
+ * HuggingFace準拠のGemmaモデル参照名
+ * RunPod側の vLLM ハンドラーに渡すモデル識別子。
+ */
+export const DEFAULT_GEMMA_MODEL = "gemma-3-12b-it";
+
+/**
+ * データベース保存用の短縮タグ
+ * summaries/translations.model カラムに保存する値。
+ */
+export const DEFAULT_GEMMA_MODEL_TAG = "gemma3-12b";
+
+/**
+ * 環境変数からGemmaモデルタグを解決する
+ *
+ * @param envValue - 環境変数 GEMMA_MODEL_NAME の値
+ * @returns 解決されたモデルタグ。未設定の場合はデフォルトタグ
+ */
+export function resolveGemmaModelTag(envValue: string | undefined): string {
+  if (!envValue) {
+    return DEFAULT_GEMMA_MODEL_TAG;
+  }
+  return envValue;
+}

--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -52,11 +52,14 @@ type GetTranslationJobStatusFn = (params: {
   content: string;
   runpodApiKey: string;
   runpodEndpointId: string;
+  modelTag?: string;
 }) => Promise<TranslationJobStatus>;
 
 type RunpodConfig = {
   apiKey: string;
   endpointId: string;
+  /** データベース保存用のモデルタグ（省略時は DEFAULT_GEMMA_MODEL_TAG を使用） */
+  modelTag?: string;
 };
 
 /** 認証済みユーザーの型 */
@@ -227,6 +230,7 @@ export function createAiRoute(options: AiRouteOptions) {
         targetLanguage,
         runpodApiKey: runpodConfig.apiKey,
         runpodEndpointId: runpodConfig.endpointId,
+        modelTag: runpodConfig.modelTag,
       });
 
       const now = new Date();
@@ -355,6 +359,7 @@ export function createAiRoute(options: AiRouteOptions) {
         content: article.content ?? "",
         runpodApiKey: runpodConfig.apiKey,
         runpodEndpointId: runpodConfig.endpointId,
+        modelTag: runpodConfig.modelTag,
       });
       const now = new Date();
 

--- a/apps/api/src/routes/articles.ts
+++ b/apps/api/src/routes/articles.ts
@@ -42,6 +42,13 @@ const NOT_FOUND_ERROR_MESSAGE = "記事が見つかりません";
 /** URL最大文字数 */
 const URL_MAX_LENGTH = 2048;
 
+/** 字幕取得失敗を示すエラーコード（YouTubeパーサーが投げる） */
+const NO_CAPTIONS_ERROR_CODE = "NO_CAPTIONS";
+
+/** 字幕取得失敗時に返すユーザー向けメッセージ */
+const NO_CAPTIONS_ERROR_MESSAGE =
+  "この動画には字幕がないため、要約できません。別の動画をお試しください";
+
 /** 記事保存リクエストのZodスキーマ */
 const CreateArticleSchema = z.object({
   url: z
@@ -101,6 +108,16 @@ type ArticlesRouteOptions = {
   parseArticleFn: ParseArticleFn;
   queryFn: ArticlesQueryFn;
 };
+
+/**
+ * 例外が YouTube の NO_CAPTIONS エラーかどうかを判定する
+ *
+ * @param error - catch で捕捉した値
+ * @returns NO_CAPTIONS エラーの場合 true
+ */
+function isNoCaptionsError(error: unknown): boolean {
+  return error instanceof Error && error.message === NO_CAPTIONS_ERROR_CODE;
+}
 
 /**
  * ブール値クエリパラメータをパースする
@@ -315,7 +332,19 @@ export function createArticlesRoute(options: ArticlesRouteOptions) {
         },
         HTTP_OK,
       );
-    } catch {
+    } catch (error) {
+      if (isNoCaptionsError(error)) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: NO_CAPTIONS_ERROR_CODE,
+              message: NO_CAPTIONS_ERROR_MESSAGE,
+            },
+          },
+          HTTP_UNPROCESSABLE_ENTITY,
+        );
+      }
       return c.json(
         {
           success: false,
@@ -423,7 +452,19 @@ export function createArticlesRoute(options: ArticlesRouteOptions) {
         },
         HTTP_CREATED,
       );
-    } catch {
+    } catch (error) {
+      if (isNoCaptionsError(error)) {
+        return c.json(
+          {
+            success: false,
+            error: {
+              code: NO_CAPTIONS_ERROR_CODE,
+              message: NO_CAPTIONS_ERROR_MESSAGE,
+            },
+          },
+          HTTP_UNPROCESSABLE_ENTITY,
+        );
+      }
       return c.json(
         {
           success: false,

--- a/apps/api/src/services/article-parser.ts
+++ b/apps/api/src/services/article-parser.ts
@@ -122,11 +122,6 @@ async function dispatchParser(source: ArticleSource, url: string): Promise<Parse
     return parseTwitter(url);
   }
 
-  if (source === "youtube") {
-    const { parseYouTube } = await import("./parsers/youtube");
-    return parseYouTube(url);
-  }
-
   const { parseGeneric } = await import("./parsers/generic");
   return parseGeneric(url);
 }

--- a/apps/api/src/services/article-parser.ts
+++ b/apps/api/src/services/article-parser.ts
@@ -122,6 +122,11 @@ async function dispatchParser(source: ArticleSource, url: string): Promise<Parse
     return parseTwitter(url);
   }
 
+  if (source === "youtube") {
+    const { parseYouTube } = await import("./parsers/youtube");
+    return parseYouTube(url);
+  }
+
   const { parseGeneric } = await import("./parsers/generic");
   return parseGeneric(url);
 }
@@ -131,9 +136,11 @@ async function dispatchParser(source: ArticleSource, url: string): Promise<Parse
  *
  * sourceDetectorでソースを判定し、対応するパーサーを呼び出す。
  * 個別パーサーがエラーになった場合は汎用パーサーにフォールバックする。
+ * ただし YouTube はフォールバックが無意味なため、エラーをそのまま伝播させる。
  *
  * @param url - パース対象のURL文字列
  * @returns パース済み記事データ
+ * @throws Error - YouTube の字幕取得に失敗した場合（NO_CAPTIONS など）
  */
 export async function parseArticle(url: string): Promise<ParsedArticle> {
   const source = detectSource(url);
@@ -141,6 +148,12 @@ export async function parseArticle(url: string): Promise<ParsedArticle> {
   if (source === "other") {
     const { parseGeneric } = await import("./parsers/generic");
     const result = await parseGeneric(url);
+    return { ...result, source };
+  }
+
+  if (source === "youtube") {
+    const { parseYouTube } = await import("./parsers/youtube");
+    const result = await parseYouTube(url);
     return { ...result, source };
   }
 

--- a/apps/api/src/services/parsers/youtube.ts
+++ b/apps/api/src/services/parsers/youtube.ts
@@ -1,12 +1,7 @@
 import { z } from "zod";
 
 import type { ParsedArticle } from "../../types/article";
-import {
-  calculateReadingTime,
-  createExcerpt,
-  EXCERPT_MAX_LENGTH,
-  TECHCLIP_USER_AGENT,
-} from "./_shared";
+import { calculateReadingTime, createExcerpt, TECHCLIP_USER_AGENT } from "./_shared";
 
 /** YouTube oEmbed API エンドポイント */
 const OEMBED_ENDPOINT = "https://www.youtube.com/oembed";
@@ -25,6 +20,15 @@ const YOUTUBE_HOSTNAMES = ["www.youtube.com", "youtube.com", "m.youtube.com"];
 
 /** YouTube 短縮ホスト名 */
 const YOUTU_BE_HOSTNAME = "youtu.be";
+
+/** 字幕 API として許可するホスト名 */
+const CAPTION_ALLOWED_HOSTNAMES = ["www.youtube.com", "youtube.com"];
+
+/** 動画ページ HTML のサイズ上限（バイト）。ReDoS 対策のため制限する */
+const VIDEO_PAGE_HTML_MAX_BYTES = 5 * 1024 * 1024;
+
+/** ytInitialPlayerResponse JSON の文字数上限。JSON.parse サイズ制限 */
+const PLAYER_RESPONSE_JSON_MAX_LENGTH = 500 * 1024;
 
 /** 動画 ID 抽出用パターン（11文字の英数字・ハイフン・アンダースコア） */
 const VIDEO_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
@@ -174,7 +178,12 @@ async function fetchVideoPageHtml(videoUrl: string): Promise<string> {
     throw new Error(`YouTube動画ページの取得に失敗しました（ステータス: ${response.status}）`);
   }
 
-  return response.text();
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength > VIDEO_PAGE_HTML_MAX_BYTES) {
+    throw new Error("YouTube動画ページのレスポンスサイズが上限を超えています");
+  }
+
+  return new TextDecoder().decode(buffer);
 }
 
 /**
@@ -186,6 +195,10 @@ async function fetchVideoPageHtml(videoUrl: string): Promise<string> {
 function extractCaptionTracks(html: string): CaptionTrack[] {
   const match = html.match(PLAYER_RESPONSE_REGEX);
   if (!match?.[1]) {
+    return [];
+  }
+
+  if (match[1].length > PLAYER_RESPONSE_JSON_MAX_LENGTH) {
     return [];
   }
 
@@ -208,10 +221,10 @@ function extractCaptionTracks(html: string): CaptionTrack[] {
  *
  * 日本語 → 英語 → 自動生成以外 → 先頭 の順で優先する。
  *
- * @param tracks - 字幕トラック配列
+ * @param tracks - 字幕トラック配列（少なくとも 1 件以上であること）
  * @returns 選択された字幕トラック
  */
-function selectCaptionTrack(tracks: CaptionTrack[]): CaptionTrack {
+function selectCaptionTrack(tracks: readonly [CaptionTrack, ...CaptionTrack[]]): CaptionTrack {
   const japanese = tracks.find((track) => track.languageCode === "ja");
   if (japanese) {
     return japanese;
@@ -258,6 +271,24 @@ function decodeXmlEntities(text: string): string {
 }
 
 /**
+ * 字幕 API の URL が許可されたホスト名か検証する
+ *
+ * @param baseUrl - 字幕 API の baseUrl
+ * @throws Error - 許可されていないホスト名の場合（SSRF 対策）
+ */
+function validateCaptionBaseUrl(baseUrl: string): void {
+  let hostname: string;
+  try {
+    hostname = new URL(baseUrl).hostname;
+  } catch {
+    throw new Error("字幕URLの形式が不正です");
+  }
+  if (!CAPTION_ALLOWED_HOSTNAMES.includes(hostname)) {
+    throw new Error("字幕URLのホスト名が許可されていません");
+  }
+}
+
+/**
  * 字幕 URL から字幕本文を取得する
  *
  * @param baseUrl - 字幕 API の baseUrl
@@ -265,6 +296,8 @@ function decodeXmlEntities(text: string): string {
  * @throws Error - 取得失敗、または字幕が空の場合
  */
 async function fetchCaptionText(baseUrl: string): Promise<string> {
+  validateCaptionBaseUrl(baseUrl);
+
   const response = await fetch(baseUrl, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     headers: { "User-Agent": TECHCLIP_USER_AGENT },
@@ -295,7 +328,8 @@ async function fetchCaptions(videoUrl: string): Promise<string> {
   if (tracks.length === 0) {
     throw new Error(NO_CAPTIONS_ERROR_CODE);
   }
-  const track = selectCaptionTrack(tracks);
+  const nonEmptyTracks = tracks as [CaptionTrack, ...CaptionTrack[]];
+  const track = selectCaptionTrack(nonEmptyTracks);
   return fetchCaptionText(track.baseUrl);
 }
 
@@ -316,8 +350,7 @@ export async function parseYouTube(url: string): Promise<ParsedArticle> {
   const oembed = await fetchOEmbed(watchUrl);
   const captionText = await fetchCaptions(watchUrl);
 
-  const excerpt =
-    captionText.length > EXCERPT_MAX_LENGTH ? createExcerpt(captionText) : captionText;
+  const excerpt = createExcerpt(captionText);
 
   return {
     title: oembed.title,

--- a/apps/api/src/services/parsers/youtube.ts
+++ b/apps/api/src/services/parsers/youtube.ts
@@ -42,9 +42,6 @@ const CAPTION_ENTRIES_MAX = 10_000;
 /** 動画 ID 抽出用パターン（11文字の英数字・ハイフン・アンダースコア） */
 const VIDEO_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
 
-/** ytInitialPlayerResponse を抽出する正規表現 */
-const PLAYER_RESPONSE_REGEX = /var\s+ytInitialPlayerResponse\s*=\s*(\{[\s\S]*?\});/;
-
 /** 字幕 XML 内の text タグを抽出する正規表現 */
 const CAPTION_TEXT_REGEX = /<text[^>]*>([\s\S]*?)<\/text>/g;
 
@@ -196,6 +193,34 @@ async function fetchVideoPageHtml(videoUrl: string): Promise<string> {
 }
 
 /**
+ * テキスト中の指定位置以降から最初の JSON オブジェクトをブラケット深度カウントで抽出する
+ *
+ * ReDoS を回避するため正規表現を使わず、'{' / '}' の深度を追跡して抽出する。
+ *
+ * @param text - 検索対象のテキスト
+ * @param startIndex - 検索開始位置
+ * @returns 抽出した JSON 文字列。見つからない場合は null
+ */
+function extractJsonObject(text: string, startIndex: number): string | null {
+  const start = text.indexOf("{", startIndex);
+  if (start === -1) {
+    return null;
+  }
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "{") {
+      depth++;
+    } else if (text[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * 動画ページの HTML から字幕トラック一覧を抽出する
  *
  * @param html - 動画ページの HTML
@@ -206,20 +231,26 @@ function extractCaptionTracks(html: string): CaptionTrack[] {
   if (markerIndex === -1) {
     return [];
   }
-  const searchStart = Math.max(0, markerIndex - 10);
-  const searchArea = html.slice(searchStart, markerIndex + PLAYER_RESPONSE_SEARCH_RANGE);
-  const match = PLAYER_RESPONSE_REGEX.exec(searchArea);
-  if (!match?.[1]) {
+  const searchEnd = Math.min(html.length, markerIndex + PLAYER_RESPONSE_SEARCH_RANGE);
+  const searchArea = html.slice(markerIndex, searchEnd);
+
+  const jsonStart = searchArea.indexOf("{");
+  if (jsonStart === -1) {
     return [];
   }
 
-  if (match[1].length > PLAYER_RESPONSE_JSON_MAX_LENGTH) {
+  const jsonStr = extractJsonObject(searchArea, jsonStart);
+  if (!jsonStr) {
+    return [];
+  }
+
+  if (jsonStr.length > PLAYER_RESPONSE_JSON_MAX_LENGTH) {
     return [];
   }
 
   let parsed: PlayerResponse;
   try {
-    parsed = JSON.parse(match[1]) as PlayerResponse;
+    parsed = JSON.parse(jsonStr) as PlayerResponse;
   } catch {
     return [];
   }

--- a/apps/api/src/services/parsers/youtube.ts
+++ b/apps/api/src/services/parsers/youtube.ts
@@ -30,6 +30,15 @@ const VIDEO_PAGE_HTML_MAX_BYTES = 5 * 1024 * 1024;
 /** ytInitialPlayerResponse JSON の文字数上限。JSON.parse サイズ制限 */
 const PLAYER_RESPONSE_JSON_MAX_LENGTH = 500 * 1024;
 
+/** ytInitialPlayerResponse 検索範囲（バイト）。バックトラッキング対策のため切り出し範囲を制限する */
+const PLAYER_RESPONSE_SEARCH_RANGE = 500_000;
+
+/** 字幕 XML の最大サイズ（バイト）。過大レスポンス対策 */
+const CAPTION_XML_MAX_BYTES = 1_000_000;
+
+/** 字幕エントリの最大件数。過大 XML 対策 */
+const CAPTION_ENTRIES_MAX = 10_000;
+
 /** 動画 ID 抽出用パターン（11文字の英数字・ハイフン・アンダースコア） */
 const VIDEO_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
 
@@ -193,7 +202,13 @@ async function fetchVideoPageHtml(videoUrl: string): Promise<string> {
  * @returns 字幕トラックの配列。存在しない場合は空配列
  */
 function extractCaptionTracks(html: string): CaptionTrack[] {
-  const match = html.match(PLAYER_RESPONSE_REGEX);
+  const markerIndex = html.indexOf("ytInitialPlayerResponse");
+  if (markerIndex === -1) {
+    return [];
+  }
+  const searchStart = Math.max(0, markerIndex - 10);
+  const searchArea = html.slice(searchStart, markerIndex + PLAYER_RESPONSE_SEARCH_RANGE);
+  const match = PLAYER_RESPONSE_REGEX.exec(searchArea);
   if (!match?.[1]) {
     return [];
   }
@@ -248,13 +263,52 @@ function selectCaptionTrack(tracks: readonly [CaptionTrack, ...CaptionTrack[]]):
  */
 function parseCaptionXml(xml: string): string {
   const lines: string[] = [];
+  let count = 0;
   for (const match of xml.matchAll(CAPTION_TEXT_REGEX)) {
+    if (count >= CAPTION_ENTRIES_MAX) {
+      break;
+    }
     const text = decodeXmlEntities(match[1]).trim();
     if (text.length > 0) {
       lines.push(text);
     }
+    count++;
   }
   return lines.join("\n");
+}
+
+/**
+ * XML で禁止されている制御文字か判定する
+ *
+ * 対象: U+0000-U+0008, U+000B-U+000C, U+000E-U+001F
+ *
+ * @param code - 文字コードポイント
+ * @returns 制御文字であれば true
+ */
+function isXmlForbiddenControlChar(code: number): boolean {
+  return (
+    (code >= 0x00 && code <= 0x08) ||
+    code === 0x0b ||
+    code === 0x0c ||
+    (code >= 0x0e && code <= 0x1f)
+  );
+}
+
+/**
+ * 文字列から XML 禁止制御文字を除去する
+ *
+ * @param text - 入力テキスト
+ * @returns 制御文字を除去したテキスト
+ */
+function stripXmlForbiddenControlChars(text: string): string {
+  let result = "";
+  for (const char of text) {
+    const code = char.codePointAt(0) ?? 0;
+    if (!isXmlForbiddenControlChar(code)) {
+      result += char;
+    }
+  }
+  return result;
 }
 
 /**
@@ -264,10 +318,12 @@ function parseCaptionXml(xml: string): string {
  * @returns デコード済みテキスト
  */
 function decodeXmlEntities(text: string): string {
-  return text
-    .replace(/&#x([\da-fA-F]+);/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
-    .replace(/&([a-zA-Z]+);/g, (match, name) => NAMED_ENTITY_MAP[name] ?? match);
+  return stripXmlForbiddenControlChars(
+    text
+      .replace(/&#x([\da-fA-F]+);/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+      .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+      .replace(/&([a-zA-Z]+);/g, (match, name) => NAMED_ENTITY_MAP[name] ?? match),
+  );
 }
 
 /**
@@ -307,7 +363,11 @@ async function fetchCaptionText(baseUrl: string): Promise<string> {
     throw new Error(NO_CAPTIONS_ERROR_CODE);
   }
 
-  const xml = await response.text();
+  const buffer = await response.arrayBuffer();
+  if (buffer.byteLength > CAPTION_XML_MAX_BYTES) {
+    throw new Error("字幕XMLのサイズが上限を超えています");
+  }
+  const xml = new TextDecoder().decode(buffer);
   const text = parseCaptionXml(xml);
   if (text.length === 0) {
     throw new Error(NO_CAPTIONS_ERROR_CODE);

--- a/apps/api/src/services/parsers/youtube.ts
+++ b/apps/api/src/services/parsers/youtube.ts
@@ -1,0 +1,332 @@
+import { z } from "zod";
+
+import type { ParsedArticle } from "../../types/article";
+import {
+  calculateReadingTime,
+  createExcerpt,
+  EXCERPT_MAX_LENGTH,
+  TECHCLIP_USER_AGENT,
+} from "./_shared";
+
+/** YouTube oEmbed API エンドポイント */
+const OEMBED_ENDPOINT = "https://www.youtube.com/oembed";
+
+/** 字幕なしを示すエラーコード（呼び出し側で 422 にマップする） */
+const NO_CAPTIONS_ERROR_CODE = "NO_CAPTIONS";
+
+/** ソース識別子 */
+const SOURCE_IDENTIFIER = "youtube";
+
+/** fetch タイムアウト（ミリ秒） */
+const FETCH_TIMEOUT_MS = 10000;
+
+/** YouTube ホスト名（標準ドメイン） */
+const YOUTUBE_HOSTNAMES = ["www.youtube.com", "youtube.com", "m.youtube.com"];
+
+/** YouTube 短縮ホスト名 */
+const YOUTU_BE_HOSTNAME = "youtu.be";
+
+/** 動画 ID 抽出用パターン（11文字の英数字・ハイフン・アンダースコア） */
+const VIDEO_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
+
+/** ytInitialPlayerResponse を抽出する正規表現 */
+const PLAYER_RESPONSE_REGEX = /var\s+ytInitialPlayerResponse\s*=\s*(\{[\s\S]*?\});/;
+
+/** 字幕 XML 内の text タグを抽出する正規表現 */
+const CAPTION_TEXT_REGEX = /<text[^>]*>([\s\S]*?)<\/text>/g;
+
+/** HTML named entity マップ（字幕 XML 内に出現するもの） */
+const NAMED_ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: "\u00a0",
+};
+
+/**
+ * oEmbed API レスポンスの Zod スキーマ
+ */
+const OEmbedResponseSchema = z.object({
+  title: z.string(),
+  author_name: z.string(),
+  author_url: z.string().optional(),
+  thumbnail_url: z.string().optional(),
+});
+
+/** oEmbed API レスポンス */
+type OEmbedResponse = z.infer<typeof OEmbedResponseSchema>;
+
+/** 字幕トラック情報 */
+type CaptionTrack = {
+  baseUrl: string;
+  languageCode: string;
+  kind?: string;
+};
+
+/** ytInitialPlayerResponse の必要部分の型 */
+type PlayerResponse = {
+  captions?: {
+    playerCaptionsTracklistRenderer?: {
+      captionTracks?: CaptionTrack[];
+    };
+  };
+};
+
+/**
+ * URL から YouTube 動画 ID を抽出する
+ *
+ * youtube.com の watch / shorts、youtu.be の短縮 URL に対応する。
+ *
+ * @param url - YouTube の動画 URL
+ * @returns 11文字の動画 ID
+ * @throws Error - YouTube 以外の URL、または動画 ID を抽出できない場合
+ */
+export function extractYouTubeVideoId(url: string): string {
+  const parsed = new URL(url);
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (hostname === YOUTU_BE_HOSTNAME) {
+    const id = parsed.pathname.slice(1).split("/")[0];
+    if (!VIDEO_ID_REGEX.test(id)) {
+      throw new Error("YouTube動画IDを抽出できません");
+    }
+    return id;
+  }
+
+  if (!YOUTUBE_HOSTNAMES.includes(hostname)) {
+    throw new Error("YouTubeのURLではありません");
+  }
+
+  if (parsed.pathname === "/watch") {
+    const id = parsed.searchParams.get("v");
+    if (!id || !VIDEO_ID_REGEX.test(id)) {
+      throw new Error("YouTube動画IDを抽出できません");
+    }
+    return id;
+  }
+
+  if (parsed.pathname.startsWith("/shorts/")) {
+    const id = parsed.pathname.replace("/shorts/", "").split("/")[0];
+    if (!VIDEO_ID_REGEX.test(id)) {
+      throw new Error("YouTube動画IDを抽出できません");
+    }
+    return id;
+  }
+
+  throw new Error("YouTube動画IDを抽出できません");
+}
+
+/**
+ * 標準化された動画ページ URL を生成する
+ *
+ * @param videoId - 動画 ID
+ * @returns watch ページの URL
+ */
+function buildWatchUrl(videoId: string): string {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+/**
+ * oEmbed API から動画情報を取得する
+ *
+ * @param videoUrl - 動画 URL
+ * @returns oEmbed レスポンス
+ * @throws Error - API 失敗、またはレスポンスが不正な場合
+ */
+async function fetchOEmbed(videoUrl: string): Promise<OEmbedResponse> {
+  const oembedUrl = `${OEMBED_ENDPOINT}?url=${encodeURIComponent(videoUrl)}&format=json`;
+  const response = await fetch(oembedUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { "User-Agent": TECHCLIP_USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(`YouTube動画情報の取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  const raw: unknown = await response.json();
+  const parsed = OEmbedResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error("YouTube動画情報のレスポンス形式が不正です");
+  }
+  return parsed.data;
+}
+
+/**
+ * 動画ページの HTML を取得する
+ *
+ * @param videoUrl - 動画 URL
+ * @returns 動画ページの HTML 文字列
+ * @throws Error - 取得失敗時
+ */
+async function fetchVideoPageHtml(videoUrl: string): Promise<string> {
+  const response = await fetch(videoUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: {
+      "User-Agent": TECHCLIP_USER_AGENT,
+      "Accept-Language": "ja,en;q=0.9",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`YouTube動画ページの取得に失敗しました（ステータス: ${response.status}）`);
+  }
+
+  return response.text();
+}
+
+/**
+ * 動画ページの HTML から字幕トラック一覧を抽出する
+ *
+ * @param html - 動画ページの HTML
+ * @returns 字幕トラックの配列。存在しない場合は空配列
+ */
+function extractCaptionTracks(html: string): CaptionTrack[] {
+  const match = html.match(PLAYER_RESPONSE_REGEX);
+  if (!match?.[1]) {
+    return [];
+  }
+
+  let parsed: PlayerResponse;
+  try {
+    parsed = JSON.parse(match[1]) as PlayerResponse;
+  } catch {
+    return [];
+  }
+
+  const tracks = parsed.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+  if (!Array.isArray(tracks)) {
+    return [];
+  }
+  return tracks;
+}
+
+/**
+ * 字幕トラックの中から優先度の高いものを 1 件選ぶ
+ *
+ * 日本語 → 英語 → 自動生成以外 → 先頭 の順で優先する。
+ *
+ * @param tracks - 字幕トラック配列
+ * @returns 選択された字幕トラック
+ */
+function selectCaptionTrack(tracks: CaptionTrack[]): CaptionTrack {
+  const japanese = tracks.find((track) => track.languageCode === "ja");
+  if (japanese) {
+    return japanese;
+  }
+  const english = tracks.find((track) => track.languageCode === "en");
+  if (english) {
+    return english;
+  }
+  const manual = tracks.find((track) => track.kind !== "asr");
+  if (manual) {
+    return manual;
+  }
+  return tracks[0];
+}
+
+/**
+ * 字幕 XML をプレーンテキストに変換する
+ *
+ * @param xml - timedtext API が返す XML
+ * @returns 結合済みのテキスト
+ */
+function parseCaptionXml(xml: string): string {
+  const lines: string[] = [];
+  for (const match of xml.matchAll(CAPTION_TEXT_REGEX)) {
+    const text = decodeXmlEntities(match[1]).trim();
+    if (text.length > 0) {
+      lines.push(text);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * XML エンティティをデコードする
+ *
+ * @param text - エンコード済みテキスト
+ * @returns デコード済みテキスト
+ */
+function decodeXmlEntities(text: string): string {
+  return text
+    .replace(/&#x([\da-fA-F]+);/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&([a-zA-Z]+);/g, (match, name) => NAMED_ENTITY_MAP[name] ?? match);
+}
+
+/**
+ * 字幕 URL から字幕本文を取得する
+ *
+ * @param baseUrl - 字幕 API の baseUrl
+ * @returns 字幕テキスト
+ * @throws Error - 取得失敗、または字幕が空の場合
+ */
+async function fetchCaptionText(baseUrl: string): Promise<string> {
+  const response = await fetch(baseUrl, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    headers: { "User-Agent": TECHCLIP_USER_AGENT },
+  });
+
+  if (!response.ok) {
+    throw new Error(NO_CAPTIONS_ERROR_CODE);
+  }
+
+  const xml = await response.text();
+  const text = parseCaptionXml(xml);
+  if (text.length === 0) {
+    throw new Error(NO_CAPTIONS_ERROR_CODE);
+  }
+  return text;
+}
+
+/**
+ * YouTube 動画ページから字幕本文を取得する
+ *
+ * @param videoUrl - 動画 URL
+ * @returns 字幕テキスト
+ * @throws Error - 字幕が見つからない場合は NO_CAPTIONS
+ */
+async function fetchCaptions(videoUrl: string): Promise<string> {
+  const html = await fetchVideoPageHtml(videoUrl);
+  const tracks = extractCaptionTracks(html);
+  if (tracks.length === 0) {
+    throw new Error(NO_CAPTIONS_ERROR_CODE);
+  }
+  const track = selectCaptionTrack(tracks);
+  return fetchCaptionText(track.baseUrl);
+}
+
+/**
+ * YouTube 動画 URL をパースする
+ *
+ * oEmbed でメタ情報を取得し、動画ページから字幕トラックを抽出する。
+ * 字幕がない場合は NO_CAPTIONS エラーを投げる（呼び出し側で 422 を返す）。
+ *
+ * @param url - YouTube 動画 URL
+ * @returns パース済み記事情報
+ * @throws Error - YouTube 以外の URL、字幕なし、API 失敗時
+ */
+export async function parseYouTube(url: string): Promise<ParsedArticle> {
+  const videoId = extractYouTubeVideoId(url);
+  const watchUrl = buildWatchUrl(videoId);
+
+  const oembed = await fetchOEmbed(watchUrl);
+  const captionText = await fetchCaptions(watchUrl);
+
+  const excerpt =
+    captionText.length > EXCERPT_MAX_LENGTH ? createExcerpt(captionText) : captionText;
+
+  return {
+    title: oembed.title,
+    author: oembed.author_name,
+    content: captionText,
+    excerpt,
+    thumbnailUrl: oembed.thumbnail_url ?? null,
+    readingTimeMinutes: calculateReadingTime(captionText),
+    publishedAt: null,
+    source: SOURCE_IDENTIFIER,
+  };
+}

--- a/apps/api/src/services/source-detector.ts
+++ b/apps/api/src/services/source-detector.ts
@@ -60,6 +60,9 @@ const SMASHING_PATTERN = /^(www\.)?smashingmagazine\.com/;
 /** Twitter/X判定パターン */
 const TWITTER_PATTERN = /^(www\.)?(x\.com|twitter\.com)\/\w+\/status\//;
 
+/** YouTube判定パターン (youtube.com の watch / shorts と youtu.be の短縮 URL に対応) */
+const YOUTUBE_PATTERN = /^((www\.|m\.)?youtube\.com\/(watch|shorts)|youtu\.be\/)/;
+
 /** URLホスト+パスとArticleSourceの対応表 */
 const SOURCE_MAPPINGS: SourceMapping[] = [
   { pattern: ZENN_BOOKS_PATTERN, source: "zenn" },
@@ -80,6 +83,7 @@ const SOURCE_MAPPINGS: SourceMapping[] = [
   { pattern: CSS_TRICKS_PATTERN, source: "css-tricks" },
   { pattern: SMASHING_PATTERN, source: "smashing" },
   { pattern: TWITTER_PATTERN, source: "twitter" },
+  { pattern: YOUTUBE_PATTERN, source: "youtube" },
 ];
 
 /**

--- a/apps/api/src/services/summary.ts
+++ b/apps/api/src/services/summary.ts
@@ -1,7 +1,11 @@
+import { DEFAULT_GEMMA_MODEL_TAG } from "../lib/ai-model";
+
 /** RunPod接続設定 */
 export type RunPodConfig = {
   apiKey: string;
   endpointId: string;
+  /** データベース保存用のモデルタグ（省略時は DEFAULT_GEMMA_MODEL_TAG を使用） */
+  modelTag?: string;
 };
 
 /** 要約生成結果 */
@@ -31,9 +35,6 @@ type SummarizeArticleParams = {
 /** コンテンツの最大文字数（約8000トークン相当） */
 const MAX_CONTENT_LENGTH = 24000;
 
-/** RunPodモデル名 */
-const MODEL_NAME = "qwen3.5-9b";
-
 /** RunPod API ベースURL */
 const RUNPOD_API_BASE = "https://api.runpod.ai/v2";
 
@@ -43,6 +44,12 @@ const POLLING_INTERVAL_MS = 2000;
 /** RunPod APIのポーリング最大回数 */
 const MAX_POLLING_ATTEMPTS = 60;
 
+/** 要約生成時の最大トークン数 */
+const SUMMARY_MAX_TOKENS = 1024;
+
+/** 要約生成時の temperature */
+const SUMMARY_TEMPERATURE = 0.3;
+
 /** 言語名マッピング */
 const LANGUAGE_NAMES: Record<string, string> = {
   ja: "Japanese",
@@ -50,6 +57,16 @@ const LANGUAGE_NAMES: Record<string, string> = {
   zh: "Chinese",
   ko: "Korean",
 };
+
+/**
+ * 使用するモデルタグを解決する
+ *
+ * @param config - RunPod接続設定
+ * @returns modelTagが未指定の場合はデフォルトタグ
+ */
+function resolveModelTag(config: RunPodConfig): string {
+  return config.modelTag ?? DEFAULT_GEMMA_MODEL_TAG;
+}
 
 function buildPrompt(content: string, language: string): string {
   const truncated =
@@ -65,6 +82,43 @@ Article:
 ${truncated}
 
 Summary:`;
+}
+
+/** RunPod要約レスポンスの期待する構造（Gemma chat template 互換） */
+type RunPodSummaryOutput = {
+  output: {
+    choices: Array<{
+      message: {
+        content: string;
+      };
+    }>;
+  };
+};
+
+/**
+ * RunPod要約レスポンスの型ガード
+ *
+ * @param value - 検証対象の値
+ * @returns RunPodSummaryOutput型かどうか
+ */
+function isRunPodSummaryOutput(value: unknown): value is RunPodSummaryOutput {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (typeof v.output !== "object" || v.output === null) {
+    return false;
+  }
+  const output = v.output as Record<string, unknown>;
+  if (!Array.isArray(output.choices) || output.choices.length === 0) {
+    return false;
+  }
+  const first = output.choices[0] as Record<string, unknown> | undefined;
+  if (typeof first?.message !== "object" || first.message === null) {
+    return false;
+  }
+  const message = first.message as Record<string, unknown>;
+  return typeof message.content === "string";
 }
 
 function mapRunPodStatus(status: string): "queued" | "running" | "completed" | "failed" {
@@ -84,6 +138,7 @@ export async function createSummaryJob(params: SummarizeArticleParams): Promise<
   const { content, language, config, fetchFn = fetch } = params;
   const prompt = buildPrompt(content, language);
   const runUrl = `${RUNPOD_API_BASE}/${config.endpointId}/run`;
+  const modelTag = resolveModelTag(config);
 
   const response = await fetchFn(runUrl, {
     method: "POST",
@@ -93,9 +148,9 @@ export async function createSummaryJob(params: SummarizeArticleParams): Promise<
     },
     body: JSON.stringify({
       input: {
-        prompt,
-        max_tokens: 1024,
-        temperature: 0.3,
+        messages: [{ role: "user", content: prompt }],
+        max_tokens: SUMMARY_MAX_TOKENS,
+        temperature: SUMMARY_TEMPERATURE,
       },
     }),
   });
@@ -112,7 +167,7 @@ export async function createSummaryJob(params: SummarizeArticleParams): Promise<
 
   return {
     providerJobId: data.id,
-    model: MODEL_NAME,
+    model: modelTag,
   };
 }
 
@@ -123,6 +178,7 @@ export async function getSummaryJobStatus(params: {
 }): Promise<SummaryJobStatus> {
   const { providerJobId, config, fetchFn = fetch } = params;
   const statusUrl = `${RUNPOD_API_BASE}/${config.endpointId}/status/${providerJobId}`;
+  const modelTag = resolveModelTag(config);
 
   const response = await fetchFn(statusUrl, {
     headers: {
@@ -137,22 +193,22 @@ export async function getSummaryJobStatus(params: {
   const data = (await response.json()) as {
     status: string;
     error?: string;
-    output?: { text?: string };
+    output?: unknown;
   };
   const status = mapRunPodStatus(data.status);
 
-  if (status === "completed" && data.output?.text) {
+  if (status === "completed" && isRunPodSummaryOutput(data)) {
     return {
       status: "completed",
-      model: MODEL_NAME,
-      summary: data.output.text,
+      model: modelTag,
+      summary: data.output.choices[0].message.content,
     };
   }
 
   if (status === "failed") {
     return {
       status: "failed",
-      model: MODEL_NAME,
+      model: modelTag,
       error: data.error ?? "RunPod job failed",
     };
   }
@@ -160,14 +216,14 @@ export async function getSummaryJobStatus(params: {
   if (status === "completed") {
     return {
       status: "failed",
-      model: MODEL_NAME,
+      model: modelTag,
       error: "RunPod job completed without summary output",
     };
   }
 
   return {
     status,
-    model: MODEL_NAME,
+    model: modelTag,
   };
 }
 

--- a/apps/api/src/services/translator.ts
+++ b/apps/api/src/services/translator.ts
@@ -1,8 +1,7 @@
+import { DEFAULT_GEMMA_MODEL_TAG } from "../lib/ai-model";
+
 /** RunPod API ベースURL */
 const RUNPOD_API_BASE = "https://api.runpod.ai/v2";
-
-/** 使用するモデル名 */
-const MODEL_NAME = "qwen3.5-9b";
 
 /** 翻訳時の最大トークン数 */
 const MAX_TRANSLATION_TOKENS = 4096;
@@ -29,6 +28,8 @@ export type TranslateOptions = {
   targetLanguage: string;
   runpodApiKey: string;
   runpodEndpointId: string;
+  /** データベース保存用のモデルタグ（省略時は DEFAULT_GEMMA_MODEL_TAG を使用） */
+  modelTag?: string;
 };
 
 /** 翻訳結果 */
@@ -177,6 +178,16 @@ function parseArticleTranslationPayload(text: string): {
   };
 }
 
+/**
+ * 使用するモデルタグを解決する
+ *
+ * @param modelTag - 任意のモデルタグ
+ * @returns 未指定の場合は DEFAULT_GEMMA_MODEL_TAG
+ */
+function resolveModelTag(modelTag: string | undefined): string {
+  return modelTag ?? DEFAULT_GEMMA_MODEL_TAG;
+}
+
 async function callRunPodTranslation(
   text: string,
   targetLanguage: string,
@@ -216,7 +227,7 @@ async function callRunPodTranslation(
 export async function createTranslationJob(
   options: TranslateOptions,
 ): Promise<TranslationJobResult> {
-  const { title, content, targetLanguage, runpodApiKey, runpodEndpointId } = options;
+  const { title, content, targetLanguage, runpodApiKey, runpodEndpointId, modelTag } = options;
   const { text: textWithoutCode } = extractCodeBlocks(content);
   const prompt = buildArticleTranslationPrompt(title, textWithoutCode, targetLanguage);
   const url = `${RUNPOD_API_BASE}/${runpodEndpointId}/run`;
@@ -247,7 +258,7 @@ export async function createTranslationJob(
 
   return {
     providerJobId: data.id,
-    model: MODEL_NAME,
+    model: resolveModelTag(modelTag),
   };
 }
 
@@ -256,9 +267,11 @@ export async function getTranslationJobStatus(params: {
   content: string;
   runpodApiKey: string;
   runpodEndpointId: string;
+  modelTag?: string;
 }): Promise<TranslationJobStatus> {
-  const { providerJobId, content, runpodApiKey, runpodEndpointId } = params;
+  const { providerJobId, content, runpodApiKey, runpodEndpointId, modelTag } = params;
   const url = `${RUNPOD_API_BASE}/${runpodEndpointId}/status/${providerJobId}`;
+  const resolvedTag = resolveModelTag(modelTag);
 
   const response = await fetch(url, {
     headers: {
@@ -289,7 +302,7 @@ export async function getTranslationJobStatus(params: {
 
     return {
       status: "completed",
-      model: MODEL_NAME,
+      model: resolvedTag,
       translatedTitle: parsed.translatedTitle,
       translatedContent: restoreCodeBlocks(parsed.translatedContent, blocks),
     };
@@ -298,19 +311,19 @@ export async function getTranslationJobStatus(params: {
   if (data.status === "FAILED" || data.status === "CANCELLED" || data.status === "TIMED_OUT") {
     return {
       status: "failed",
-      model: MODEL_NAME,
+      model: resolvedTag,
       error: data.error ?? "RunPodジョブの実行に失敗しました",
     };
   }
 
   return {
     status: data.status === "IN_QUEUE" ? "queued" : "running",
-    model: MODEL_NAME,
+    model: resolvedTag,
   };
 }
 
 export async function translateArticle(options: TranslateOptions): Promise<TranslationResult> {
-  const { title, content, targetLanguage, runpodApiKey, runpodEndpointId } = options;
+  const { title, content, targetLanguage, runpodApiKey, runpodEndpointId, modelTag } = options;
 
   try {
     const { text: textWithoutCode, blocks } = extractCodeBlocks(content);
@@ -325,7 +338,7 @@ export async function translateArticle(options: TranslateOptions): Promise<Trans
     return {
       translatedTitle,
       translatedContent,
-      model: MODEL_NAME,
+      model: resolveModelTag(modelTag),
     };
   } catch (error) {
     if (error instanceof Error && error.message.includes("RunPod API")) {

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -32,6 +32,8 @@ export type Bindings = {
   SENTRY_DSN?: string;
   /** RevenueCat Webhook シークレット */
   REVENUECAT_WEBHOOK_SECRET?: string;
+  /** Gemmaモデル名（省略時は DEFAULT_GEMMA_MODEL_TAG を使用） */
+  GEMMA_MODEL_NAME?: string;
 };
 
 /** リクエストスコープで共有する変数 */

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -32,7 +32,7 @@ export type Bindings = {
   SENTRY_DSN?: string;
   /** RevenueCat Webhook シークレット */
   REVENUECAT_WEBHOOK_SECRET?: string;
-  /** Gemmaモデル名（省略時は DEFAULT_GEMMA_MODEL_TAG を使用） */
+  /** データベース保存用Gemmaモデルタグ（省略時は DEFAULT_GEMMA_MODEL_TAG を使用） */
   GEMMA_MODEL_NAME?: string;
 };
 

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -11,12 +11,13 @@ RUN pip install --no-cache-dir \
 # ハンドラーをコピー
 COPY handler.py .
 
-# 16GB GPU を狙うため、量子化済み AWQ モデルをデフォルトにする。
-ARG MODEL_NAME=QuantTrio/Qwen3.5-9B-AWQ
+# デフォルトは Google の Gemma 3 12B IT。
+# GEMMA_MODEL_NAME 環境変数で HuggingFace モデル名を差し替え可能。
+ARG MODEL_NAME=google/gemma-3-12b-it
 ENV MODEL_NAME=${MODEL_NAME}
 ENV MODEL_PATH=${MODEL_NAME}
-ENV VLLM_QUANTIZATION=awq
-ENV MAX_MODEL_LEN=2048
+# Gemma は量子化なしのネイティブ fp16/bf16 を想定する。
+ENV MAX_MODEL_LEN=4096
 ENV MAX_NUM_SEQS=2
 ENV GPU_MEMORY_UTILIZATION=0.85
 ENV TENSOR_PARALLEL_SIZE=1

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -107,6 +107,27 @@ def validate_max_tokens(value: Any) -> int:
     return value
 
 
+def validate_temperature(value: Any) -> float:
+    """
+    temperature の値を検証する。
+
+    Args:
+        value: 検証対象の temperature 値
+
+    Returns:
+        検証済み temperature 浮動小数点数値
+
+    Raises:
+        ValueError: 型・範囲が不正な場合
+    """
+    if not isinstance(value, (int, float)):
+        raise ValueError("temperature は数値である必要があります")
+    temperature = float(value)
+    if temperature < 0.0 or temperature > 1.0:
+        raise ValueError("temperature は 0.0 以上 1.0 以下である必要があります")
+    return temperature
+
+
 def handle_messages_request(job_input: dict) -> dict:
     """
     messages キーを使ったリクエストを処理する（要約・翻訳共通）。
@@ -123,7 +144,8 @@ def handle_messages_request(job_input: dict) -> dict:
     messages = validate_messages(job_input["messages"])
     raw_max_tokens = job_input.get("max_tokens", 4096)
     max_tokens = validate_max_tokens(raw_max_tokens)
-    temperature = job_input.get("temperature", 0.3)
+    raw_temperature = job_input.get("temperature", 0.3)
+    temperature = validate_temperature(raw_temperature)
 
     tokenizer = llm.get_tokenizer()
     prompt = tokenizer.apply_chat_template(

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -73,11 +73,13 @@ def validate_messages(messages: Any) -> list[dict]:
     for i, msg in enumerate(messages):
         if not isinstance(msg, dict):
             raise ValueError(f"messages[{i}] はオブジェクト形式である必要があります")
-        if not isinstance(msg.get("role"), str) or msg["role"] not in valid_roles:
+        role = msg.get("role")
+        if isinstance(role, bool) or not isinstance(role, str) or role not in valid_roles:
             raise ValueError(
                 f"messages[{i}].role は {valid_roles} のいずれかである必要があります"
             )
-        if not isinstance(msg.get("content"), str):
+        content = msg.get("content")
+        if isinstance(content, bool) or not isinstance(content, str):
             raise ValueError(f"messages[{i}].content は文字列である必要があります")
         if len(msg["content"]) > MESSAGE_CONTENT_MAX_LENGTH:
             raise ValueError(
@@ -100,7 +102,7 @@ def validate_max_tokens(value: Any) -> int:
     Raises:
         ValueError: 型・範囲が不正な場合
     """
-    if not isinstance(value, int):
+    if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError("max_tokens は整数である必要があります")
     if value <= 0 or value > MAX_TOKENS_LIMIT:
         raise ValueError(f"max_tokens は 1 以上 {MAX_TOKENS_LIMIT} 以下である必要があります")
@@ -120,7 +122,7 @@ def validate_temperature(value: Any) -> float:
     Raises:
         ValueError: 型・範囲が不正な場合
     """
-    if not isinstance(value, (int, float)):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError("temperature は数値である必要があります")
     temperature = float(value)
     if temperature < 0.0 or temperature > 1.0:

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -14,8 +14,15 @@ Google Gemma 3 12B IT モデルを vLLM で起動し、RunPod サーバーレス
 """
 
 import os
+from typing import Any
 import runpod
 from vllm import LLM, SamplingParams
+
+# メッセージ本文の最大文字数
+MESSAGE_CONTENT_MAX_LENGTH = 50000
+
+# max_tokens の最大値
+MAX_TOKENS_LIMIT = 8192
 
 # モデル参照の解決優先順位:
 #   1. GEMMA_MODEL_NAME (Gemma 系切り替え用の専用変数)
@@ -41,8 +48,63 @@ llm = LLM(
     max_num_seqs=MAX_NUM_SEQS,
     gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
     tensor_parallel_size=TENSOR_PARALLEL_SIZE,
-    trust_remote_code=True,
 )
+
+
+def validate_messages(messages: Any) -> list[dict]:
+    """
+    messages の型・内容を検証する。
+
+    Args:
+        messages: 検証対象の messages 値
+
+    Returns:
+        検証済み messages リスト
+
+    Raises:
+        ValueError: 形式が不正な場合
+    """
+    if not isinstance(messages, list):
+        raise ValueError("messages はリスト形式である必要があります")
+    if len(messages) == 0:
+        raise ValueError("messages は 1 件以上必要です")
+
+    valid_roles = {"user", "assistant", "system"}
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            raise ValueError(f"messages[{i}] はオブジェクト形式である必要があります")
+        if not isinstance(msg.get("role"), str) or msg["role"] not in valid_roles:
+            raise ValueError(
+                f"messages[{i}].role は {valid_roles} のいずれかである必要があります"
+            )
+        if not isinstance(msg.get("content"), str):
+            raise ValueError(f"messages[{i}].content は文字列である必要があります")
+        if len(msg["content"]) > MESSAGE_CONTENT_MAX_LENGTH:
+            raise ValueError(
+                f"messages[{i}].content は {MESSAGE_CONTENT_MAX_LENGTH} 文字以内である必要があります"
+            )
+
+    return messages
+
+
+def validate_max_tokens(value: Any) -> int:
+    """
+    max_tokens の値を検証する。
+
+    Args:
+        value: 検証対象の max_tokens 値
+
+    Returns:
+        検証済み max_tokens 整数値
+
+    Raises:
+        ValueError: 型・範囲が不正な場合
+    """
+    if not isinstance(value, int):
+        raise ValueError("max_tokens は整数である必要があります")
+    if value <= 0 or value > MAX_TOKENS_LIMIT:
+        raise ValueError(f"max_tokens は 1 以上 {MAX_TOKENS_LIMIT} 以下である必要があります")
+    return value
 
 
 def handle_messages_request(job_input: dict) -> dict:
@@ -54,9 +116,13 @@ def handle_messages_request(job_input: dict) -> dict:
 
     Returns:
         {"choices": [{"message": {"role": "assistant", "content": "..."}}]}
+
+    Raises:
+        ValueError: 入力バリデーション失敗時
     """
-    messages = job_input["messages"]
-    max_tokens = job_input.get("max_tokens", 4096)
+    messages = validate_messages(job_input["messages"])
+    raw_max_tokens = job_input.get("max_tokens", 4096)
+    max_tokens = validate_max_tokens(raw_max_tokens)
     temperature = job_input.get("temperature", 0.3)
 
     tokenizer = llm.get_tokenizer()
@@ -103,7 +169,11 @@ def handler(job: dict) -> dict:
     if "messages" not in job_input:
         return {"error": "input に messages キーが必要です"}
 
-    output = handle_messages_request(job_input)
+    try:
+        output = handle_messages_request(job_input)
+    except ValueError as e:
+        return {"error": str(e)}
+
     return {"output": output}
 
 

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -1,39 +1,42 @@
 """
 RunPodサーバーレスハンドラー
 
-Qwen3.5-9BモデルをvLLMで起動し、RunPodサーバーレスAPIのリクエストを処理する。
+Google Gemma 3 12B IT モデルを vLLM で起動し、RunPod サーバーレス API のリクエストを処理する。
 
 リクエスト形式:
-    {"input": {"prompt": "...", "max_tokens": 1024}}
-    または
     {"input": {"messages": [{"role": "user", "content": "..."}], "max_tokens": 4096}}
 
-レスポンス形式（promptの場合）:
-    {"output": {"text": "..."}}
-
-レスポンス形式（messagesの場合）:
+レスポンス形式:
     {"output": {"choices": [{"message": {"role": "assistant", "content": "..."}}]}}
+
+モデル名は以下の優先順で解決する:
+    GEMMA_MODEL_NAME 環境変数 -> MODEL_PATH 環境変数 -> MODEL_NAME 環境変数 -> デフォルト
 """
 
 import os
 import runpod
 from vllm import LLM, SamplingParams
 
-# モデル参照。Dockerfile では Hugging Face のモデル名をそのまま入れる。
-MODEL_REF = os.environ.get("MODEL_PATH") or os.environ.get(
-    "MODEL_NAME", "QuantTrio/Qwen3.5-9B-AWQ"
+# モデル参照の解決優先順位:
+#   1. GEMMA_MODEL_NAME (Gemma 系切り替え用の専用変数)
+#   2. MODEL_PATH (汎用パス指定)
+#   3. MODEL_NAME (Dockerfile からの注入)
+#   4. デフォルト (google/gemma-3-12b-it)
+MODEL_REF = (
+    os.environ.get("GEMMA_MODEL_NAME")
+    or os.environ.get("MODEL_PATH")
+    or os.environ.get("MODEL_NAME", "google/gemma-3-12b-it")
 )
 MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "4096"))
-MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "4"))
+MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "2"))
 GPU_MEMORY_UTILIZATION = float(os.environ.get("GPU_MEMORY_UTILIZATION", "0.85"))
 TENSOR_PARALLEL_SIZE = int(os.environ.get("TENSOR_PARALLEL_SIZE", "1"))
-QUANTIZATION = os.environ.get("VLLM_QUANTIZATION", "awq")
 
-# 16GB GPU を前提に、KV cache と同時実行数を抑えた設定にする。
+# Gemma は量子化なしのネイティブ fp16/bf16 を想定する。
+# 16GB GPU で動かす場合は MAX_MODEL_LEN と MAX_NUM_SEQS を小さく保つ。
 llm = LLM(
     model=MODEL_REF,
-    quantization=QUANTIZATION,
-    dtype="half",
+    dtype="bfloat16",
     max_model_len=MAX_MODEL_LEN,
     max_num_seqs=MAX_NUM_SEQS,
     gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
@@ -42,34 +45,9 @@ llm = LLM(
 )
 
 
-def handle_prompt_request(job_input: dict) -> dict:
-    """
-    promptキーを使ったリクエストを処理する（要約用）。
-
-    Args:
-        job_input: {"prompt": "...", "max_tokens": 1024, "temperature": 0.3}
-
-    Returns:
-        {"text": "生成されたテキスト"}
-    """
-    prompt = job_input["prompt"]
-    max_tokens = job_input.get("max_tokens", 1024)
-    temperature = job_input.get("temperature", 0.7)
-
-    sampling_params = SamplingParams(
-        max_tokens=max_tokens,
-        temperature=temperature,
-    )
-
-    outputs = llm.generate([prompt], sampling_params)
-    generated_text = outputs[0].outputs[0].text
-
-    return {"text": generated_text}
-
-
 def handle_messages_request(job_input: dict) -> dict:
     """
-    messagesキーを使ったリクエストを処理する（翻訳用）。
+    messages キーを使ったリクエストを処理する（要約・翻訳共通）。
 
     Args:
         job_input: {"messages": [{"role": "user", "content": "..."}], "max_tokens": 4096}
@@ -110,25 +88,22 @@ def handle_messages_request(job_input: dict) -> dict:
 
 def handler(job: dict) -> dict:
     """
-    RunPodサーバーレスハンドラーのエントリーポイント。
+    RunPod サーバーレスハンドラーのエントリーポイント。
 
-    promptキーとmessagesキーの両形式に対応する。
+    Gemma 3 では messages 形式のみをサポートする。
 
     Args:
-        job: RunPodジョブオブジェクト（{"input": {...}}）
+        job: RunPod ジョブオブジェクト（{"input": {...}}）
 
     Returns:
-        生成結果（{"output": {...}}形式）
+        生成結果（{"output": {...}} 形式）
     """
     job_input = job.get("input", {})
 
-    if "messages" in job_input:
-        output = handle_messages_request(job_input)
-    elif "prompt" in job_input:
-        output = handle_prompt_request(job_input)
-    else:
-        return {"error": "inputにpromptまたはmessagesキーが必要です"}
+    if "messages" not in job_input:
+        return {"error": "input に messages キーが必要です"}
 
+    output = handle_messages_request(job_input)
     return {"output": output}
 
 

--- a/packages/types/src/article.ts
+++ b/packages/types/src/article.ts
@@ -16,6 +16,7 @@ export type ArticleSource =
   | "css-tricks"
   | "smashing"
   | "twitter"
+  | "youtube"
   | "other";
 
 export type Article = {

--- a/tests/api/lib/ai-model.test.ts
+++ b/tests/api/lib/ai-model.test.ts
@@ -1,0 +1,63 @@
+import {
+  DEFAULT_GEMMA_MODEL,
+  DEFAULT_GEMMA_MODEL_TAG,
+  resolveGemmaModelTag,
+} from "@api/lib/ai-model";
+import { describe, expect, it } from "vitest";
+
+describe("ai-model", () => {
+  describe("DEFAULT_GEMMA_MODEL", () => {
+    it("HuggingFace準拠のGemma3 12Bモデル名を定義していること", () => {
+      // Arrange & Act
+      const model = DEFAULT_GEMMA_MODEL;
+
+      // Assert
+      expect(model).toBe("gemma-3-12b-it");
+    });
+  });
+
+  describe("DEFAULT_GEMMA_MODEL_TAG", () => {
+    it("データベース保存用の短縮タグを定義していること", () => {
+      // Arrange & Act
+      const tag = DEFAULT_GEMMA_MODEL_TAG;
+
+      // Assert
+      expect(tag).toBe("gemma3-12b");
+    });
+  });
+
+  describe("resolveGemmaModelTag", () => {
+    it("環境変数が未定義の場合デフォルトタグを返すこと", () => {
+      // Arrange
+      const envValue = undefined;
+
+      // Act
+      const result = resolveGemmaModelTag(envValue);
+
+      // Assert
+      expect(result).toBe(DEFAULT_GEMMA_MODEL_TAG);
+    });
+
+    it("環境変数が空文字の場合デフォルトタグを返すこと", () => {
+      // Arrange
+      const envValue = "";
+
+      // Act
+      const result = resolveGemmaModelTag(envValue);
+
+      // Assert
+      expect(result).toBe(DEFAULT_GEMMA_MODEL_TAG);
+    });
+
+    it("環境変数が設定されている場合その値を返すこと", () => {
+      // Arrange
+      const envValue = "gemma4-9b";
+
+      // Act
+      const result = resolveGemmaModelTag(envValue);
+
+      // Assert
+      expect(result).toBe("gemma4-9b");
+    });
+  });
+});

--- a/tests/api/lib/ai-model.test.ts
+++ b/tests/api/lib/ai-model.test.ts
@@ -1,21 +1,7 @@
-import {
-  DEFAULT_GEMMA_MODEL,
-  DEFAULT_GEMMA_MODEL_TAG,
-  resolveGemmaModelTag,
-} from "@api/lib/ai-model";
+import { DEFAULT_GEMMA_MODEL_TAG, resolveGemmaModelTag } from "@api/lib/ai-model";
 import { describe, expect, it } from "vitest";
 
 describe("ai-model", () => {
-  describe("DEFAULT_GEMMA_MODEL", () => {
-    it("HuggingFace準拠のGemma3 12Bモデル名を定義していること", () => {
-      // Arrange & Act
-      const model = DEFAULT_GEMMA_MODEL;
-
-      // Assert
-      expect(model).toBe("gemma-3-12b-it");
-    });
-  });
-
   describe("DEFAULT_GEMMA_MODEL_TAG", () => {
     it("データベース保存用の短縮タグを定義していること", () => {
       // Arrange & Act

--- a/tests/api/routes/articles.test.ts
+++ b/tests/api/routes/articles.test.ts
@@ -920,6 +920,42 @@ describe("POST /api/articles", () => {
       expect(body.success).toBe(false);
       expect(body.error?.code).toBe("INTERNAL_ERROR");
     });
+
+    it("YouTube字幕なしエラー(NO_CAPTIONS)の場合422を返すこと", async () => {
+      // Arrange
+      const app = createPostTestApp();
+      mockSelectWhere.mockResolvedValue([]);
+      mockParseArticle.mockRejectedValue(new Error("NO_CAPTIONS"));
+
+      // Act
+      const res = await postArticle(app, {
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      });
+
+      // Assert
+      expect(res.status).toBe(HTTP_UNPROCESSABLE_ENTITY);
+      const body = (await res.json()) as ArticleResponseBody;
+      expect(body.success).toBe(false);
+      expect(body.error?.code).toBe("NO_CAPTIONS");
+    });
+
+    it("YouTube字幕なしエラーのメッセージが日本語であること", async () => {
+      // Arrange
+      const app = createPostTestApp();
+      mockSelectWhere.mockResolvedValue([]);
+      mockParseArticle.mockRejectedValue(new Error("NO_CAPTIONS"));
+
+      // Act
+      const res = await postArticle(app, {
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      });
+
+      // Assert
+      const body = (await res.json()) as ArticleResponseBody;
+      expect(body.error?.message).toBe(
+        "この動画には字幕がないため、要約できません。別の動画をお試しください",
+      );
+    });
   });
 
   describe("レスポンス形式", () => {

--- a/tests/api/services/article-parser.test.ts
+++ b/tests/api/services/article-parser.test.ts
@@ -78,6 +78,10 @@ vi.mock("@api/services/parsers/speakerdeck", () => ({
   parseSpeakerdeck: vi.fn(),
 }));
 
+vi.mock("@api/services/parsers/youtube", () => ({
+  parseYouTube: vi.fn(),
+}));
+
 /** モック化されたdetectSource */
 const mockDetectSource = sourceDetectorModule.detectSource as Mock;
 
@@ -339,6 +343,24 @@ describe("parseArticle", () => {
       expect(parseSpeakerdeck).toHaveBeenCalledWith(url);
       expect(result.source).toBe("speakerdeck");
     });
+
+    it("YouTube URLがparseYouTubeにディスパッチされること", async () => {
+      // Arrange
+      const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+      mockDetectSource.mockReturnValue("youtube");
+      const { parseYouTube } = await import("@api/services/parsers/youtube");
+      (parseYouTube as Mock).mockResolvedValue({
+        ...MOCK_PARSE_RESULT,
+        source: "youtube",
+      });
+
+      // Act
+      const result = await parseArticle(url);
+
+      // Assert
+      expect(parseYouTube).toHaveBeenCalledWith(url);
+      expect(result.source).toBe("youtube");
+    });
   });
 
   describe("汎用パーサーへのフォールバック", () => {
@@ -441,6 +463,19 @@ describe("parseArticle", () => {
 
       // Act & Assert
       await expect(parseArticle(url)).rejects.toThrow("記事の取得に失敗しました");
+    });
+
+    it("YouTubeパーサーがNO_CAPTIONSエラーを投げた場合フォールバックせずそのまま伝播すること", async () => {
+      // Arrange
+      const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+      mockDetectSource.mockReturnValue("youtube");
+      const { parseYouTube } = await import("@api/services/parsers/youtube");
+      (parseYouTube as Mock).mockRejectedValue(new Error("NO_CAPTIONS"));
+      const { parseGeneric } = await import("@api/services/parsers/generic");
+
+      // Act & Assert
+      await expect(parseArticle(url)).rejects.toThrow("NO_CAPTIONS");
+      expect(parseGeneric).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/api/services/parsers/youtube.test.ts
+++ b/tests/api/services/parsers/youtube.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  extractYouTubeVideoId,
+  parseYouTube,
+} from "../../../../apps/api/src/services/parsers/youtube";
+
+/**
+ * テスト用の oEmbed レスポンスを生成する
+ */
+function buildOEmbedResponse(
+  overrides: Partial<Record<string, string>> = {},
+): Record<string, string> {
+  return {
+    title: "テスト動画タイトル",
+    author_name: "テストチャンネル",
+    author_url: "https://www.youtube.com/@testchannel",
+    thumbnail_url: "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+    type: "video",
+    provider_name: "YouTube",
+    provider_url: "https://www.youtube.com/",
+    ...overrides,
+  };
+}
+
+/**
+ * テスト用の動画ページ HTML を生成する
+ *
+ * 字幕トラックを含む ytInitialPlayerResponse を埋め込む。
+ */
+function buildVideoPageHtml(captionBaseUrl: string | null): string {
+  if (captionBaseUrl === null) {
+    const playerResponse = {
+      videoDetails: { videoId: "dQw4w9WgXcQ", title: "テスト動画タイトル" },
+    };
+    return `<html><body><script>var ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};</script></body></html>`;
+  }
+
+  const playerResponse = {
+    videoDetails: { videoId: "dQw4w9WgXcQ", title: "テスト動画タイトル" },
+    captions: {
+      playerCaptionsTracklistRenderer: {
+        captionTracks: [
+          {
+            baseUrl: captionBaseUrl,
+            languageCode: "ja",
+            kind: "",
+          },
+        ],
+      },
+    },
+  };
+  return `<html><body><script>var ytInitialPlayerResponse = ${JSON.stringify(playerResponse)};</script></body></html>`;
+}
+
+/**
+ * テスト用の字幕 XML を生成する
+ */
+function buildCaptionXml(): string {
+  return `<?xml version="1.0" encoding="utf-8" ?>
+<transcript>
+<text start="0" dur="2.5">こんにちは、視聴者の皆さん。</text>
+<text start="2.5" dur="3.0">本日は TypeScript について話します。</text>
+<text start="5.5" dur="2.0">よろしくお願いします。</text>
+</transcript>`;
+}
+
+describe("extractYouTubeVideoId", () => {
+  it("youtube.com/watch?v= 形式の URL から動画IDを抽出できること", () => {
+    // Arrange
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+    // Act
+    const result = extractYouTubeVideoId(url);
+
+    // Assert
+    expect(result).toBe("dQw4w9WgXcQ");
+  });
+
+  it("youtu.be 形式の短縮 URL から動画IDを抽出できること", () => {
+    // Arrange
+    const url = "https://youtu.be/dQw4w9WgXcQ";
+
+    // Act
+    const result = extractYouTubeVideoId(url);
+
+    // Assert
+    expect(result).toBe("dQw4w9WgXcQ");
+  });
+
+  it("youtube.com/shorts/ 形式の URL から動画IDを抽出できること", () => {
+    // Arrange
+    const url = "https://www.youtube.com/shorts/dQw4w9WgXcQ";
+
+    // Act
+    const result = extractYouTubeVideoId(url);
+
+    // Assert
+    expect(result).toBe("dQw4w9WgXcQ");
+  });
+
+  it("m.youtube.com/watch?v= 形式のモバイル URL から動画IDを抽出できること", () => {
+    // Arrange
+    const url = "https://m.youtube.com/watch?v=dQw4w9WgXcQ";
+
+    // Act
+    const result = extractYouTubeVideoId(url);
+
+    // Assert
+    expect(result).toBe("dQw4w9WgXcQ");
+  });
+
+  it("追加クエリパラメーターが付いている URL から動画IDを抽出できること", () => {
+    // Arrange
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42&feature=share";
+
+    // Act
+    const result = extractYouTubeVideoId(url);
+
+    // Assert
+    expect(result).toBe("dQw4w9WgXcQ");
+  });
+
+  it("YouTube ではない URL の場合エラーになること", () => {
+    // Arrange
+    const url = "https://example.com/watch?v=dQw4w9WgXcQ";
+
+    // Act & Assert
+    expect(() => extractYouTubeVideoId(url)).toThrow("YouTubeのURLではありません");
+  });
+
+  it("動画IDを抽出できない場合エラーになること", () => {
+    // Arrange
+    const url = "https://www.youtube.com/feed/trending";
+
+    // Act & Assert
+    expect(() => extractYouTubeVideoId(url)).toThrow("YouTube動画IDを抽出できません");
+  });
+});
+
+describe("parseYouTube", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("oEmbed と字幕からタイトル・著者・本文を取得できること", async () => {
+    // Arrange
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+    const oembed = buildOEmbedResponse();
+    const captionUrl = "https://www.youtube.com/api/timedtext?lang=ja&v=dQw4w9WgXcQ";
+    const html = buildVideoPageHtml(captionUrl);
+    const captionXml = buildCaptionXml();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockImplementation(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === "string" ? input : input.toString();
+      if (requestUrl.includes("/oembed")) {
+        return new Response(JSON.stringify(oembed), { status: 200 });
+      }
+      if (requestUrl.includes("/watch")) {
+        return new Response(html, { status: 200 });
+      }
+      if (requestUrl.includes("/api/timedtext")) {
+        return new Response(captionXml, { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    // Act
+    const result = await parseYouTube(url);
+
+    // Assert
+    expect(result.title).toBe("テスト動画タイトル");
+    expect(result.author).toBe("テストチャンネル");
+    expect(result.content).toContain("こんにちは、視聴者の皆さん。");
+    expect(result.content).toContain("TypeScript");
+    expect(result.thumbnailUrl).toBe("https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg");
+    expect(result.source).toBe("youtube");
+    expect(result.readingTimeMinutes).toBeGreaterThanOrEqual(1);
+  });
+
+  it("字幕がない動画の場合 NO_CAPTIONS エラーになること", async () => {
+    // Arrange
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+    const oembed = buildOEmbedResponse();
+    const html = buildVideoPageHtml(null);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === "string" ? input : input.toString();
+      if (requestUrl.includes("/oembed")) {
+        return new Response(JSON.stringify(oembed), { status: 200 });
+      }
+      if (requestUrl.includes("/watch")) {
+        return new Response(html, { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    // Act & Assert
+    await expect(parseYouTube(url)).rejects.toThrow("NO_CAPTIONS");
+  });
+
+  it("oEmbed API が失敗した場合エラーになること", async () => {
+    // Arrange
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === "string" ? input : input.toString();
+      if (requestUrl.includes("/oembed")) {
+        return new Response("Not Found", { status: 404 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    // Act & Assert
+    await expect(parseYouTube(url)).rejects.toThrow("YouTube動画情報の取得に失敗しました");
+  });
+
+  it("動画ページが取得できない場合エラーになること", async () => {
+    // Arrange
+    const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+    const oembed = buildOEmbedResponse();
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === "string" ? input : input.toString();
+      if (requestUrl.includes("/oembed")) {
+        return new Response(JSON.stringify(oembed), { status: 200 });
+      }
+      if (requestUrl.includes("/watch")) {
+        return new Response("Server Error", { status: 500 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    // Act & Assert
+    await expect(parseYouTube(url)).rejects.toThrow("YouTube動画ページの取得に失敗しました");
+  });
+
+  it("不正なURLの場合エラーになること", async () => {
+    // Arrange
+    const url = "https://example.com/not-youtube";
+
+    // Act & Assert
+    await expect(parseYouTube(url)).rejects.toThrow("YouTubeのURLではありません");
+  });
+
+  it("YouTube Shorts の URL も同様に処理できること", async () => {
+    // Arrange
+    const url = "https://www.youtube.com/shorts/dQw4w9WgXcQ";
+    const oembed = buildOEmbedResponse();
+    const captionUrl = "https://www.youtube.com/api/timedtext?lang=en&v=dQw4w9WgXcQ";
+    const html = buildVideoPageHtml(captionUrl);
+    const captionXml = buildCaptionXml();
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === "string" ? input : input.toString();
+      if (requestUrl.includes("/oembed")) {
+        return new Response(JSON.stringify(oembed), { status: 200 });
+      }
+      if (requestUrl.includes("/watch")) {
+        return new Response(html, { status: 200 });
+      }
+      if (requestUrl.includes("/api/timedtext")) {
+        return new Response(captionXml, { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    // Act
+    const result = await parseYouTube(url);
+
+    // Assert
+    expect(result.title).toBe("テスト動画タイトル");
+    expect(result.content).toContain("こんにちは");
+  });
+});

--- a/tests/api/services/source-detector.test.ts
+++ b/tests/api/services/source-detector.test.ts
@@ -322,6 +322,52 @@ describe("detectSource", () => {
     });
   });
 
+  describe("YouTube", () => {
+    it("youtube.com の通常動画URLを判定できること", () => {
+      // Arrange
+      const url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("youtube");
+    });
+
+    it("youtu.be の短縮URLを判定できること", () => {
+      // Arrange
+      const url = "https://youtu.be/dQw4w9WgXcQ";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("youtube");
+    });
+
+    it("youtube.com の Shorts URLを判定できること", () => {
+      // Arrange
+      const url = "https://www.youtube.com/shorts/dQw4w9WgXcQ";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("youtube");
+    });
+
+    it("m.youtube.com のモバイルURLを判定できること", () => {
+      // Arrange
+      const url = "https://m.youtube.com/watch?v=dQw4w9WgXcQ";
+
+      // Act
+      const result = detectSource(url);
+
+      // Assert
+      expect(result).toBe("youtube");
+    });
+  });
+
   describe("その他", () => {
     it("未知のドメインの場合otherを返すこと", () => {
       // Arrange

--- a/tests/api/services/summary.test.ts
+++ b/tests/api/services/summary.test.ts
@@ -1,12 +1,22 @@
+import { DEFAULT_GEMMA_MODEL_TAG } from "@api/lib/ai-model";
 import type { SummaryResult } from "@api/services/summary";
 import { createSummaryJob, getSummaryJobStatus, summarizeArticle } from "@api/services/summary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const MOCK_SUMMARY_TEXT = "## 概要\nこの記事はTypeScriptの型システムについて解説しています。";
 
 const MOCK_RUNPOD_SUCCESS_RESPONSE = {
   id: "run_abc123",
   status: "COMPLETED",
   output: {
-    text: "## 概要\nこの記事はTypeScriptの型システムについて解説しています。",
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: MOCK_SUMMARY_TEXT,
+        },
+      },
+    ],
   },
 };
 
@@ -40,6 +50,48 @@ describe("summary service", () => {
     });
 
     expect(result.providerJobId).toBe("run_abc123");
+    expect(result.model).toBe(DEFAULT_GEMMA_MODEL_TAG);
+  });
+
+  it("createSummaryJobがRunPodにmessages形式でリクエストすること", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "run_abc123" }), { status: HTTP_OK }),
+      );
+
+    await createSummaryJob({
+      content: MOCK_CONTENT,
+      language: "ja",
+      config: MOCK_CONFIG,
+      fetchFn: mockFetch,
+    });
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    const body = JSON.parse(requestInit.body as string) as {
+      input: { messages?: Array<{ role: string; content: string }>; prompt?: string };
+    };
+    expect(body.input.messages).toBeDefined();
+    expect(body.input.prompt).toBeUndefined();
+    expect(body.input.messages?.[0].role).toBe("user");
+    expect(body.input.messages?.[0].content).toContain("TypeScript");
+  });
+
+  it("config.modelTagが指定されている場合その値を返すこと", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: "run_abc123" }), { status: HTTP_OK }),
+      );
+
+    const result = await createSummaryJob({
+      content: MOCK_CONTENT,
+      language: "ja",
+      config: { ...MOCK_CONFIG, modelTag: "gemma4-9b" },
+      fetchFn: mockFetch,
+    });
+
+    expect(result.model).toBe("gemma4-9b");
   });
 
   it("getSummaryJobStatusがcompletedを返すこと", async () => {
@@ -79,7 +131,7 @@ describe("summary service", () => {
     });
 
     expect(result.summary).toContain("TypeScript");
-    expect(result.model).toBe("qwen3.5-9b");
+    expect(result.model).toBe(DEFAULT_GEMMA_MODEL_TAG);
   });
 
   it("戻り値がSummaryResult型であること", async () => {

--- a/tests/api/services/translator.test.ts
+++ b/tests/api/services/translator.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_GEMMA_MODEL_TAG } from "@api/lib/ai-model";
 import {
   buildPrompt,
   createTranslationJob,
@@ -126,6 +127,25 @@ describe("translator", () => {
     const result = await translateArticle(options);
 
     expect(result.translatedTitle).toBe("How to use React Hooks");
-    expect(result.model).toBe("qwen3.5-9b");
+    expect(result.model).toBe(DEFAULT_GEMMA_MODEL_TAG);
+  });
+
+  it("modelTagが指定されている場合createTranslationJobが指定タグを返すこと", async () => {
+    const options: TranslateOptions = {
+      title: "テスト",
+      content: "テスト本文",
+      targetLanguage: "en",
+      runpodApiKey: RUNPOD_CONFIG.apiKey,
+      runpodEndpointId: RUNPOD_CONFIG.endpointId,
+      modelTag: "gemma4-9b",
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "run_abc123" }),
+    });
+
+    const result = await createTranslationJob(options);
+    expect(result.model).toBe("gemma4-9b");
   });
 });


### PR DESCRIPTION
## Summary

- Qwen から Gemma 3 12B IT (`gemma-3-12b-it`) へモデル切り替え
- YouTube 動画 URL からキャプションを取得して要約する機能を追加
- モデル名を環境変数 `GEMMA_MODEL_NAME` で設定可能に変更

## Changes

- `apps/api/src/lib/ai-model.ts`: Gemma モデルタグ定数
- `apps/api/src/services/parsers/youtube.ts`: YouTube キャプション取得・パース（SSRF対策・ReDoS対策含む）
- `apps/api/src/services/summary.ts` / `translator.ts`: Gemma messages 形式対応
- `apps/api/src/services/source-detector.ts`: YouTube URL パターン追加
- `packages/types/src/article.ts`: `ArticleSource` に `"youtube"` 追加
- `infra/runpod/handler.py`: Gemma messages 形式ハンドラー・入力バリデーション強化
- `infra/runpod/Dockerfile`: デフォルトモデルを `gemma-3-12b-it` に変更

## Test plan

- [x] `pnpm lint` クリーン
- [x] `pnpm typecheck` 全パッケージ成功
- [x] `pnpm test` 2035件全通過（youtube.test.ts 13件含む）
- [x] code-reviewer PASS
- [x] security-reviewer PASS

Closes #806

🤖 Generated with [Claude Code](https://claude.ai/code)