### PR TITLE
fix: CI の Nix セットアップで claude-code-bin の unfree ライセンスを許可する #809

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -15,4 +15,6 @@ runs:
       continue-on-error: true
     - name: Install deps (nix develop)
       shell: bash
+      env:
+        NIXPKGS_ALLOW_UNFREE: "1"
       run: nix develop --command pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- `.github/actions/nix-setup/action.yml` の `nix develop` ステップに `NIXPKGS_ALLOW_UNFREE=1` 環境変数を追加
- `flake.nix` に含まれる `claude-code-bin`（unfree ライセンス）の評価エラーを解消し、CI の全ジョブが Nix セットアップ段階で失敗する問題を修正

Closes #809

## Test plan

- [ ] PR の CI (`audit` / `lint` / `test` / `typecheck` / `zap` / `hooks-test`) が Nix セットアップ段階でエラーなく通過することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)