### PR TITLE
fix(mobile/source): YouTube ソースを UI 定義と SourceBadge に追加する

### DIFF
--- a/apps/mobile/src/lib/sources.ts
+++ b/apps/mobile/src/lib/sources.ts
@@ -52,6 +52,7 @@ export const SOURCE_DEFINITIONS = [
     badgeClassName: "bg-rose-500/20 text-rose-400",
   },
   { id: "twitter", label: "X (Twitter)", badgeClassName: "bg-slate-500/20 text-slate-300" },
+  { id: "youtube", label: "YouTube", badgeClassName: "bg-rose-600/20 text-rose-500" },
   { id: "other", label: "その他", badgeClassName: "bg-stone-500/20 text-stone-300" },
 ] as const satisfies readonly SourceDefinition[];
 

--- a/apps/mobile/src/lib/sources.ts
+++ b/apps/mobile/src/lib/sources.ts
@@ -52,7 +52,7 @@ export const SOURCE_DEFINITIONS = [
     badgeClassName: "bg-rose-500/20 text-rose-400",
   },
   { id: "twitter", label: "X (Twitter)", badgeClassName: "bg-slate-500/20 text-slate-300" },
-  { id: "youtube", label: "YouTube", badgeClassName: "bg-rose-600/20 text-rose-500" },
+  { id: "youtube", label: "YouTube", badgeClassName: "bg-red-600/20 text-red-500" },
   { id: "other", label: "その他", badgeClassName: "bg-stone-500/20 text-stone-300" },
 ] as const satisfies readonly SourceDefinition[];
 

--- a/tests/mobile/lib/sources.test.ts
+++ b/tests/mobile/lib/sources.test.ts
@@ -1,0 +1,39 @@
+import { getSourceDefinition, SOURCE_DEFINITIONS } from "@/lib/sources";
+
+describe("SOURCE_DEFINITIONS", () => {
+  it("youtubeが含まれていること", () => {
+    // Arrange
+    const ids = SOURCE_DEFINITIONS.map(({ id }) => id);
+
+    // Act / Assert
+    expect(ids).toContain("youtube");
+  });
+
+  it("各定義にid・label・badgeClassNameが含まれていること", () => {
+    for (const def of SOURCE_DEFINITIONS) {
+      // Assert
+      expect(def.id).toBeDefined();
+      expect(def.label).toBeDefined();
+      expect(def.badgeClassName).toBeDefined();
+    }
+  });
+});
+
+describe("getSourceDefinition", () => {
+  it("youtubeを渡したときyoutube定義を返すこと", () => {
+    // Act
+    const result = getSourceDefinition("youtube");
+
+    // Assert
+    expect(result.id).toBe("youtube");
+    expect(result.label).toBe("YouTube");
+  });
+
+  it("youtubeを渡したときotherにフォールバックしないこと", () => {
+    // Act
+    const result = getSourceDefinition("youtube");
+
+    // Assert
+    expect(result.id).not.toBe("other");
+  });
+});

--- a/tests/mobile/lib/sources.test.ts
+++ b/tests/mobile/lib/sources.test.ts
@@ -1,4 +1,10 @@
-import { getSourceDefinition, SOURCE_DEFINITIONS } from "@/lib/sources";
+import {
+  getSourceDefinition,
+  SOURCE_CONFIG,
+  SOURCE_DEFINITIONS,
+  SUPPORTED_SOURCE_COUNT,
+  SUPPORTED_SOURCES,
+} from "@/lib/sources";
 
 describe("SOURCE_DEFINITIONS", () => {
   it("youtubeが含まれていること", () => {
@@ -12,10 +18,30 @@ describe("SOURCE_DEFINITIONS", () => {
   it("各定義にid・label・badgeClassNameが含まれていること", () => {
     for (const def of SOURCE_DEFINITIONS) {
       // Assert
-      expect(def.id).toBeDefined();
-      expect(def.label).toBeDefined();
-      expect(def.badgeClassName).toBeDefined();
+      expect(typeof def.id).toBe("string");
+      expect(def.label.length).toBeGreaterThan(0);
+      expect(def.badgeClassName.length).toBeGreaterThan(0);
     }
+  });
+
+  it("件数がSUPPORTED_SOURCE_COUNTと一致すること", () => {
+    // Assert
+    expect(SOURCE_DEFINITIONS.length).toBe(SUPPORTED_SOURCE_COUNT);
+  });
+
+  it("各定義のIDに重複がないこと", () => {
+    // Arrange
+    const ids = SOURCE_DEFINITIONS.map((d) => d.id);
+
+    // Assert
+    expect(new Set(ids).size).toBe(SOURCE_DEFINITIONS.length);
+  });
+});
+
+describe("SUPPORTED_SOURCES", () => {
+  it("youtubeが含まれていること", () => {
+    // Assert
+    expect(SUPPORTED_SOURCES).toContain("youtube");
   });
 });
 
@@ -29,11 +55,38 @@ describe("getSourceDefinition", () => {
     expect(result.label).toBe("YouTube");
   });
 
-  it("youtubeを渡したときotherにフォールバックしないこと", () => {
+  it("zennを渡したときzenn定義を返すこと", () => {
     // Act
-    const result = getSourceDefinition("youtube");
+    const result = getSourceDefinition("zenn");
 
     // Assert
-    expect(result.id).not.toBe("other");
+    expect(result.id).toBe("zenn");
+    expect(result.label).toBe("Zenn");
+  });
+
+  it("qiitaを渡したときqiita定義を返すこと", () => {
+    // Act
+    const result = getSourceDefinition("qiita");
+
+    // Assert
+    expect(result.id).toBe("qiita");
+    expect(result.label).toBe("Qiita");
+  });
+
+  it("otherを渡したときother定義を返すこと", () => {
+    // Act
+    const result = getSourceDefinition("other");
+
+    // Assert
+    expect(result.id).toBe("other");
+    expect(result.label).toBe("その他");
+  });
+});
+
+describe("SOURCE_CONFIG", () => {
+  it("SOURCE_CONFIGにyoutubeエントリが登録されていること", () => {
+    // Assert
+    expect(SOURCE_CONFIG.youtube.label).toBe("YouTube");
+    expect(SOURCE_CONFIG.youtube.id).toBe("youtube");
   });
 });


### PR DESCRIPTION
## Summary

- `apps/mobile/src/lib/sources.ts` の `SOURCE_DEFINITIONS` に `youtube` エントリを追加（`twitter` と `other` の間、共有型の並び順に合わせた）
- `SourceBadge` は `getSourceDefinition()` 経由で自動的に YouTube バッジを描画（変更不要）
- `tests/mobile/lib/sources.test.ts` を新規作成し、YouTube 追加・ID重複なし・SUPPORTED_SOURCES 整合性・複数ソースの定義取得を検証

## Test plan

- [ ] `tests/mobile/lib/sources.test.ts` - 10 テスト PASS
- [ ] `tests/mobile/components/ui/SourceBadge.test.tsx` - it.each で YouTube が自動的にカバーされていること
- [ ] `pnpm lint` 0 エラー
- [ ] `pnpm typecheck` 0 エラー

Closes #824

🤖 Generated with [Claude Code](https://claude.ai/code)