### PR TITLE
feat: RunPod を AWQ/GPTQ 量子化で高速化（turboquant）#731

### DIFF
--- a/infra/runpod/.dockerignore
+++ b/infra/runpod/.dockerignore
@@ -1,0 +1,7 @@
+.env
+*.env
+*.key
+*.pem
+__pycache__/
+*.pyc
+.git

--- a/infra/runpod/.dockerignore
+++ b/infra/runpod/.dockerignore
@@ -11,4 +11,5 @@ tests/
 __tests__/
 *.test.py
 *.spec.py
+# ドキュメント類（README.md を含む）は実行に不要
 *.md

--- a/infra/runpod/.dockerignore
+++ b/infra/runpod/.dockerignore
@@ -4,4 +4,10 @@
 *.pem
 __pycache__/
 *.pyc
-.git
+.git/
+**/.git
+*.log
+tests/
+__tests__/
+*.test.py
+*.spec.py

--- a/infra/runpod/.dockerignore
+++ b/infra/runpod/.dockerignore
@@ -11,3 +11,4 @@ tests/
 __tests__/
 *.test.py
 *.spec.py
+*.md

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -11,8 +11,8 @@ RUN pip install --no-cache-dir \
 # ハンドラーをコピー
 COPY handler.py .
 
-# デフォルトは信頼できる組織の Gemma 3 12B IT AWQ 量子化済みモデル。
-# MODEL_NAME 環境変数で HuggingFace モデル名を差し替え可能。
+# デフォルトは量子化なし（bfloat16）。AWQ を使う場合は MODEL_NAME を AWQ モデルに
+# 変更し、VLLM_QUANTIZATION=awq を同時に設定すること。
 # 注意: モデル変更はレビュー必須。許可モデル一覧は管理ドキュメントで管理する。
 ARG MODEL_NAME=google/gemma-3-12b-it
 ENV MODEL_NAME=${MODEL_NAME}

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -1,36 +1,35 @@
-FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04
+FROM nvidia/cuda:12.8.0-cudnn9-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 python3.12-pip git && \
+    rm -rf /var/lib/apt/lists/*
+
+# CUDA 対応 PyTorch（Transformers の基盤）
+RUN python3.12 -m pip install --no-cache-dir \
+    torch --index-url https://download.pytorch.org/whl/cu128
+
+# TurboQuant（SWA バイパス付き、Gemma 4 対応）
+# back2matching/turboquant は Gemma 4 のハイブリッド注意機構（SWA）をバイパスし、
+# グローバル注意層のみ KV キャッシュを圧縮する。
+# fused-turboquant（PyPI 公式）は SWA 未対応のため使用しない。
+RUN python3.12 -m pip install --no-cache-dir turboquant
+
+# HuggingFace Transformers + RunPod SDK
+RUN python3.12 -m pip install --no-cache-dir \
+    "transformers>=4.51.0" \
+    accelerate \
+    auto-round \
+    "runpod>=1.7.4"
 
 WORKDIR /app
-
-# vLLM と RunPod サーバーレスランタイムのみを入れる。
-# モデルは image に焼かず、RunPod の cached models / Hugging Face cache を使う。
-RUN pip install --no-cache-dir \
-    vllm==0.7.3 \
-    runpod==1.7.4
-
-# ハンドラーをコピー
 COPY handler.py .
 
-# デフォルトは量子化なし（bfloat16）。AWQ を使う場合は MODEL_NAME を AWQ モデルに
-# 変更し、VLLM_QUANTIZATION=awq を同時に設定すること。
-# 注意: モデル変更はレビュー必須。許可モデル一覧は管理ドキュメントで管理する。
-ARG MODEL_NAME=google/gemma-3-12b-it
-ENV MODEL_NAME=${MODEL_NAME}
-ENV MODEL_PATH=${MODEL_NAME}
+# モデル ID は環境変数で上書き可能
+ENV MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
 
-# 量子化設定（awq / gptq_marlin / fp8 / 空文字で非量子化）
-# AWQ 量子化済みモデルを使う場合は "awq" を設定する。
-# 量子化モデルは信頼できる組織（例: neuralmagic / RedHatAI / google）のものを指定する。
-ARG VLLM_QUANTIZATION=
-ENV VLLM_QUANTIZATION=${VLLM_QUANTIZATION}
+# モデルキャッシュをボリュームマウントへ（コールドスタート対策）
+ENV HF_HOME=/runpod-volume/hf-cache
+ENV TRANSFORMERS_OFFLINE=0
 
-# AWQ 量子化時は dtype=auto を推奨（vLLM が自動でカーネルを選択する）
-ENV VLLM_DTYPE=auto
-
-# 量子化で VRAM に余裕が出るため非量子化より大きく設定できる
-ENV MAX_MODEL_LEN=8192
-ENV MAX_NUM_SEQS=4
-ENV GPU_MEMORY_UTILIZATION=0.90
-ENV TENSOR_PARALLEL_SIZE=1
-
-CMD ["python", "-u", "handler.py"]
+CMD ["python3.12", "-u", "handler.py"]

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -1,18 +1,18 @@
 # Stage 1: builder（devel イメージでパッケージをインストール）
 FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04 AS builder
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --target /install \
     transformers==4.51.3 \
     accelerate==1.6.0 \
     auto-round==0.5.3 \
     runpod==1.7.4 \
-    git+https://github.com/back2matching/turboquant.git@main
+    git+https://github.com/back2matching/turboquant.git@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0
 
 # Stage 2: runtime（軽量イメージ）
 FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04
 
-# site-packages とビルド成果物をコピー
-COPY --from=builder /usr/local/lib/python3.11/dist-packages /usr/local/lib/python3.11/dist-packages
+# builder ステージでインストールしたパッケージをコピー（devel 固有ファイルを除外）
+COPY --from=builder /install /usr/local/lib/python3.11/site-packages
 
 # 非 root ユーザーを作成
 RUN useradd -m -u 1000 appuser \

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -12,7 +12,8 @@ RUN pip install --no-cache-dir --target /install \
 FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04
 
 # builder ステージでインストールしたパッケージをコピー（devel 固有ファイルを除外）
-COPY --from=builder /install /usr/local/lib/python3.11/site-packages
+COPY --from=builder /install /opt/app-packages
+ENV PYTHONPATH=/opt/app-packages
 
 # 非 root ユーザーを作成
 RUN useradd -m -u 1000 appuser \
@@ -20,8 +21,7 @@ RUN useradd -m -u 1000 appuser \
     && chown -R appuser /app /runpod-volume
 
 WORKDIR /app
-COPY handler.py .
-RUN chown appuser /app/handler.py
+COPY --chown=appuser:appuser handler.py .
 
 USER appuser
 

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -18,6 +18,7 @@ USER appuser
 
 ENV MODEL_ID=raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4
 ENV HF_HOME=/runpod-volume/hf-cache
+# TRANSFORMERS_OFFLINE=1: ネットワークボリューム（HF_HOME）へのモデル事前ダウンロードが必須
 ENV TRANSFORMERS_OFFLINE=1
 
 CMD ["python", "-u", "handler.py"]

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -1,19 +1,12 @@
-# Stage 1: builder（vLLM 公式イメージでパッケージをインストール）
-FROM vllm/vllm-openai:v0.9.0 AS builder
+# vLLM 公式イメージ（PyTorch + CUDA 同梱）
+FROM vllm/vllm-openai:v0.9.0@sha256:df2c55e5107afea09ea1a50f9dd96c99ebf97a795334c4d08f691f3d79b2ab12
 
-# 0xSero/turboquant を固定コミットでインストール
-RUN pip install --no-cache-dir --target /opt/app-packages \
+# 追加パッケージをインストール
+RUN pip install --no-cache-dir \
     runpod==1.7.4 \
     git+https://github.com/0xSero/turboquant.git@7ac9b8d165a3f7d5e6df33b0450bc1f88ec0d4d5
 
-# Stage 2: runtime（vLLM 公式 runtime イメージ）
-FROM vllm/vllm-openai:v0.9.0
-
-# builder ステージでインストールした追加パッケージをコピー
-COPY --from=builder /opt/app-packages /opt/app-packages
-ENV PYTHONPATH=/opt/app-packages
-
-# 非 root ユーザーを作成
+# 非 root ユーザー
 RUN useradd -m -u 1000 appuser \
     && mkdir -p /app \
     && chown -R appuser /app
@@ -23,13 +16,8 @@ COPY --chown=appuser:appuser handler.py .
 
 USER appuser
 
-# モデル ID は環境変数で上書き可能（GPTQ Int4）
 ENV MODEL_ID=raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4
-
-# モデルキャッシュをボリュームマウントへ（コールドスタート対策）
 ENV HF_HOME=/runpod-volume/hf-cache
-
-# オフラインモード: モデルは /runpod-volume/hf-cache に事前ダウンロードしておくこと
 ENV TRANSFORMERS_OFFLINE=1
 
 CMD ["python", "-u", "handler.py"]

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -1,35 +1,37 @@
-FROM nvidia/cuda:12.8.0-cudnn9-devel-ubuntu22.04
+# Stage 1: builder（devel イメージでパッケージをインストール）
+FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04 AS builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3.12 python3.12-pip git && \
-    rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir \
+    transformers==4.51.3 \
+    accelerate==1.6.0 \
+    auto-round==0.5.3 \
+    runpod==1.7.4 \
+    git+https://github.com/back2matching/turboquant.git@main
 
-# CUDA 対応 PyTorch（Transformers の基盤）
-RUN python3.12 -m pip install --no-cache-dir \
-    torch --index-url https://download.pytorch.org/whl/cu128
+# Stage 2: runtime（軽量イメージ）
+FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04
 
-# TurboQuant（SWA バイパス付き、Gemma 4 対応）
-# back2matching/turboquant は Gemma 4 のハイブリッド注意機構（SWA）をバイパスし、
-# グローバル注意層のみ KV キャッシュを圧縮する。
-# fused-turboquant（PyPI 公式）は SWA 未対応のため使用しない。
-RUN python3.12 -m pip install --no-cache-dir turboquant
+# site-packages とビルド成果物をコピー
+COPY --from=builder /usr/local/lib/python3.11/dist-packages /usr/local/lib/python3.11/dist-packages
 
-# HuggingFace Transformers + RunPod SDK
-RUN python3.12 -m pip install --no-cache-dir \
-    "transformers>=4.51.0" \
-    accelerate \
-    auto-round \
-    "runpod>=1.7.4"
+# 非 root ユーザーを作成
+RUN useradd -m -u 1000 appuser \
+    && mkdir -p /app /runpod-volume \
+    && chown -R appuser /app /runpod-volume
 
 WORKDIR /app
 COPY handler.py .
+RUN chown appuser /app/handler.py
+
+USER appuser
 
 # モデル ID は環境変数で上書き可能
 ENV MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
 
 # モデルキャッシュをボリュームマウントへ（コールドスタート対策）
 ENV HF_HOME=/runpod-volume/hf-cache
-ENV TRANSFORMERS_OFFLINE=0
 
-CMD ["python3.12", "-u", "handler.py"]
+# オフラインモード: モデルは /runpod-volume/hf-cache に事前ダウンロードしておくこと
+ENV TRANSFORMERS_OFFLINE=1
+
+CMD ["python3.11", "-u", "handler.py"]

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -11,15 +11,23 @@ RUN pip install --no-cache-dir \
 # ハンドラーをコピー
 COPY handler.py .
 
-# デフォルトは Google の Gemma 3 12B IT。
+# デフォルトは Google の Gemma 3 12B IT AWQ 量子化済みモデル。
 # GEMMA_MODEL_NAME 環境変数で HuggingFace モデル名を差し替え可能。
-ARG MODEL_NAME=google/gemma-3-12b-it
+ARG MODEL_NAME=abhishek/gemma-3-12b-it-awq
 ENV MODEL_NAME=${MODEL_NAME}
 ENV MODEL_PATH=${MODEL_NAME}
-# Gemma は量子化なしのネイティブ fp16/bf16 を想定する。
-ENV MAX_MODEL_LEN=4096
-ENV MAX_NUM_SEQS=2
-ENV GPU_MEMORY_UTILIZATION=0.85
+
+# 量子化設定（awq / gptq_marlin / fp8 / 空文字で非量子化）
+# AWQ 量子化済みモデルを使う場合は "awq" を設定する
+ENV VLLM_QUANTIZATION=awq
+
+# AWQ 量子化時は dtype=auto を推奨（vLLM が自動でカーネルを選択する）
+ENV VLLM_DTYPE=auto
+
+# 量子化で VRAM に余裕が出るため非量子化より大きく設定できる
+ENV MAX_MODEL_LEN=8192
+ENV MAX_NUM_SEQS=4
+ENV GPU_MEMORY_UTILIZATION=0.90
 ENV TENSOR_PARALLEL_SIZE=1
 
 CMD ["python", "-u", "handler.py"]

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -1,7 +1,7 @@
 # Stage 1: builder（devel イメージでパッケージをインストール）
 FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04 AS builder
 
-RUN pip install --no-cache-dir --target /install \
+RUN pip install --no-cache-dir --target /opt/app-packages \
     transformers==4.51.3 \
     accelerate==1.6.0 \
     auto-round==0.5.3 \
@@ -12,13 +12,13 @@ RUN pip install --no-cache-dir --target /install \
 FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04
 
 # builder ステージでインストールしたパッケージをコピー（devel 固有ファイルを除外）
-COPY --from=builder /install /opt/app-packages
+COPY --from=builder /opt/app-packages /opt/app-packages
 ENV PYTHONPATH=/opt/app-packages
 
 # 非 root ユーザーを作成
 RUN useradd -m -u 1000 appuser \
-    && mkdir -p /app /runpod-volume \
-    && chown -R appuser /app /runpod-volume
+    && mkdir -p /app \
+    && chown -R appuser /app
 
 WORKDIR /app
 COPY --chown=appuser:appuser handler.py .
@@ -34,4 +34,4 @@ ENV HF_HOME=/runpod-volume/hf-cache
 # オフラインモード: モデルは /runpod-volume/hf-cache に事前ダウンロードしておくこと
 ENV TRANSFORMERS_OFFLINE=1
 
-CMD ["python3.11", "-u", "handler.py"]
+CMD ["python", "-u", "handler.py"]

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -1,17 +1,15 @@
-# Stage 1: builder（devel イメージでパッケージをインストール）
-FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04 AS builder
+# Stage 1: builder（vLLM 公式イメージでパッケージをインストール）
+FROM vllm/vllm-openai:v0.9.0 AS builder
 
+# 0xSero/turboquant を固定コミットでインストール
 RUN pip install --no-cache-dir --target /opt/app-packages \
-    transformers==4.51.3 \
-    accelerate==1.6.0 \
-    auto-round==0.5.3 \
     runpod==1.7.4 \
-    git+https://github.com/back2matching/turboquant.git@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0
+    git+https://github.com/0xSero/turboquant.git@7ac9b8d165a3f7d5e6df33b0450bc1f88ec0d4d5
 
-# Stage 2: runtime（軽量イメージ）
-FROM runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04
+# Stage 2: runtime（vLLM 公式 runtime イメージ）
+FROM vllm/vllm-openai:v0.9.0
 
-# builder ステージでインストールしたパッケージをコピー（devel 固有ファイルを除外）
+# builder ステージでインストールした追加パッケージをコピー
 COPY --from=builder /opt/app-packages /opt/app-packages
 ENV PYTHONPATH=/opt/app-packages
 
@@ -25,8 +23,8 @@ COPY --chown=appuser:appuser handler.py .
 
 USER appuser
 
-# モデル ID は環境変数で上書き可能
-ENV MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
+# モデル ID は環境変数で上書き可能（GPTQ Int4）
+ENV MODEL_ID=raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4
 
 # モデルキャッシュをボリュームマウントへ（コールドスタート対策）
 ENV HF_HOME=/runpod-volume/hf-cache

--- a/infra/runpod/Dockerfile
+++ b/infra/runpod/Dockerfile
@@ -11,15 +11,18 @@ RUN pip install --no-cache-dir \
 # ハンドラーをコピー
 COPY handler.py .
 
-# デフォルトは Google の Gemma 3 12B IT AWQ 量子化済みモデル。
-# GEMMA_MODEL_NAME 環境変数で HuggingFace モデル名を差し替え可能。
-ARG MODEL_NAME=abhishek/gemma-3-12b-it-awq
+# デフォルトは信頼できる組織の Gemma 3 12B IT AWQ 量子化済みモデル。
+# MODEL_NAME 環境変数で HuggingFace モデル名を差し替え可能。
+# 注意: モデル変更はレビュー必須。許可モデル一覧は管理ドキュメントで管理する。
+ARG MODEL_NAME=google/gemma-3-12b-it
 ENV MODEL_NAME=${MODEL_NAME}
 ENV MODEL_PATH=${MODEL_NAME}
 
 # 量子化設定（awq / gptq_marlin / fp8 / 空文字で非量子化）
-# AWQ 量子化済みモデルを使う場合は "awq" を設定する
-ENV VLLM_QUANTIZATION=awq
+# AWQ 量子化済みモデルを使う場合は "awq" を設定する。
+# 量子化モデルは信頼できる組織（例: neuralmagic / RedHatAI / google）のものを指定する。
+ARG VLLM_QUANTIZATION=
+ENV VLLM_QUANTIZATION=${VLLM_QUANTIZATION}
 
 # AWQ 量子化時は dtype=auto を推奨（vLLM が自動でカーネルを選択する）
 ENV VLLM_DTYPE=auto

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -1,14 +1,14 @@
 # RunPod サーバーレスデプロイ手順
 
-TechClip の AI 要約・翻訳機能で使用する Qwen3.5 9B モデルを RunPod Serverless にデプロイする手順。
-この worker は 16GB GPU を狙うため、量子化済み `QuantTrio/Qwen3.5-9B-AWQ` を前提にしている。
+TechClip の AI 要約・翻訳機能で使用する Gemma 3 12B IT モデルを RunPod Serverless にデプロイする手順。
+デフォルトは AWQ 量子化済みモデル `abhishek/gemma-3-12b-it-awq` を使用する。量子化により推論速度が向上し、16GB GPU でも `MAX_MODEL_LEN=8192` を実現できる。
 
 ## 前提条件
 
 - Docker（ビルド・プッシュ用）
-- Docker Hubアカウント（またはその他のコンテナレジストリ）
-- RunPodアカウント（https://runpod.io）
-- RunPod APIキー
+- Docker Hub アカウント（またはその他のコンテナレジストリ）
+- RunPod アカウント（https://runpod.io）
+- RunPod API キー
 
 ## デプロイ手順
 
@@ -18,7 +18,7 @@ TechClip の AI 要約・翻訳機能で使用する Qwen3.5 9B モデルを Run
 
 ```bash
 # 環境変数を設定
-export DOCKER_IMAGE=your-dockerhub-username/techclip-qwen:latest
+export DOCKER_IMAGE=your-dockerhub-username/techclip-gemma:latest
 
 # ビルドとプッシュ
 bash scripts/deploy-runpod.sh
@@ -30,22 +30,22 @@ bash scripts/deploy-runpod.sh
 cd infra/runpod
 
 # ビルド
-docker build -t your-dockerhub-username/techclip-qwen:latest .
+docker build -t your-dockerhub-username/techclip-gemma:latest .
 
 # プッシュ
-docker push your-dockerhub-username/techclip-qwen:latest
+docker push your-dockerhub-username/techclip-gemma:latest
 ```
 
 ### 2. RunPod テンプレートと endpoint の自動作成
 
-`scripts/provision-runpod.sh` を使うと、Qwen 用の template / endpoint をコードから作成または更新できる。
+`scripts/provision-runpod.sh` を使うと、template / endpoint をコードから作成または更新できる。
 
 ```bash
 RUNPOD_API_KEY=your_runpod_api_key_here \
 bash scripts/provision-runpod.sh \
-  --type qwen \
+  --type gemma \
   --target production \
-  --image your-dockerhub-username/techclip-qwen:latest
+  --image your-dockerhub-username/techclip-gemma:latest
 ```
 
 `--target local` で作成した endpoint は、開発環境では `RUNPOD_LOCAL_ENDPOINT_ID` として使う。
@@ -59,10 +59,10 @@ bash scripts/provision-runpod.sh \
 
 | 項目 | 値 |
 |------|-----|
-| Template Name | `techclip-qwen3.5-9b` |
-| Container Image | `your-dockerhub-username/techclip-qwen:latest` |
+| Template Name | `techclip-gemma3-12b-awq` |
+| Container Image | `your-dockerhub-username/techclip-gemma:latest` |
 | Container Disk | `20 GB` |
-| GPU | `16GB` tier (`A4000 / A4500 / RTX 4000`) |
+| GPU | `16GB` tier（A4000 / A4500 / RTX 4000） |
 | FlashBoot | `ON` |
 | Cached Models | `ON` |
 
@@ -74,14 +74,14 @@ bash scripts/provision-runpod.sh \
 
 | 項目 | 推奨値 |
 |------|--------|
-| Endpoint Name | `techclip-qwen3.5` |
+| Endpoint Name | `techclip-gemma3` |
 | Min Provisioned Workers | `0`（コスト最適化） |
 | Max Workers | `1` から開始 |
 | Idle Timeout | `120` 秒 |
 | Execution Timeout | `300` 秒 |
 
 4. **Deploy** をクリック
-5. 作成されたエンドポイントIDをコピーする（例: `abc123def456`）
+5. 作成されたエンドポイント ID をコピーする（例: `abc123def456`）
 
 `Idle Timeout` は、最後のリクエストを処理し終えた worker を何秒間そのまま残すかの設定。
 `Min Provisioned Workers = 0` でも、この時間内に次のリクエストが来れば warm な worker が再利用される。
@@ -89,7 +89,7 @@ bash scripts/provision-runpod.sh \
 
 ### 5. 環境変数の設定
 
-Cloudflare Workers の環境変数（`apps/api/.dev.vars` またはWranglerシークレット）に設定する。
+Cloudflare Workers の環境変数（`apps/api/.dev.vars` または Wrangler シークレット）に設定する。
 
 **ローカル開発 (`apps/api/.dev.vars`):**
 
@@ -99,19 +99,19 @@ RUNPOD_ENDPOINT_ID=your_endpoint_id_here
 RUNPOD_LOCAL_ENDPOINT_ID=your_local_endpoint_id_here
 ```
 
-**本番環境（Wranglerシークレット）:**
+**本番環境（Wrangler シークレット）:**
 
 ```bash
-# APIキーをシークレットとして登録
+# API キーをシークレットとして登録
 wrangler secret put RUNPOD_API_KEY --env production
 
-# エンドポイントIDをシークレットとして登録
+# エンドポイント ID をシークレットとして登録
 wrangler secret put RUNPOD_ENDPOINT_ID --env production
 ```
 
 `ENVIRONMENT=development` かつ `RUNPOD_LOCAL_ENDPOINT_ID` が設定されている場合、API は local endpoint を優先して使う。
 
-### 6. RunPod APIキーの取得
+### 6. RunPod API キーの取得
 
 1. [RunPod アカウント設定](https://www.runpod.io/console/user/settings) を開く
 2. **API Keys** セクションで **+ API Key** をクリック
@@ -120,31 +120,7 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
 
 ## API リクエスト形式
 
-ハンドラーは2種類のリクエスト形式に対応している。
-
-### 要約用（prompt形式）
-
-```json
-{
-  "input": {
-    "prompt": "Summarize the following article...",
-    "max_tokens": 1024,
-    "temperature": 0.3
-  }
-}
-```
-
-レスポンス:
-
-```json
-{
-  "output": {
-    "text": "生成されたテキスト"
-  }
-}
-```
-
-### 翻訳用（messages形式）
+ハンドラーは `messages` 形式のみをサポートする。
 
 ```json
 {
@@ -152,7 +128,7 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
     "messages": [
       {
         "role": "user",
-        "content": "Translate the following text..."
+        "content": "次の記事を要約してください: ..."
       }
     ],
     "max_tokens": 4096,
@@ -170,7 +146,7 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
       {
         "message": {
           "role": "assistant",
-          "content": "翻訳されたテキスト"
+          "content": "生成されたテキスト"
         }
       }
     ]
@@ -180,36 +156,75 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
 
 ## モデル設定
 
-この Docker image はモデルを build 時に含めない。RunPod の `cached models` と Hugging Face cache を使って、
-起動時に `QuantTrio/Qwen3.5-9B-AWQ` を解決する。
+この Docker image はモデルを build 時に含めない。RunPod の `cached models` と Hugging Face cache を使って起動時にモデルを解決する。
 
-デフォルト環境変数:
+モデル名は以下の優先順で解決する:
+1. `GEMMA_MODEL_NAME` 環境変数
+2. `MODEL_PATH` 環境変数
+3. `MODEL_NAME` 環境変数
+4. デフォルト（`abhishek/gemma-3-12b-it-awq`）
+
+### デフォルト環境変数
 
 ```env
-MODEL_NAME=QuantTrio/Qwen3.5-9B-AWQ
+MODEL_NAME=abhishek/gemma-3-12b-it-awq
 VLLM_QUANTIZATION=awq
-MAX_MODEL_LEN=4096
+VLLM_DTYPE=auto
+MAX_MODEL_LEN=8192
 MAX_NUM_SEQS=4
-GPU_MEMORY_UTILIZATION=0.85
+GPU_MEMORY_UTILIZATION=0.90
 TENSOR_PARALLEL_SIZE=1
 ```
 
-16GB で厳しい場合は次を下げる:
+### 量子化設定（VLLM_QUANTIZATION）
 
-- `MAX_MODEL_LEN`
-- `MAX_NUM_SEQS`
-- `GPU_MEMORY_UTILIZATION`
+`VLLM_QUANTIZATION` 環境変数で量子化方式を制御する:
+
+| 値 | 説明 |
+|----|------|
+| `awq` | AWQ 量子化（推奨）。Marlin カーネルで高速推論 |
+| `gptq_marlin` | GPTQ + Marlin カーネル |
+| `fp8` | FP8 量子化（H100 / H200 等の対応 GPU が必要） |
+| 空文字 / 未設定 | 量子化なし（後方互換）。`bfloat16` で動作 |
+
+AWQ 量子化を使う場合は `VLLM_DTYPE=auto` を推奨する（vLLM が自動でカーネルを選択する）。
+
+### 非量子化で動かす場合
+
+```env
+MODEL_NAME=google/gemma-3-12b-it
+VLLM_QUANTIZATION=
+VLLM_DTYPE=bfloat16
+MAX_MODEL_LEN=4096
+MAX_NUM_SEQS=2
+GPU_MEMORY_UTILIZATION=0.85
+```
+
+## 量子化のメリット
+
+| 指標 | 非量子化（bfloat16） | AWQ 量子化 |
+|------|---------------------|------------|
+| モデルサイズ | 約 24 GB | 約 7 GB |
+| 推論速度 | ベースライン | 約 2-3x 高速 |
+| 最大コンテキスト長（16GB GPU） | 4096 | 8192 |
+| 同時シーケンス数（16GB GPU） | 2 | 4 |
+
+量子化により同じ GPU メモリでより多くのリクエストを並列処理できる。
 
 ## トラブルシューティング
 
-### OOMエラーが発生する場合
+### OOM エラーが発生する場合
 
 `GPU_MEMORY_UTILIZATION`、`MAX_MODEL_LEN`、`MAX_NUM_SEQS` を下げる。改善しない場合は 24GB GPU に上げる。
 
-### コンテナ起動が遅い場合
+### コールドスタートが遅い場合
 
-`FlashBoot` と `Cached Models` を有効にする。初回ロード後は cold start をかなり短縮できる。
+`FlashBoot` と `Cached Models` を有効にする。初回ロード後は cold start をかなり短縮できる。AWQ 量子化はモデルサイズが小さいため、非量子化より cold start も短縮される。
 
 ### タイムアウトが発生する場合
 
-エンドポイントの **Execution Timeout** を増やす（推奨: 300秒）。
+エンドポイントの **Execution Timeout** を増やす（推奨: 300 秒）。
+
+### 量子化モデルで精度が落ちる場合
+
+`VLLM_QUANTIZATION` を空にして非量子化モードに切り替える（後方互換のため動作する）。

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -28,6 +28,12 @@ Gemma 4 26B-A4B はハイブリッド注意機構を持つ（25層 SWA + 5層 Gl
 - `fused-turboquant`（PyPI 公式）は SWA 未対応のため **使用しない**
 - `turboquant`（back2matching/turboquant）は SWA をバイパスし、5つのグローバル注意層のみ KV キャッシュを **3.8x 圧縮**する
 
+インストールは PyPI 版ではなく GitHub リポジトリを直接指定すること:
+
+```bash
+pip install git+https://github.com/back2matching/turboquant.git@main
+```
+
 これにより 16GB VRAM でモデル重みの他に十分なキャッシュ余裕を確保できる。
 
 ## デプロイ手順
@@ -116,6 +122,8 @@ RUNPOD_ENDPOINT_ID=your_endpoint_id_here
 RUNPOD_LOCAL_ENDPOINT_ID=your_local_endpoint_id_here
 ```
 
+> **注意**: `apps/api/.dev.vars` は `.gitignore` に含まれていることを必ず確認すること。API キーなどの機密情報をリポジトリにコミットしないよう注意すること。
+
 **本番環境（Wrangler シークレット）:**
 
 ```bash
@@ -187,8 +195,18 @@ MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
 ```env
 MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
 HF_HOME=/runpod-volume/hf-cache
-TRANSFORMERS_OFFLINE=0
+TRANSFORMERS_OFFLINE=1
 ```
+
+> **重要**: `TRANSFORMERS_OFFLINE=1` のため、コンテナ起動前にモデルを `/runpod-volume/hf-cache` へ事前ダウンロードしておくこと。RunPod コンソールの **Cached Models** 機能を使うか、以下のコマンドで手動ダウンロードすること:
+>
+> ```bash
+> HF_HOME=/runpod-volume/hf-cache python3 -c "
+> from transformers import AutoModelForCausalLM, AutoProcessor
+> AutoModelForCausalLM.from_pretrained('Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound')
+> AutoProcessor.from_pretrained('Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound')
+> "
+> ```
 
 ## トラブルシューティング
 
@@ -215,11 +233,14 @@ TRANSFORMERS_OFFLINE=0
 
 | コンポーネント | バージョン | 備考 |
 |----------------|------------|------|
-| ベースイメージ | `nvidia/cuda:12.8.0-cudnn9-devel-ubuntu22.04` | CUDA 12.8.0 |
-| Python | `3.12` | |
-| transformers | `>=4.51.0` | Gemma 4 対応 |
-| turboquant | 最新（back2matching/turboquant） | SWA バイパス対応 |
-| auto-round | 最新 | Intel AutoRound int4 サポート |
-| RunPod SDK | `>=1.7.4` | サーバーレスランタイム |
+| ベースイメージ（builder） | `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04` | Python + PyTorch + CUDA 同梱 |
+| ベースイメージ（runtime） | `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04` | 軽量 runtime |
+| Python | `3.11` | ベースイメージに同梱 |
+| torch | `2.8.0` | ベースイメージに同梱 |
+| transformers | `4.51.3` | Gemma 4 対応 |
+| turboquant | `@main`（back2matching/turboquant） | SWA バイパス対応・PyPI 版は使用しない |
+| auto-round | `0.5.3` | Intel AutoRound int4 サポート |
+| accelerate | `1.6.0` | デバイスマップサポート |
+| RunPod SDK | `1.7.4` | サーバーレスランタイム |
 
-バージョンを変更する場合は `Dockerfile` の `pip install` 行を更新し、動作確認後にこのテーブルを更新すること。
+バージョンを変更する場合は `requirements.txt` と `Dockerfile` を更新し、動作確認後にこのテーブルを更新すること。

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -31,7 +31,7 @@ Gemma 4 26B-A4B はハイブリッド注意機構を持つ（25層 SWA + 5層 Gl
 インストールは PyPI 版ではなく GitHub リポジトリを直接指定すること:
 
 ```bash
-pip install git+https://github.com/back2matching/turboquant.git@main
+pip install git+https://github.com/back2matching/turboquant.git@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0
 ```
 
 これにより 16GB VRAM でモデル重みの他に十分なキャッシュ余裕を確保できる。
@@ -238,7 +238,7 @@ TRANSFORMERS_OFFLINE=1
 | Python | `3.11` | ベースイメージに同梱 |
 | torch | `2.8.0` | ベースイメージに同梱 |
 | transformers | `4.51.3` | Gemma 4 対応 |
-| turboquant | `@main`（back2matching/turboquant） | SWA バイパス対応・PyPI 版は使用しない |
+| turboquant | `@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0`（back2matching/turboquant） | SWA バイパス対応・PyPI 版は使用しない |
 | auto-round | `0.5.3` | Intel AutoRound int4 サポート |
 | accelerate | `1.6.0` | デバイスマップサポート |
 | RunPod SDK | `1.7.4` | サーバーレスランタイム |

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -1,8 +1,8 @@
 # RunPod サーバーレスデプロイ手順
 
-TechClip の AI 要約・翻訳機能で使用する `Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound` モデルを RunPod Serverless にデプロイする手順。
+TechClip の AI 要約・翻訳機能で使用する `raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4` モデルを RunPod Serverless にデプロイする手順。
 
-HuggingFace Transformers で直接ロードし、TurboQuant（back2matching/turboquant）で KV キャッシュを圧縮することで、RTX 4080 / A4000（16GB VRAM）での動作を実現する。
+vLLM でモデルをロードし、0xSero/turboquant で KV キャッシュを圧縮することで、RTX 4080 / A4000（16GB VRAM）での動作を実現する。
 
 ## 前提条件
 
@@ -10,31 +10,65 @@ HuggingFace Transformers で直接ロードし、TurboQuant（back2matching/turb
 - Docker Hub アカウント（またはその他のコンテナレジストリ）
 - RunPod アカウント（https://runpod.io）
 - RunPod API キー
+- HuggingFace アカウントと API トークン（モデルダウンロード用）
 
 ## モデル情報
 
 | 項目 | 値 |
 |------|-----|
-| モデル ID | `Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound` |
-| 量子化方式 | Intel AutoRound int4-mixed |
-| 推定 VRAM（モデル重み） | ~14 GB |
-| 推奨残余 VRAM（KV キャッシュ等） | ~2 GB |
+| モデル ID | `raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4` |
+| 量子化方式 | GPTQ Int4 |
+| 推定 VRAM（モデル重み） | ~13-15 GB |
+| 推奨残余 VRAM（KV キャッシュ等） | ~1-3 GB |
 | 推奨 GPU | RTX 4080 / A4000（16GB VRAM） |
 
 ## TurboQuant について
 
-Gemma 4 26B-A4B はハイブリッド注意機構を持つ（25層 SWA + 5層 Global Attention）。
+0xSero/turboquant（ICLR 2026、arXiv:2504.19874）は vLLM の attention backend に monkey-patch を挿入し、KV キャッシュを圧縮する。
 
-- `fused-turboquant`（PyPI 公式）は SWA 未対応のため **使用しない**
-- `turboquant`（back2matching/turboquant）は SWA をバイパスし、5つのグローバル注意層のみ KV キャッシュを **3.8x 圧縮**する
+- key: 3-bit（ほぼ無損失、cos_sim=1.000）
+- value: 2-bit（cos_sim=0.94）
+- full-attention 層のみ圧縮（linear-attention/Mamba 層は対象外）
+- 4.4x の KV キャッシュ圧縮（head_dim=256 の dense モデル）
 
-インストールは PyPI 版ではなく GitHub リポジトリを直接指定すること:
+インストールは GitHub リポジトリを直接指定する:
 
 ```bash
-pip install git+https://github.com/back2matching/turboquant.git@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0
+pip install git+https://github.com/0xSero/turboquant.git@7ac9b8d165a3f7d5e6df33b0450bc1f88ec0d4d5
 ```
 
-これにより 16GB VRAM でモデル重みの他に十分なキャッシュ余裕を確保できる。
+vLLM 統合は `turboquant.vllm_attn_backend.install_turboquant_hooks` を使用する:
+
+```python
+from turboquant.vllm_attn_backend import install_turboquant_hooks, MODE_ACTIVE
+
+install_turboquant_hooks(
+    worker.model_runner,
+    key_bits=3,
+    value_bits=2,
+    buffer_size=128,
+    mode=MODE_ACTIVE,
+)
+```
+
+## モデルの事前ダウンロード
+
+`TRANSFORMERS_OFFLINE=1` のため、コンテナ起動前にモデルを事前ダウンロードしておく必要がある。
+
+```bash
+# HuggingFace Token が必要な場合は環境変数で設定
+export HF_TOKEN=your_hf_token_here
+
+HF_HOME=/runpod-volume/hf-cache python3 -c "
+from huggingface_hub import snapshot_download
+snapshot_download(
+    repo_id='raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4',
+    token='${HF_TOKEN}',
+)
+"
+```
+
+または RunPod コンソールの **Cached Models** 機能を使って `/runpod-volume/hf-cache` にダウンロードする。
 
 ## デプロイ手順
 
@@ -82,7 +116,7 @@ bash scripts/provision-runpod.sh \
 
 | 項目 | 値 |
 |------|-----|
-| Template Name | `techclip-gemma4-26b-int4` |
+| Template Name | `techclip-gemma4-26b-gptq-int4` |
 | Container Image | `your-dockerhub-username/techclip-gemma4:latest` |
 | Container Disk | `20 GB` |
 | GPU | RTX 4080 / A4000（16GB VRAM） |
@@ -187,26 +221,18 @@ Docker image はモデルを build 時に含めない。RunPod の `cached model
 モデル ID は `MODEL_ID` 環境変数で上書き可能:
 
 ```env
-MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
+MODEL_ID=raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4
 ```
 
 ### デフォルト環境変数
 
 ```env
-MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
+MODEL_ID=raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4
 HF_HOME=/runpod-volume/hf-cache
 TRANSFORMERS_OFFLINE=1
 ```
 
-> **重要**: `TRANSFORMERS_OFFLINE=1` のため、コンテナ起動前にモデルを `/runpod-volume/hf-cache` へ事前ダウンロードしておくこと。RunPod コンソールの **Cached Models** 機能を使うか、以下のコマンドで手動ダウンロードすること:
->
-> ```bash
-> HF_HOME=/runpod-volume/hf-cache python3 -c "
-> from transformers import AutoModelForCausalLM, AutoProcessor
-> AutoModelForCausalLM.from_pretrained('Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound')
-> AutoProcessor.from_pretrained('Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound')
-> "
-> ```
+> **重要**: `TRANSFORMERS_OFFLINE=1` のため、コンテナ起動前にモデルを `/runpod-volume/hf-cache` へ事前ダウンロードしておくこと。
 
 ## トラブルシューティング
 
@@ -214,10 +240,10 @@ TRANSFORMERS_OFFLINE=1
 
 16GB VRAM GPU（RTX 4080 / A4000）を使用していること、および他のプロセスが VRAM を占有していないことを確認する。改善しない場合は 24GB 以上の GPU に変更する。
 
-### TurboQuant パッチが失敗する場合
+### TurboQuant フックのインストールが失敗する場合
 
-ハンドラーは TurboQuant のパッチ適用失敗を警告として記録し、圧縮なしで推論を続行する。
-ログに `TurboQuant パッチの適用に失敗しました` と出ている場合は turboquant パッケージのインストール状況を確認する。
+ハンドラーは TurboQuant フックのインストール失敗を警告として記録し、圧縮なしで推論を続行する。
+ログに `TurboQuant フックのインストールに失敗しました` と出ている場合は turboquant パッケージのインストール状況と vLLM バージョンの互換性を確認する。
 
 ### コールドスタートが遅い場合
 
@@ -229,18 +255,14 @@ TRANSFORMERS_OFFLINE=1
 
 ## バージョン管理
 
-以下の組み合わせで動作確認済み:
+以下の組み合わせで構成:
 
 | コンポーネント | バージョン | 備考 |
 |----------------|------------|------|
-| ベースイメージ（builder） | `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04` | Python + PyTorch + CUDA 同梱 |
-| ベースイメージ（runtime） | `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-runtime-ubuntu22.04` | 軽量 runtime |
-| Python | `3.11` | ベースイメージに同梱 |
-| torch | `2.8.0` | ベースイメージに同梱 |
-| transformers | `4.51.3` | Gemma 4 対応 |
-| turboquant | `@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0`（back2matching/turboquant） | SWA バイパス対応・PyPI 版は使用しない・`pip audit` の対象外のため定期的に upstream のコミット履歴を手動確認すること |
-| auto-round | `0.5.3` | Intel AutoRound int4 サポート |
-| accelerate | `1.6.0` | デバイスマップサポート |
+| ベースイメージ | `vllm/vllm-openai:v0.9.0` | vLLM 公式イメージ（PyTorch + CUDA 同梱） |
+| Python | `3.12` | ベースイメージに同梱 |
+| vLLM | `0.9.0` | GPTQ サポート、TurboQuant vLLM 統合対応 |
+| turboquant | `@7ac9b8d165a3f7d5e6df33b0450bc1f88ec0d4d5`（0xSero/turboquant） | vLLM integration API 対応・`pip audit` の対象外のため定期的に upstream のコミット履歴を手動確認すること |
 | RunPod SDK | `1.7.4` | サーバーレスランタイム |
 
 バージョンを変更する場合は `requirements.txt` と `Dockerfile` を更新し、動作確認後にこのテーブルを更新すること。

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -24,13 +24,11 @@ export DOCKER_IMAGE=your-dockerhub-username/techclip-gemma:latest
 bash scripts/deploy-runpod.sh
 ```
 
-または手動でビルド・プッシュする場合:
+または手動でビルド・プッシュする場合（リポジトリルートから実行）:
 
 ```bash
-cd infra/runpod
-
-# ビルド
-docker build -t your-dockerhub-username/techclip-gemma:latest .
+# ビルド（リポジトリルートから実行）
+docker build -t your-dockerhub-username/techclip-gemma:latest infra/runpod/
 
 # プッシュ
 docker push your-dockerhub-username/techclip-gemma:latest
@@ -231,3 +229,15 @@ GPU_MEMORY_UTILIZATION=0.85
 ### 量子化モデルで精度が落ちる場合
 
 `VLLM_QUANTIZATION` を空にして非量子化モードに切り替える（後方互換のため動作する）。
+
+## バージョン管理
+
+以下の組み合わせで動作確認済み:
+
+| コンポーネント | バージョン | 備考 |
+|----------------|------------|------|
+| ベースイメージ | `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04` | CUDA 12.8.1 |
+| vLLM | `0.7.3` | AWQ / GPTQ-Marlin / FP8 量子化対応 |
+| RunPod SDK | `1.7.4` | サーバーレスランタイム |
+
+バージョンを変更する場合は `Dockerfile` の `pip install` 行を更新し、動作確認後にこのテーブルを更新すること。

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -238,7 +238,7 @@ TRANSFORMERS_OFFLINE=1
 | Python | `3.11` | ベースイメージに同梱 |
 | torch | `2.8.0` | ベースイメージに同梱 |
 | transformers | `4.51.3` | Gemma 4 対応 |
-| turboquant | `@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0`（back2matching/turboquant） | SWA バイパス対応・PyPI 版は使用しない |
+| turboquant | `@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0`（back2matching/turboquant） | SWA バイパス対応・PyPI 版は使用しない・`pip audit` の対象外のため定期的に upstream のコミット履歴を手動確認すること |
 | auto-round | `0.5.3` | Intel AutoRound int4 サポート |
 | accelerate | `1.6.0` | デバイスマップサポート |
 | RunPod SDK | `1.7.4` | サーバーレスランタイム |

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -60,10 +60,11 @@ install_turboquant_hooks(
 export HF_TOKEN=your_hf_token_here
 
 HF_HOME=/runpod-volume/hf-cache python3 -c "
+import os
 from huggingface_hub import snapshot_download
 snapshot_download(
     repo_id='raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4',
-    token='${HF_TOKEN}',
+    token=os.environ.get('HF_TOKEN'),
 )
 "
 ```

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -1,7 +1,8 @@
 # RunPod サーバーレスデプロイ手順
 
-TechClip の AI 要約・翻訳機能で使用する Gemma 3 12B IT モデルを RunPod Serverless にデプロイする手順。
-デフォルトは Google 公式 `google/gemma-3-12b-it` を使用する。量子化モデルを利用する場合は `VLLM_QUANTIZATION` 環境変数と信頼できる組織（例: neuralmagic / RedHatAI / google）の AWQ モデルを別途指定する。量子化により推論速度が向上し、16GB GPU でも `MAX_MODEL_LEN=8192` を実現できる。
+TechClip の AI 要約・翻訳機能で使用する `Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound` モデルを RunPod Serverless にデプロイする手順。
+
+HuggingFace Transformers で直接ロードし、TurboQuant（back2matching/turboquant）で KV キャッシュを圧縮することで、RTX 4080 / A4000（16GB VRAM）での動作を実現する。
 
 ## 前提条件
 
@@ -10,15 +11,32 @@ TechClip の AI 要約・翻訳機能で使用する Gemma 3 12B IT モデルを
 - RunPod アカウント（https://runpod.io）
 - RunPod API キー
 
+## モデル情報
+
+| 項目 | 値 |
+|------|-----|
+| モデル ID | `Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound` |
+| 量子化方式 | Intel AutoRound int4-mixed |
+| 推定 VRAM（モデル重み） | ~14 GB |
+| 推奨残余 VRAM（KV キャッシュ等） | ~2 GB |
+| 推奨 GPU | RTX 4080 / A4000（16GB VRAM） |
+
+## TurboQuant について
+
+Gemma 4 26B-A4B はハイブリッド注意機構を持つ（25層 SWA + 5層 Global Attention）。
+
+- `fused-turboquant`（PyPI 公式）は SWA 未対応のため **使用しない**
+- `turboquant`（back2matching/turboquant）は SWA をバイパスし、5つのグローバル注意層のみ KV キャッシュを **3.8x 圧縮**する
+
+これにより 16GB VRAM でモデル重みの他に十分なキャッシュ余裕を確保できる。
+
 ## デプロイ手順
 
 ### 1. Docker イメージのビルドとプッシュ
 
-`scripts/deploy-runpod.sh` を使用する。
-
 ```bash
 # 環境変数を設定
-export DOCKER_IMAGE=your-dockerhub-username/techclip-gemma:latest
+export DOCKER_IMAGE=your-dockerhub-username/techclip-gemma4:latest
 
 # ビルドとプッシュ
 bash scripts/deploy-runpod.sh
@@ -28,10 +46,10 @@ bash scripts/deploy-runpod.sh
 
 ```bash
 # ビルド（リポジトリルートから実行）
-docker build -t your-dockerhub-username/techclip-gemma:latest infra/runpod/
+docker build -t your-dockerhub-username/techclip-gemma4:latest infra/runpod/
 
 # プッシュ
-docker push your-dockerhub-username/techclip-gemma:latest
+docker push your-dockerhub-username/techclip-gemma4:latest
 ```
 
 ### 2. RunPod テンプレートと endpoint の自動作成
@@ -44,7 +62,7 @@ docker push your-dockerhub-username/techclip-gemma:latest
 bash scripts/provision-runpod.sh \
   --type gemma \
   --target production \
-  --image your-dockerhub-username/techclip-gemma:latest
+  --image your-dockerhub-username/techclip-gemma4:latest
 ```
 
 `--target local` で作成した endpoint は、開発環境では `RUNPOD_LOCAL_ENDPOINT_ID` として使う。
@@ -58,10 +76,10 @@ bash scripts/provision-runpod.sh \
 
 | 項目 | 値 |
 |------|-----|
-| Template Name | `techclip-gemma3-12b-awq` |
-| Container Image | `your-dockerhub-username/techclip-gemma:latest` |
+| Template Name | `techclip-gemma4-26b-int4` |
+| Container Image | `your-dockerhub-username/techclip-gemma4:latest` |
 | Container Disk | `20 GB` |
-| GPU | 16GB VRAM 以上の GPU（例: A4000 16GB、RTX 4000 Ada 20GB） |
+| GPU | RTX 4080 / A4000（16GB VRAM） |
 | FlashBoot | `ON` |
 | Cached Models | `ON` |
 
@@ -73,7 +91,7 @@ bash scripts/provision-runpod.sh \
 
 | 項目 | 推奨値 |
 |------|--------|
-| Endpoint Name | `techclip-gemma3` |
+| Endpoint Name | `techclip-gemma4` |
 | Min Provisioned Workers | `0`（コスト最適化） |
 | Max Workers | `1` から開始 |
 | Idle Timeout | `120` 秒 |
@@ -130,8 +148,9 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
         "content": "次の記事を要約してください: ..."
       }
     ],
-    "max_tokens": 4096,
-    "temperature": 0.3
+    "max_new_tokens": 512,
+    "temperature": 0.7,
+    "top_p": 0.9
   }
 }
 ```
@@ -155,80 +174,40 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
 
 ## モデル設定
 
-この Docker image はモデルを build 時に含めない。RunPod の `cached models` と Hugging Face cache を使って起動時にモデルを解決する。
+Docker image はモデルを build 時に含めない。RunPod の `cached models` と Hugging Face cache を使って起動時にモデルをロードする（コールドスタート対策）。
 
-モデル名は以下の優先順で解決する:
-1. `GEMMA_MODEL_NAME` 環境変数
-2. `MODEL_PATH` 環境変数
-3. `MODEL_NAME` 環境変数
-4. デフォルト（`google/gemma-3-12b-it`）
+モデル ID は `MODEL_ID` 環境変数で上書き可能:
 
-**注意**: `MODEL_NAME` は外部から任意のモデルに上書き可能なため、許可モデル一覧は管理ドキュメントで管理し変更はレビュー必須とする。
+```env
+MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
+```
 
 ### デフォルト環境変数
 
 ```env
-MODEL_NAME=google/gemma-3-12b-it
-VLLM_QUANTIZATION=
-VLLM_DTYPE=auto
-MAX_MODEL_LEN=8192
-MAX_NUM_SEQS=4
-GPU_MEMORY_UTILIZATION=0.90
-TENSOR_PARALLEL_SIZE=1
+MODEL_ID=Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
+HF_HOME=/runpod-volume/hf-cache
+TRANSFORMERS_OFFLINE=0
 ```
-
-### 量子化設定（VLLM_QUANTIZATION）
-
-`VLLM_QUANTIZATION` 環境変数で量子化方式を制御する:
-
-| 値 | 説明 |
-|----|------|
-| `awq` | AWQ 量子化（推奨）。Marlin カーネルで高速推論 |
-| `gptq_marlin` | GPTQ + Marlin カーネル |
-| `fp8` | FP8 量子化（H100 / H200 等の対応 GPU が必要） |
-| 空文字 / 未設定 | 量子化なし（後方互換）。`bfloat16` で動作 |
-
-AWQ 量子化を使う場合は `VLLM_DTYPE=auto` を推奨する（vLLM が自動でカーネルを選択する）。
-
-### 非量子化で動かす場合
-
-```env
-MODEL_NAME=google/gemma-3-12b-it
-VLLM_QUANTIZATION=
-VLLM_DTYPE=bfloat16
-MAX_MODEL_LEN=4096
-MAX_NUM_SEQS=2
-GPU_MEMORY_UTILIZATION=0.85
-```
-
-## 量子化のメリット
-
-| 指標 | 非量子化（bfloat16） | AWQ 量子化 |
-|------|---------------------|------------|
-| モデルサイズ | 約 24 GB | 約 7 GB |
-| 推論速度 | ベースライン | 約 2-3x 高速（GPU 環境・ワークロードにより異なる） |
-| 最大コンテキスト長（16GB GPU） | 4096 | 8192 |
-| 同時シーケンス数（16GB GPU） | 2 | 4 |
-
-量子化により同じ GPU メモリでより多くのリクエストを並列処理できる。
 
 ## トラブルシューティング
 
 ### OOM エラーが発生する場合
 
-`GPU_MEMORY_UTILIZATION`、`MAX_MODEL_LEN`、`MAX_NUM_SEQS` を下げる。改善しない場合は 24GB GPU に上げる。
+16GB VRAM GPU（RTX 4080 / A4000）を使用していること、および他のプロセスが VRAM を占有していないことを確認する。改善しない場合は 24GB 以上の GPU に変更する。
+
+### TurboQuant パッチが失敗する場合
+
+ハンドラーは TurboQuant のパッチ適用失敗を警告として記録し、圧縮なしで推論を続行する。
+ログに `TurboQuant パッチの適用に失敗しました` と出ている場合は turboquant パッケージのインストール状況を確認する。
 
 ### コールドスタートが遅い場合
 
-`FlashBoot` と `Cached Models` を有効にする。初回ロード後は cold start をかなり短縮できる。AWQ 量子化はモデルサイズが小さいため、非量子化より cold start も短縮される。
+`FlashBoot` と `Cached Models` を有効にする。`HF_HOME=/runpod-volume/hf-cache` を設定してモデルキャッシュを永続ボリュームに保存することで、2回目以降の起動を大幅に短縮できる。
 
 ### タイムアウトが発生する場合
 
 エンドポイントの **Execution Timeout** を増やす（推奨: 300 秒）。
-
-### 量子化モデルで精度が落ちる場合
-
-`VLLM_QUANTIZATION` を空にして非量子化モードに切り替える（後方互換のため動作する）。
 
 ## バージョン管理
 
@@ -236,8 +215,11 @@ GPU_MEMORY_UTILIZATION=0.85
 
 | コンポーネント | バージョン | 備考 |
 |----------------|------------|------|
-| ベースイメージ | `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04` | CUDA 12.8.1 |
-| vLLM | `0.7.3` | AWQ / GPTQ-Marlin / FP8 量子化対応 |
-| RunPod SDK | `1.7.4` | サーバーレスランタイム |
+| ベースイメージ | `nvidia/cuda:12.8.0-cudnn9-devel-ubuntu22.04` | CUDA 12.8.0 |
+| Python | `3.12` | |
+| transformers | `>=4.51.0` | Gemma 4 対応 |
+| turboquant | 最新（back2matching/turboquant） | SWA バイパス対応 |
+| auto-round | 最新 | Intel AutoRound int4 サポート |
+| RunPod SDK | `>=1.7.4` | サーバーレスランタイム |
 
 バージョンを変更する場合は `Dockerfile` の `pip install` 行を更新し、動作確認後にこのテーブルを更新すること。

--- a/infra/runpod/README.md
+++ b/infra/runpod/README.md
@@ -1,7 +1,7 @@
 # RunPod サーバーレスデプロイ手順
 
 TechClip の AI 要約・翻訳機能で使用する Gemma 3 12B IT モデルを RunPod Serverless にデプロイする手順。
-デフォルトは AWQ 量子化済みモデル `abhishek/gemma-3-12b-it-awq` を使用する。量子化により推論速度が向上し、16GB GPU でも `MAX_MODEL_LEN=8192` を実現できる。
+デフォルトは Google 公式 `google/gemma-3-12b-it` を使用する。量子化モデルを利用する場合は `VLLM_QUANTIZATION` 環境変数と信頼できる組織（例: neuralmagic / RedHatAI / google）の AWQ モデルを別途指定する。量子化により推論速度が向上し、16GB GPU でも `MAX_MODEL_LEN=8192` を実現できる。
 
 ## 前提条件
 
@@ -41,7 +41,8 @@ docker push your-dockerhub-username/techclip-gemma:latest
 `scripts/provision-runpod.sh` を使うと、template / endpoint をコードから作成または更新できる。
 
 ```bash
-RUNPOD_API_KEY=your_runpod_api_key_here \
+# APIキーはシェル変数ではなく .env ファイル経由で読み込むことを推奨（シェル履歴にキーが残るため）
+# 例: echo 'RUNPOD_API_KEY=your_runpod_api_key_here' >> .env && source .env
 bash scripts/provision-runpod.sh \
   --type gemma \
   --target production \
@@ -62,7 +63,7 @@ bash scripts/provision-runpod.sh \
 | Template Name | `techclip-gemma3-12b-awq` |
 | Container Image | `your-dockerhub-username/techclip-gemma:latest` |
 | Container Disk | `20 GB` |
-| GPU | `16GB` tier（A4000 / A4500 / RTX 4000） |
+| GPU | 16GB VRAM 以上の GPU（例: A4000 16GB、RTX 4000 Ada 20GB） |
 | FlashBoot | `ON` |
 | Cached Models | `ON` |
 
@@ -162,13 +163,15 @@ wrangler secret put RUNPOD_ENDPOINT_ID --env production
 1. `GEMMA_MODEL_NAME` 環境変数
 2. `MODEL_PATH` 環境変数
 3. `MODEL_NAME` 環境変数
-4. デフォルト（`abhishek/gemma-3-12b-it-awq`）
+4. デフォルト（`google/gemma-3-12b-it`）
+
+**注意**: `MODEL_NAME` は外部から任意のモデルに上書き可能なため、許可モデル一覧は管理ドキュメントで管理し変更はレビュー必須とする。
 
 ### デフォルト環境変数
 
 ```env
-MODEL_NAME=abhishek/gemma-3-12b-it-awq
-VLLM_QUANTIZATION=awq
+MODEL_NAME=google/gemma-3-12b-it
+VLLM_QUANTIZATION=
 VLLM_DTYPE=auto
 MAX_MODEL_LEN=8192
 MAX_NUM_SEQS=4
@@ -205,7 +208,7 @@ GPU_MEMORY_UTILIZATION=0.85
 | 指標 | 非量子化（bfloat16） | AWQ 量子化 |
 |------|---------------------|------------|
 | モデルサイズ | 約 24 GB | 約 7 GB |
-| 推論速度 | ベースライン | 約 2-3x 高速 |
+| 推論速度 | ベースライン | 約 2-3x 高速（GPU 環境・ワークロードにより異なる） |
 | 最大コンテキスト長（16GB GPU） | 4096 | 8192 |
 | 同時シーケンス数（16GB GPU） | 2 | 4 |
 

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -39,8 +39,16 @@ logger = logging.getLogger(__name__)
 # デフォルトモデル ID（環境変数で上書き可能）
 DEFAULT_MODEL_ID = "Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound"
 
+# 許可するモデル ID の一覧
+ALLOWED_MODEL_IDS: frozenset[str] = frozenset({
+    "Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound",
+})
+
 # メッセージ本文の最大文字数
 MESSAGE_CONTENT_MAX_LENGTH = 50000
+
+# 1 リクエストあたりの最大メッセージ数
+MAX_MESSAGES_COUNT = 100
 
 # max_new_tokens の上限・デフォルト値
 MAX_NEW_TOKENS_LIMIT = 2048
@@ -51,6 +59,9 @@ TEMPERATURE_MIN = 0.0
 TEMPERATURE_MAX = 2.0
 DEFAULT_TEMPERATURE = 0.7
 
+# temperature がこの値以下の場合は決定論的生成（do_sample=False）
+TEMPERATURE_GREEDY_THRESHOLD = 0.0
+
 # top_p の有効範囲
 TOP_P_MIN = 0.0
 TOP_P_MAX = 1.0
@@ -59,7 +70,10 @@ DEFAULT_TOP_P = 0.9
 # TurboQuant KV キャッシュ圧縮ビット数
 TURBOQUANT_BITS = 4
 
-MODEL_ID: str = os.environ.get("MODEL_ID", DEFAULT_MODEL_ID)
+model_id_env: str = os.environ.get("MODEL_ID", DEFAULT_MODEL_ID)
+if model_id_env not in ALLOWED_MODEL_IDS:
+    raise ValueError(f"許可されていないモデルID: {model_id_env}")
+MODEL_ID: str = model_id_env
 
 # グローバルモデル（コールドスタート時のみロード）
 _model: AutoModelForCausalLM | None = None
@@ -140,6 +154,8 @@ def _validate_messages(messages: Any) -> list[dict]:
         raise ValueError("messages はリスト形式である必要があります")
     if len(messages) == 0:
         raise ValueError("messages は 1 件以上必要です")
+    if len(messages) > MAX_MESSAGES_COUNT:
+        raise ValueError(f"メッセージ数が上限（{MAX_MESSAGES_COUNT}件）を超えています")
 
     valid_roles = {"user", "assistant", "system"}
     for i, msg in enumerate(messages):
@@ -247,7 +263,7 @@ def _generate(job_input: dict) -> dict:
     Raises:
         ValueError: 入力バリデーション失敗時
     """
-    messages = _validate_messages(job_input["messages"])
+    messages = _validate_messages(job_input.get("messages", []))
     max_new_tokens = _validate_max_new_tokens(
         job_input.get("max_new_tokens", DEFAULT_MAX_NEW_TOKENS)
     )
@@ -268,13 +284,15 @@ def _generate(job_input: dict) -> dict:
     inputs = inputs.to(model.device)
     input_len = inputs["input_ids"].shape[-1]
 
+    do_sample = temperature > TEMPERATURE_GREEDY_THRESHOLD
+
     with torch.inference_mode():
         output_ids = model.generate(
             **inputs,
             max_new_tokens=max_new_tokens,
             temperature=temperature,
             top_p=top_p,
-            do_sample=True,
+            do_sample=do_sample,
         )
 
     # 入力トークンを除いた生成部分のみデコード
@@ -314,7 +332,7 @@ def handler(job: dict) -> dict:
         return {"error": str(e)}
     except Exception as e:
         logger.error("推論エラー: %s: %s", type(e).__name__, e)
-        return {"error": f"推論エラーが発生しました: {type(e).__name__}"}
+        return {"error": "推論エラーが発生しました"}
 
     return {"output": output}
 

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -16,10 +16,13 @@ RunPod サーバーレス API のリクエストを処理する。
 量子化は VLLM_QUANTIZATION 環境変数で制御する（awq / gptq_marlin / fp8 / 空で非量子化）。
 """
 
+import logging
 import os
 from typing import Any
 import runpod
 from vllm import LLM, SamplingParams
+
+logger = logging.getLogger(__name__)
 
 # メッセージ本文の最大文字数
 MESSAGE_CONTENT_MAX_LENGTH = 50000
@@ -37,6 +40,8 @@ MODEL_REF = (
     or os.environ.get("MODEL_PATH")
     or os.environ.get("MODEL_NAME", "google/gemma-3-12b-it")
 )
+if not os.environ.get("MODEL_NAME"):
+    logger.warning("MODEL_NAME が未設定のためデフォルトモデルを使用します: %s", MODEL_REF)
 MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "8192"))
 MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "4"))
 GPU_MEMORY_UTILIZATION = float(os.environ.get("GPU_MEMORY_UTILIZATION", "0.90"))
@@ -44,12 +49,19 @@ TENSOR_PARALLEL_SIZE = int(os.environ.get("TENSOR_PARALLEL_SIZE", "1"))
 
 # 量子化設定: 環境変数 VLLM_QUANTIZATION で制御する
 # awq / gptq_marlin / fp8 を指定するか、空文字・未設定で非量子化（後方互換）
-VLLM_QUANTIZATION = os.environ.get("VLLM_QUANTIZATION") or None
+_ALLOWED_QUANTIZATION = {"awq", "gptq_marlin", "fp8"}
+_RAW = os.environ.get("VLLM_QUANTIZATION", "").strip()
+VLLM_QUANTIZATION = _RAW if _RAW else None
+if VLLM_QUANTIZATION and VLLM_QUANTIZATION not in _ALLOWED_QUANTIZATION:
+    raise ValueError(
+        f"VLLM_QUANTIZATION の値が不正です: {VLLM_QUANTIZATION!r}。"
+        f"許可値: {_ALLOWED_QUANTIZATION}"
+    )
 
 # AWQ 量子化時は "auto" を推奨。非量子化時は "bfloat16" を維持する
 VLLM_DTYPE = os.environ.get("VLLM_DTYPE", "bfloat16")
 
-llm_kwargs: dict = {
+llm_kwargs: dict[str, Any] = {
     "model": MODEL_REF,
     "dtype": VLLM_DTYPE,
     "max_model_len": MAX_MODEL_LEN,
@@ -167,6 +179,10 @@ def handle_messages_request(job_input: dict) -> dict:
         tokenize=False,
         add_generation_prompt=True,
     )
+    if not isinstance(prompt, str):
+        raise ValueError(
+            f"apply_chat_template が str を返しませんでした: {type(prompt).__name__}"
+        )
 
     sampling_params = SamplingParams(
         max_tokens=max_tokens,
@@ -209,6 +225,8 @@ def handler(job: dict) -> dict:
         output = handle_messages_request(job_input)
     except ValueError as e:
         return {"error": str(e)}
+    except Exception as e:
+        return {"error": f"推論エラーが発生しました: {type(e).__name__}"}
 
     return {"output": output}
 

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -333,7 +333,7 @@ def handler(job: dict) -> dict:
     except ValueError as e:
         return {"error": str(e)}
     except Exception as e:
-        logger.error("推論エラー: %s: %s", type(e).__name__, e)
+        logger.error("推論エラー: %s: %s", type(e).__name__, e, exc_info=True)
         return {"error": "推論エラーが発生しました"}
 
     return {"output": output}

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -1,7 +1,8 @@
 """
 RunPodサーバーレスハンドラー
 
-Google Gemma 3 12B IT モデルを vLLM で起動し、RunPod サーバーレス API のリクエストを処理する。
+Google Gemma 3 12B IT モデル（AWQ/GPTQ 量子化対応）を vLLM で起動し、
+RunPod サーバーレス API のリクエストを処理する。
 
 リクエスト形式:
     {"input": {"messages": [{"role": "user", "content": "..."}], "max_tokens": 4096}}
@@ -11,6 +12,8 @@ Google Gemma 3 12B IT モデルを vLLM で起動し、RunPod サーバーレス
 
 モデル名は以下の優先順で解決する:
     GEMMA_MODEL_NAME 環境変数 -> MODEL_PATH 環境変数 -> MODEL_NAME 環境変数 -> デフォルト
+
+量子化は VLLM_QUANTIZATION 環境変数で制御する（awq / gptq_marlin / fp8 / 空で非量子化）。
 """
 
 import os
@@ -34,21 +37,30 @@ MODEL_REF = (
     or os.environ.get("MODEL_PATH")
     or os.environ.get("MODEL_NAME", "google/gemma-3-12b-it")
 )
-MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "4096"))
-MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "2"))
-GPU_MEMORY_UTILIZATION = float(os.environ.get("GPU_MEMORY_UTILIZATION", "0.85"))
+MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "8192"))
+MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "4"))
+GPU_MEMORY_UTILIZATION = float(os.environ.get("GPU_MEMORY_UTILIZATION", "0.90"))
 TENSOR_PARALLEL_SIZE = int(os.environ.get("TENSOR_PARALLEL_SIZE", "1"))
 
-# Gemma は量子化なしのネイティブ fp16/bf16 を想定する。
-# 16GB GPU で動かす場合は MAX_MODEL_LEN と MAX_NUM_SEQS を小さく保つ。
-llm = LLM(
-    model=MODEL_REF,
-    dtype="bfloat16",
-    max_model_len=MAX_MODEL_LEN,
-    max_num_seqs=MAX_NUM_SEQS,
-    gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
-    tensor_parallel_size=TENSOR_PARALLEL_SIZE,
-)
+# 量子化設定: 環境変数 VLLM_QUANTIZATION で制御する
+# awq / gptq_marlin / fp8 を指定するか、空文字・未設定で非量子化（後方互換）
+VLLM_QUANTIZATION = os.environ.get("VLLM_QUANTIZATION") or None
+
+# AWQ 量子化時は "auto" を推奨。非量子化時は "bfloat16" を維持する
+VLLM_DTYPE = os.environ.get("VLLM_DTYPE", "bfloat16")
+
+llm_kwargs: dict = {
+    "model": MODEL_REF,
+    "dtype": VLLM_DTYPE,
+    "max_model_len": MAX_MODEL_LEN,
+    "max_num_seqs": MAX_NUM_SEQS,
+    "gpu_memory_utilization": GPU_MEMORY_UTILIZATION,
+    "tensor_parallel_size": TENSOR_PARALLEL_SIZE,
+}
+if VLLM_QUANTIZATION:
+    llm_kwargs["quantization"] = VLLM_QUANTIZATION
+
+llm = LLM(**llm_kwargs)
 
 
 def validate_messages(messages: Any) -> list[dict]:

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -286,14 +286,16 @@ def _generate(job_input: dict) -> dict:
 
     do_sample = temperature > TEMPERATURE_GREEDY_THRESHOLD
 
+    generate_kwargs: dict = {
+        "max_new_tokens": max_new_tokens,
+        "do_sample": do_sample,
+    }
+    if do_sample:
+        generate_kwargs["temperature"] = temperature
+        generate_kwargs["top_p"] = top_p
+
     with torch.inference_mode():
-        output_ids = model.generate(
-            **inputs,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            do_sample=do_sample,
-        )
+        output_ids = model.generate(**inputs, **generate_kwargs)
 
     # 入力トークンを除いた生成部分のみデコード
     generated_ids = output_ids[:, input_len:]

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -40,8 +40,8 @@ MODEL_REF = (
     or os.environ.get("MODEL_PATH")
     or os.environ.get("MODEL_NAME", "google/gemma-3-12b-it")
 )
-if not os.environ.get("MODEL_NAME"):
-    logger.warning("MODEL_NAME が未設定のためデフォルトモデルを使用します: %s", MODEL_REF)
+if not any(os.environ.get(k) for k in ("GEMMA_MODEL_NAME", "MODEL_PATH", "MODEL_NAME")):
+    logger.warning("モデル指定の環境変数が未設定のためデフォルトモデルを使用します: %s", MODEL_REF)
 MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "8192"))
 MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "4"))
 GPU_MEMORY_UTILIZATION = float(os.environ.get("GPU_MEMORY_UTILIZATION", "0.90"))
@@ -226,6 +226,7 @@ def handler(job: dict) -> dict:
     except ValueError as e:
         return {"error": str(e)}
     except Exception as e:
+        logger.error("推論エラー: %s: %s", type(e).__name__, e)
         return {"error": f"推論エラーが発生しました: {type(e).__name__}"}
 
     return {"output": output}

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -1,12 +1,11 @@
 """
 RunPod サーバーレスハンドラー
 
-Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound モデルを
-HuggingFace Transformers でロードし、RunPod サーバーレス API のリクエストを処理する。
+raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4 モデルを
+vLLM でロードし、RunPod サーバーレス API のリクエストを処理する。
 
-TurboQuant（back2matching/turboquant）を使って KV キャッシュを圧縮する。
-Gemma 4 のハイブリッド注意機構（25層 SWA + 5層 Global Attention）に対応しており、
-グローバル注意層のみ 3.8x の KV キャッシュ圧縮を適用する。
+0xSero/turboquant を vLLM integration API で統合し、
+KV キャッシュを圧縮することで VRAM 効率を向上させる。
 
 リクエスト形式:
     {
@@ -27,8 +26,8 @@ import os
 from typing import Any
 
 import runpod
-import torch
-from transformers import AutoModelForCausalLM, AutoProcessor
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
 
 logging.basicConfig(
     level=logging.INFO,
@@ -37,11 +36,11 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # デフォルトモデル ID（環境変数で上書き可能）
-DEFAULT_MODEL_ID = "Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound"
+DEFAULT_MODEL_ID = "raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4"
 
 # 許可するモデル ID の一覧
 ALLOWED_MODEL_IDS: frozenset[str] = frozenset({
-    "Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound",
+    "raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4",
 })
 
 # メッセージ本文の最大文字数
@@ -59,7 +58,7 @@ TEMPERATURE_MIN = 0.0
 TEMPERATURE_MAX = 2.0
 DEFAULT_TEMPERATURE = 0.7
 
-# temperature がこの値以下の場合は決定論的生成（do_sample=False）
+# temperature がこの値以下の場合は決定論的生成（greedy）
 TEMPERATURE_GREEDY_THRESHOLD = 0.0
 
 # top_p の有効範囲
@@ -67,8 +66,13 @@ TOP_P_MIN = 0.0
 TOP_P_MAX = 1.0
 DEFAULT_TOP_P = 0.9
 
-# TurboQuant KV キャッシュ圧縮ビット数
-TURBOQUANT_BITS = 4
+# GPU メモリ使用率（0.0 ~ 1.0）
+GPU_MEMORY_UTILIZATION = 0.90
+
+# TurboQuant KV キャッシュ圧縮設定
+TURBOQUANT_KEY_BITS = 3
+TURBOQUANT_VALUE_BITS = 2
+TURBOQUANT_BUFFER_SIZE = 128
 
 model_id_env: str = os.environ.get("MODEL_ID", DEFAULT_MODEL_ID)
 if model_id_env not in ALLOWED_MODEL_IDS:
@@ -76,65 +80,98 @@ if model_id_env not in ALLOWED_MODEL_IDS:
 MODEL_ID: str = model_id_env
 
 # グローバルモデル（コールドスタート時のみロード）
-_model: AutoModelForCausalLM | None = None
-_processor: AutoProcessor | None = None
+_llm: LLM | None = None
+_tokenizer: AutoTokenizer | None = None
 
 
-def _load_model() -> tuple[AutoModelForCausalLM, AutoProcessor]:
+def _install_turboquant_hooks(llm_instance: LLM) -> int:
     """
-    モデルとプロセッサをロードする。
+    vLLM エンジンに TurboQuant フックをインストールする。
 
-    TurboQuant によるKVキャッシュ圧縮を試みる。
-    patch_model が失敗した場合は警告を出して続行する。
+    Args:
+        llm_instance: フックをインストールする LLM インスタンス
 
     Returns:
-        (model, processor) のタプル
+        インストールされたフック数
     """
-    logger.info("モデルをロード中: %s", MODEL_ID)
-
-    model = AutoModelForCausalLM.from_pretrained(
-        MODEL_ID,
-        device_map="auto",
-        torch_dtype="auto",
-    )
-    processor = AutoProcessor.from_pretrained(MODEL_ID)
-
-    logger.info("モデルのロード完了。TurboQuant パッチを適用中...")
-
     try:
-        import turboquant  # type: ignore[import-untyped]
+        from turboquant.vllm_attn_backend import (
+            install_turboquant_hooks,
+            MODE_ACTIVE,
+        )
 
-        if hasattr(turboquant, "patch_model"):
-            turboquant.patch_model(model, bits=TURBOQUANT_BITS)
-            logger.info("turboquant.patch_model の適用完了（bits=%d）", TURBOQUANT_BITS)
-        elif hasattr(turboquant, "hf") and hasattr(turboquant.hf, "patch_model"):
-            turboquant.hf.patch_model(model, bits=TURBOQUANT_BITS)
-            logger.info("turboquant.hf.patch_model の適用完了（bits=%d）", TURBOQUANT_BITS)
-        else:
-            logger.warning(
-                "turboquant に patch_model が見つかりません。KV キャッシュ圧縮をスキップします"
+        engine = llm_instance.llm_engine
+        core = getattr(engine, "engine_core", engine)
+        inner = getattr(core, "engine_core", core)
+        executor = inner.model_executor
+
+        def _install(worker):
+            return len(
+                install_turboquant_hooks(
+                    worker.model_runner,
+                    key_bits=TURBOQUANT_KEY_BITS,
+                    value_bits=TURBOQUANT_VALUE_BITS,
+                    buffer_size=TURBOQUANT_BUFFER_SIZE,
+                    mode=MODE_ACTIVE,
+                )
             )
+
+        hooks = executor.collective_rpc(_install)
+        hook_count = hooks[0] if hooks else 0
+        logger.info(
+            "TurboQuant フックのインストール完了（%d 層、key_bits=%d、value_bits=%d）",
+            hook_count,
+            TURBOQUANT_KEY_BITS,
+            TURBOQUANT_VALUE_BITS,
+        )
+        return hook_count
     except Exception as e:
         logger.warning(
-            "TurboQuant パッチの適用に失敗しました（%s: %s）。圧縮なしで続行します",
+            "TurboQuant フックのインストールに失敗しました（%s: %s）。圧縮なしで続行します",
             type(e).__name__,
             e,
         )
+        return 0
 
-    return model, processor
+
+def _load_model() -> tuple[LLM, AutoTokenizer]:
+    """
+    vLLM で GPTQ モデルをロードし、TurboQuant フックをインストールする。
+
+    Returns:
+        (llm, tokenizer) のタプル
+    """
+    logger.info("モデルをロード中: %s", MODEL_ID)
+
+    llm = LLM(
+        model=MODEL_ID,
+        quantization="gptq",
+        dtype="float16",
+        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+        max_model_len=4096,
+        trust_remote_code=True,
+        max_num_seqs=1,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+
+    logger.info("モデルのロード完了。TurboQuant フックをインストール中...")
+    _install_turboquant_hooks(llm)
+
+    return llm, tokenizer
 
 
-def _get_model() -> tuple[AutoModelForCausalLM, AutoProcessor]:
+def _get_model() -> tuple[LLM, AutoTokenizer]:
     """
     グローバルモデルを返す。未初期化の場合はロードする。
 
     Returns:
-        (model, processor) のタプル
+        (llm, tokenizer) のタプル
     """
-    global _model, _processor
-    if _model is None or _processor is None:
-        _model, _processor = _load_model()
-    return _model, _processor
+    global _llm, _tokenizer
+    if _llm is None or _tokenizer is None:
+        _llm, _tokenizer = _load_model()
+    return _llm, _tokenizer
 
 
 def _validate_messages(messages: Any) -> list[dict]:
@@ -272,34 +309,29 @@ def _generate(job_input: dict) -> dict:
     )
     top_p = _validate_top_p(job_input.get("top_p", DEFAULT_TOP_P))
 
-    model, processor = _get_model()
+    llm, tokenizer = _get_model()
 
-    inputs = processor.apply_chat_template(
+    prompt = tokenizer.apply_chat_template(
         messages,
         add_generation_prompt=True,
-        tokenize=True,
-        return_tensors="pt",
-        return_dict=True,
+        tokenize=False,
     )
-    inputs = inputs.to(model.device)
-    input_len = inputs["input_ids"].shape[-1]
 
-    do_sample = temperature > TEMPERATURE_GREEDY_THRESHOLD
+    use_greedy = temperature <= TEMPERATURE_GREEDY_THRESHOLD
+    if use_greedy:
+        sampling_params = SamplingParams(
+            max_tokens=max_new_tokens,
+            temperature=0.0,
+        )
+    else:
+        sampling_params = SamplingParams(
+            max_tokens=max_new_tokens,
+            temperature=temperature,
+            top_p=top_p,
+        )
 
-    generate_kwargs: dict = {
-        "max_new_tokens": max_new_tokens,
-        "do_sample": do_sample,
-    }
-    if do_sample:
-        generate_kwargs["temperature"] = temperature
-        generate_kwargs["top_p"] = top_p
-
-    with torch.inference_mode():
-        output_ids = model.generate(**inputs, **generate_kwargs)
-
-    # 入力トークンを除いた生成部分のみデコード
-    generated_ids = output_ids[:, input_len:]
-    generated_text: str = processor.decode(generated_ids[0], skip_special_tokens=True)
+    outputs = llm.generate([prompt], sampling_params)
+    generated_text: str = outputs[0].outputs[0].text
 
     return {
         "choices": [
@@ -332,8 +364,8 @@ def handler(job: dict) -> dict:
         output = _generate(job_input)
     except ValueError as e:
         return {"error": str(e)}
-    except Exception as e:
-        logger.error("推論エラー: %s: %s", type(e).__name__, e, exc_info=True)
+    except Exception:
+        logger.error("推論エラー", exc_info=True)
         return {"error": "推論エラーが発生しました"}
 
     return {"output": output}

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -100,7 +100,11 @@ def _install_turboquant_hooks(llm_instance: LLM) -> int:
         engine = llm_instance.llm_engine
         core = getattr(engine, "engine_core", engine)
         inner = getattr(core, "engine_core", core)
-        executor = inner.model_executor
+        executor = getattr(inner, "model_executor", None)
+
+        if executor is None or not hasattr(executor, "collective_rpc"):
+            logger.warning("TurboQuant: model_executor が見つかりません。フックなしで続行します")
+            return 0
 
         def _install(worker):
             return len(
@@ -331,6 +335,9 @@ def _generate(job_input: dict) -> dict:
         )
 
     outputs = llm.generate([prompt], sampling_params)
+    if not outputs or not outputs[0].outputs:
+        logger.error("推論結果が空です")
+        raise ValueError("推論結果が空です")
     generated_text: str = outputs[0].outputs[0].text
 
     return {

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -1,81 +1,129 @@
 """
-RunPodサーバーレスハンドラー
+RunPod サーバーレスハンドラー
 
-Google Gemma 3 12B IT モデル（AWQ/GPTQ 量子化対応）を vLLM で起動し、
-RunPod サーバーレス API のリクエストを処理する。
+Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound モデルを
+HuggingFace Transformers でロードし、RunPod サーバーレス API のリクエストを処理する。
+
+TurboQuant（back2matching/turboquant）を使って KV キャッシュを圧縮する。
+Gemma 4 のハイブリッド注意機構（25層 SWA + 5層 Global Attention）に対応しており、
+グローバル注意層のみ 3.8x の KV キャッシュ圧縮を適用する。
 
 リクエスト形式:
-    {"input": {"messages": [{"role": "user", "content": "..."}], "max_tokens": 4096}}
+    {
+        "input": {
+            "messages": [{"role": "user", "content": "..."}],
+            "max_new_tokens": 512,
+            "temperature": 0.7,
+            "top_p": 0.9
+        }
+    }
 
 レスポンス形式:
     {"output": {"choices": [{"message": {"role": "assistant", "content": "..."}}]}}
-
-モデル名は以下の優先順で解決する:
-    GEMMA_MODEL_NAME 環境変数 -> MODEL_PATH 環境変数 -> MODEL_NAME 環境変数 -> デフォルト
-
-量子化は VLLM_QUANTIZATION 環境変数で制御する（awq / gptq_marlin / fp8 / 空で非量子化）。
 """
 
 import logging
 import os
 from typing import Any
-import runpod
-from vllm import LLM, SamplingParams
 
+import runpod
+import torch
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
 logger = logging.getLogger(__name__)
+
+# デフォルトモデル ID（環境変数で上書き可能）
+DEFAULT_MODEL_ID = "Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound"
 
 # メッセージ本文の最大文字数
 MESSAGE_CONTENT_MAX_LENGTH = 50000
 
-# max_tokens の最大値
-MAX_TOKENS_LIMIT = 8192
+# max_new_tokens の上限・デフォルト値
+MAX_NEW_TOKENS_LIMIT = 2048
+DEFAULT_MAX_NEW_TOKENS = 512
 
-# モデル参照の解決優先順位:
-#   1. GEMMA_MODEL_NAME (Gemma 系切り替え用の専用変数)
-#   2. MODEL_PATH (汎用パス指定)
-#   3. MODEL_NAME (Dockerfile からの注入)
-#   4. デフォルト (google/gemma-3-12b-it)
-MODEL_REF = (
-    os.environ.get("GEMMA_MODEL_NAME")
-    or os.environ.get("MODEL_PATH")
-    or os.environ.get("MODEL_NAME", "google/gemma-3-12b-it")
-)
-if not any(os.environ.get(k) for k in ("GEMMA_MODEL_NAME", "MODEL_PATH", "MODEL_NAME")):
-    logger.warning("モデル指定の環境変数が未設定のためデフォルトモデルを使用します: %s", MODEL_REF)
-MAX_MODEL_LEN = int(os.environ.get("MAX_MODEL_LEN", "8192"))
-MAX_NUM_SEQS = int(os.environ.get("MAX_NUM_SEQS", "4"))
-GPU_MEMORY_UTILIZATION = float(os.environ.get("GPU_MEMORY_UTILIZATION", "0.90"))
-TENSOR_PARALLEL_SIZE = int(os.environ.get("TENSOR_PARALLEL_SIZE", "1"))
+# temperature の有効範囲
+TEMPERATURE_MIN = 0.0
+TEMPERATURE_MAX = 2.0
+DEFAULT_TEMPERATURE = 0.7
 
-# 量子化設定: 環境変数 VLLM_QUANTIZATION で制御する
-# awq / gptq_marlin / fp8 を指定するか、空文字・未設定で非量子化（後方互換）
-_ALLOWED_QUANTIZATION = {"awq", "gptq_marlin", "fp8"}
-_RAW = os.environ.get("VLLM_QUANTIZATION", "").strip()
-VLLM_QUANTIZATION = _RAW if _RAW else None
-if VLLM_QUANTIZATION and VLLM_QUANTIZATION not in _ALLOWED_QUANTIZATION:
-    raise ValueError(
-        f"VLLM_QUANTIZATION の値が不正です: {VLLM_QUANTIZATION!r}。"
-        f"許可値: {_ALLOWED_QUANTIZATION}"
+# top_p の有効範囲
+TOP_P_MIN = 0.0
+TOP_P_MAX = 1.0
+DEFAULT_TOP_P = 0.9
+
+# TurboQuant KV キャッシュ圧縮ビット数
+TURBOQUANT_BITS = 4
+
+MODEL_ID: str = os.environ.get("MODEL_ID", DEFAULT_MODEL_ID)
+
+# グローバルモデル（コールドスタート時のみロード）
+_model: AutoModelForCausalLM | None = None
+_processor: AutoProcessor | None = None
+
+
+def _load_model() -> tuple[AutoModelForCausalLM, AutoProcessor]:
+    """
+    モデルとプロセッサをロードする。
+
+    TurboQuant によるKVキャッシュ圧縮を試みる。
+    patch_model が失敗した場合は警告を出して続行する。
+
+    Returns:
+        (model, processor) のタプル
+    """
+    logger.info("モデルをロード中: %s", MODEL_ID)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_ID,
+        device_map="auto",
+        torch_dtype="auto",
     )
+    processor = AutoProcessor.from_pretrained(MODEL_ID)
 
-# AWQ 量子化時は "auto" を推奨。非量子化時は "bfloat16" を維持する
-VLLM_DTYPE = os.environ.get("VLLM_DTYPE", "bfloat16")
+    logger.info("モデルのロード完了。TurboQuant パッチを適用中...")
 
-llm_kwargs: dict[str, Any] = {
-    "model": MODEL_REF,
-    "dtype": VLLM_DTYPE,
-    "max_model_len": MAX_MODEL_LEN,
-    "max_num_seqs": MAX_NUM_SEQS,
-    "gpu_memory_utilization": GPU_MEMORY_UTILIZATION,
-    "tensor_parallel_size": TENSOR_PARALLEL_SIZE,
-}
-if VLLM_QUANTIZATION:
-    llm_kwargs["quantization"] = VLLM_QUANTIZATION
+    try:
+        import turboquant  # type: ignore[import-untyped]
 
-llm = LLM(**llm_kwargs)
+        if hasattr(turboquant, "patch_model"):
+            turboquant.patch_model(model, bits=TURBOQUANT_BITS)
+            logger.info("turboquant.patch_model の適用完了（bits=%d）", TURBOQUANT_BITS)
+        elif hasattr(turboquant, "hf") and hasattr(turboquant.hf, "patch_model"):
+            turboquant.hf.patch_model(model, bits=TURBOQUANT_BITS)
+            logger.info("turboquant.hf.patch_model の適用完了（bits=%d）", TURBOQUANT_BITS)
+        else:
+            logger.warning(
+                "turboquant に patch_model が見つかりません。KV キャッシュ圧縮をスキップします"
+            )
+    except Exception as e:
+        logger.warning(
+            "TurboQuant パッチの適用に失敗しました（%s: %s）。圧縮なしで続行します",
+            type(e).__name__,
+            e,
+        )
+
+    return model, processor
 
 
-def validate_messages(messages: Any) -> list[dict]:
+def _get_model() -> tuple[AutoModelForCausalLM, AutoProcessor]:
+    """
+    グローバルモデルを返す。未初期化の場合はロードする。
+
+    Returns:
+        (model, processor) のタプル
+    """
+    global _model, _processor
+    if _model is None or _processor is None:
+        _model, _processor = _load_model()
+    return _model, _processor
+
+
+def _validate_messages(messages: Any) -> list[dict]:
     """
     messages の型・内容を検証する。
 
@@ -105,7 +153,7 @@ def validate_messages(messages: Any) -> list[dict]:
         content = msg.get("content")
         if isinstance(content, bool) or not isinstance(content, str):
             raise ValueError(f"messages[{i}].content は文字列である必要があります")
-        if len(msg["content"]) > MESSAGE_CONTENT_MAX_LENGTH:
+        if len(content) > MESSAGE_CONTENT_MAX_LENGTH:
             raise ValueError(
                 f"messages[{i}].content は {MESSAGE_CONTENT_MAX_LENGTH} 文字以内である必要があります"
             )
@@ -113,27 +161,29 @@ def validate_messages(messages: Any) -> list[dict]:
     return messages
 
 
-def validate_max_tokens(value: Any) -> int:
+def _validate_max_new_tokens(value: Any) -> int:
     """
-    max_tokens の値を検証する。
+    max_new_tokens の値を検証する。
 
     Args:
-        value: 検証対象の max_tokens 値
+        value: 検証対象の max_new_tokens 値
 
     Returns:
-        検証済み max_tokens 整数値
+        検証済み max_new_tokens 整数値
 
     Raises:
         ValueError: 型・範囲が不正な場合
     """
     if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError("max_tokens は整数である必要があります")
-    if value <= 0 or value > MAX_TOKENS_LIMIT:
-        raise ValueError(f"max_tokens は 1 以上 {MAX_TOKENS_LIMIT} 以下である必要があります")
+        raise ValueError("max_new_tokens は整数である必要があります")
+    if value <= 0 or value > MAX_NEW_TOKENS_LIMIT:
+        raise ValueError(
+            f"max_new_tokens は 1 以上 {MAX_NEW_TOKENS_LIMIT} 以下である必要があります"
+        )
     return value
 
 
-def validate_temperature(value: Any) -> float:
+def _validate_temperature(value: Any) -> float:
     """
     temperature の値を検証する。
 
@@ -149,17 +199,47 @@ def validate_temperature(value: Any) -> float:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError("temperature は数値である必要があります")
     temperature = float(value)
-    if temperature < 0.0 or temperature > 1.0:
-        raise ValueError("temperature は 0.0 以上 1.0 以下である必要があります")
+    if temperature < TEMPERATURE_MIN or temperature > TEMPERATURE_MAX:
+        raise ValueError(
+            f"temperature は {TEMPERATURE_MIN} 以上 {TEMPERATURE_MAX} 以下である必要があります"
+        )
     return temperature
 
 
-def handle_messages_request(job_input: dict) -> dict:
+def _validate_top_p(value: Any) -> float:
     """
-    messages キーを使ったリクエストを処理する（要約・翻訳共通）。
+    top_p の値を検証する。
 
     Args:
-        job_input: {"messages": [{"role": "user", "content": "..."}], "max_tokens": 4096}
+        value: 検証対象の top_p 値
+
+    Returns:
+        検証済み top_p 浮動小数点数値
+
+    Raises:
+        ValueError: 型・範囲が不正な場合
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("top_p は数値である必要があります")
+    top_p = float(value)
+    if top_p < TOP_P_MIN or top_p > TOP_P_MAX:
+        raise ValueError(
+            f"top_p は {TOP_P_MIN} 以上 {TOP_P_MAX} 以下である必要があります"
+        )
+    return top_p
+
+
+def _generate(job_input: dict) -> dict:
+    """
+    messages 形式のリクエストを処理し、テキストを生成する。
+
+    Args:
+        job_input: {
+            "messages": [...],
+            "max_new_tokens": 512,
+            "temperature": 0.7,
+            "top_p": 0.9
+        }
 
     Returns:
         {"choices": [{"message": {"role": "assistant", "content": "..."}}]}
@@ -167,30 +247,39 @@ def handle_messages_request(job_input: dict) -> dict:
     Raises:
         ValueError: 入力バリデーション失敗時
     """
-    messages = validate_messages(job_input["messages"])
-    raw_max_tokens = job_input.get("max_tokens", 4096)
-    max_tokens = validate_max_tokens(raw_max_tokens)
-    raw_temperature = job_input.get("temperature", 0.3)
-    temperature = validate_temperature(raw_temperature)
-
-    tokenizer = llm.get_tokenizer()
-    prompt = tokenizer.apply_chat_template(
-        messages,
-        tokenize=False,
-        add_generation_prompt=True,
+    messages = _validate_messages(job_input["messages"])
+    max_new_tokens = _validate_max_new_tokens(
+        job_input.get("max_new_tokens", DEFAULT_MAX_NEW_TOKENS)
     )
-    if not isinstance(prompt, str):
-        raise ValueError(
-            f"apply_chat_template が str を返しませんでした: {type(prompt).__name__}"
+    temperature = _validate_temperature(
+        job_input.get("temperature", DEFAULT_TEMPERATURE)
+    )
+    top_p = _validate_top_p(job_input.get("top_p", DEFAULT_TOP_P))
+
+    model, processor = _get_model()
+
+    inputs = processor.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_tensors="pt",
+        return_dict=True,
+    )
+    inputs = inputs.to(model.device)
+    input_len = inputs["input_ids"].shape[-1]
+
+    with torch.inference_mode():
+        output_ids = model.generate(
+            **inputs,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            do_sample=True,
         )
 
-    sampling_params = SamplingParams(
-        max_tokens=max_tokens,
-        temperature=temperature,
-    )
-
-    outputs = llm.generate([prompt], sampling_params)
-    generated_text = outputs[0].outputs[0].text
+    # 入力トークンを除いた生成部分のみデコード
+    generated_ids = output_ids[:, input_len:]
+    generated_text: str = processor.decode(generated_ids[0], skip_special_tokens=True)
 
     return {
         "choices": [
@@ -208,13 +297,11 @@ def handler(job: dict) -> dict:
     """
     RunPod サーバーレスハンドラーのエントリーポイント。
 
-    Gemma 3 では messages 形式のみをサポートする。
-
     Args:
         job: RunPod ジョブオブジェクト（{"input": {...}}）
 
     Returns:
-        生成結果（{"output": {...}} 形式）
+        生成結果（{"output": {...}} 形式）またはエラー（{"error": "..."} 形式）
     """
     job_input = job.get("input", {})
 
@@ -222,7 +309,7 @@ def handler(job: dict) -> dict:
         return {"error": "input に messages キーが必要です"}
 
     try:
-        output = handle_messages_request(job_input)
+        output = _generate(job_input)
     except ValueError as e:
         return {"error": str(e)}
     except Exception as e:

--- a/infra/runpod/handler.py
+++ b/infra/runpod/handler.py
@@ -26,8 +26,8 @@ import os
 from typing import Any
 
 import runpod
+import torch
 from vllm import LLM, SamplingParams
-from transformers import AutoTokenizer
 
 logging.basicConfig(
     level=logging.INFO,
@@ -74,14 +74,11 @@ TURBOQUANT_KEY_BITS = 3
 TURBOQUANT_VALUE_BITS = 2
 TURBOQUANT_BUFFER_SIZE = 128
 
-model_id_env: str = os.environ.get("MODEL_ID", DEFAULT_MODEL_ID)
-if model_id_env not in ALLOWED_MODEL_IDS:
-    raise ValueError(f"許可されていないモデルID: {model_id_env}")
-MODEL_ID: str = model_id_env
+MODEL_ID: str = os.environ.get("MODEL_ID", DEFAULT_MODEL_ID)
 
 # グローバルモデル（コールドスタート時のみロード）
 _llm: LLM | None = None
-_tokenizer: AutoTokenizer | None = None
+_tokenizer: Any | None = None
 
 
 def _install_turboquant_hooks(llm_instance: LLM) -> int:
@@ -134,13 +131,16 @@ def _install_turboquant_hooks(llm_instance: LLM) -> int:
         return 0
 
 
-def _load_model() -> tuple[LLM, AutoTokenizer]:
+def _load_model() -> tuple[LLM, Any]:
     """
     vLLM で GPTQ モデルをロードし、TurboQuant フックをインストールする。
 
     Returns:
         (llm, tokenizer) のタプル
     """
+    if MODEL_ID not in ALLOWED_MODEL_IDS:
+        raise ValueError(f"許可されていないモデルID: {MODEL_ID}")
+
     logger.info("モデルをロード中: %s", MODEL_ID)
 
     llm = LLM(
@@ -149,11 +149,11 @@ def _load_model() -> tuple[LLM, AutoTokenizer]:
         dtype="float16",
         gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
         max_model_len=4096,
-        trust_remote_code=True,
+        trust_remote_code=False,  # GPTQ は transformers 本体でサポート
         max_num_seqs=1,
     )
 
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    tokenizer = llm.get_tokenizer()
 
     logger.info("モデルのロード完了。TurboQuant フックをインストール中...")
     _install_turboquant_hooks(llm)
@@ -161,7 +161,7 @@ def _load_model() -> tuple[LLM, AutoTokenizer]:
     return llm, tokenizer
 
 
-def _get_model() -> tuple[LLM, AutoTokenizer]:
+def _get_model() -> tuple[LLM, Any]:
     """
     グローバルモデルを返す。未初期化の場合はロードする。
 
@@ -364,6 +364,9 @@ def handler(job: dict) -> dict:
         output = _generate(job_input)
     except ValueError as e:
         return {"error": str(e)}
+    except torch.cuda.OutOfMemoryError:
+        logger.error("GPU メモリ不足エラー", exc_info=True)
+        return {"error": "推論エラーが発生しました"}
     except Exception:
         logger.error("推論エラー", exc_info=True)
         return {"error": "推論エラーが発生しました"}

--- a/infra/runpod/requirements.txt
+++ b/infra/runpod/requirements.txt
@@ -1,5 +1,3 @@
-transformers==4.51.3
-accelerate==1.6.0
-auto-round==0.5.3
+vllm==0.9.0
 runpod==1.7.4
-git+https://github.com/back2matching/turboquant.git@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0
+git+https://github.com/0xSero/turboquant.git@7ac9b8d165a3f7d5e6df33b0450bc1f88ec0d4d5

--- a/infra/runpod/requirements.txt
+++ b/infra/runpod/requirements.txt
@@ -1,3 +1,4 @@
-vllm==0.9.0
+# vllm はベースイメージ (vllm/vllm-openai) に同梱のため不要
 runpod==1.7.4
+# turboquant は pip audit 対象外のため定期的に upstream コミット履歴を手動確認すること
 git+https://github.com/0xSero/turboquant.git@7ac9b8d165a3f7d5e6df33b0450bc1f88ec0d4d5

--- a/infra/runpod/requirements.txt
+++ b/infra/runpod/requirements.txt
@@ -1,0 +1,6 @@
+transformers==4.51.3
+accelerate==1.6.0
+auto-round==0.5.3
+runpod==1.7.4
+# turboquant は GitHub コミット指定でインストールする（PyPI 版は Gemma 4 SWA 未対応）
+# pip install git+https://github.com/back2matching/turboquant.git@main

--- a/infra/runpod/requirements.txt
+++ b/infra/runpod/requirements.txt
@@ -2,5 +2,4 @@ transformers==4.51.3
 accelerate==1.6.0
 auto-round==0.5.3
 runpod==1.7.4
-# turboquant は GitHub コミット指定でインストールする（PyPI 版は Gemma 4 SWA 未対応）
-# pip install git+https://github.com/back2matching/turboquant.git@main
+git+https://github.com/back2matching/turboquant.git@acef33bf44abbd4623e11a48aae5f9a60aaf9ac0


### PR DESCRIPTION
## 概要

RunPod サーバーレス上で Gemma-4 26B を vLLM + TurboQuant で動作させるインフラ実装。

## 実装内容

- **Dockerfile**: `vllm/vllm-openai:v0.9.0`（SHA256 ダイジェスト固定）をベースに `runpod==1.7.4` と `0xSero/turboquant`（コミットハッシュ固定）を追加。非 root ユーザー実行。
- **handler.py**: RunPod サーバーレスハンドラー。vLLM で GPTQ Int4 モデルをロードし、TurboQuant フックで KV キャッシュを圧縮。入力バリデーション（messages・max_new_tokens・temperature・top_p）・OOM 個別処理・outputs 境界チェック実装済み。
- **requirements.txt**: ベースイメージに含まれる vllm は記載なし（コメントで明記）。
- **.dockerignore**: 機密ファイル・不要ファイルを除外。
- **README.md**: モデル事前ダウンロード手順（Option B: ネットワークボリューム）・HF_TOKEN 設定方法を記載。

## スタック

| 項目 | 内容 |
|---|---|
| ベースイメージ | `vllm/vllm-openai:v0.9.0`（SHA256 固定） |
| モデル | `raydelossantos/gemma-4-26B-A4B-it-GPTQ-Int4` |
| KV 圧縮 | `0xSero/turboquant`（key_bits=3、value_bits=2） |
| 実行環境 | RunPod サーバーレス・RTX 4080/A4000（16GB VRAM） |
| モデル配置 | ネットワークボリューム事前ダウンロード（TRANSFORMERS_OFFLINE=1） |

## セットアップ手順

1. RunPod ネットワークボリュームにモデルを事前ダウンロード（README 参照）
2. Docker イメージをビルド・プッシュ
3. RunPod サーバーレスエンドポイントで `MODEL_ID` と `HF_HOME` 環境変数を設定

🤖 Generated with [Claude Code](https://claude.ai/code)