### PR TITLE
fix(mobile/api): apiFetch のHTTPエラー処理と非JSON応答の耐性を強化する #853

### DIFF
--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -14,14 +14,96 @@ const REQUEST_TIMEOUT_MS = 15000;
 /** トークンリフレッシュAPIのパス */
 const REFRESH_TOKEN_PATH = "/api/auth/refresh";
 
+/** HTTPステータスコード: 未認証 */
+const HTTP_STATUS_UNAUTHORIZED = 401;
+
+/** HTTPステータスコード: 成功範囲の下限 */
+const HTTP_STATUS_SUCCESS_MIN = 200;
+
+/** HTTPステータスコード: 成功範囲の上限（未満） */
+const HTTP_STATUS_SUCCESS_MAX = 300;
+
+/** JSONのContent-Type判定用の文字列 */
+const JSON_CONTENT_TYPE_HINT = "json";
+
+/** Abortエラーの識別名 */
+const ABORT_ERROR_NAME = "AbortError";
+
+/** タイムアウト時のエラーメッセージ */
+const TIMEOUT_ERROR_MESSAGE = "リクエストがタイムアウトしました";
+
+/** ネットワーク接続不能時のエラーメッセージ */
+const NETWORK_ERROR_MESSAGE = "ネットワークに接続できません";
+
+/** HTTPエラー時のデフォルトメッセージ */
+const HTTP_ERROR_MESSAGE = "サーバーエラーが発生しました";
+
+/** パースエラー時のデフォルトメッセージ */
+const PARSE_ERROR_MESSAGE = "レスポンスの解析に失敗しました";
+
+/**
+ * APIエラーの基底クラス
+ */
+export class ApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 /**
  * セッション期限切れエラー
  * トークンリフレッシュに失敗した場合にスローする
  */
-export class SessionExpiredError extends Error {
+export class SessionExpiredError extends ApiError {
   constructor() {
     super("セッションの有効期限が切れました。再度ログインしてください");
     this.name = "SessionExpiredError";
+  }
+}
+
+/**
+ * HTTPエラー（非2xxかつ業務エラーJSONでない応答）
+ * 非JSON本文や空本文など、業務エラーとして解釈できない非2xx応答に対して使う
+ */
+export class ApiHttpError extends ApiError {
+  /** HTTPステータスコード */
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiHttpError";
+    this.status = status;
+  }
+}
+
+/**
+ * ネットワークエラー
+ * fetch自体が失敗した場合（オフライン、タイムアウト等）にスローする
+ */
+export class ApiNetworkError extends ApiError {
+  /** 元のエラー */
+  public readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "ApiNetworkError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * レスポンス解析エラー
+ * 2xxレスポンスでJSONパースに失敗した場合にスローする
+ */
+export class ApiParseError extends ApiError {
+  /** HTTPステータスコード */
+  public readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiParseError";
+    this.status = status;
   }
 }
 
@@ -47,11 +129,37 @@ export function getBaseUrl(): string {
 }
 
 /**
+ * HTTPステータスが成功範囲（2xx）かどうかを判定する
+ *
+ * @param status - HTTPステータスコード
+ * @returns 2xxなら true
+ */
+function isSuccessStatus(status: number): boolean {
+  return status >= HTTP_STATUS_SUCCESS_MIN && status < HTTP_STATUS_SUCCESS_MAX;
+}
+
+/**
+ * Content-TypeヘッダーがJSONを示しているかどうかを判定する
+ *
+ * @param response - fetchレスポンス
+ * @returns JSONを示している、またはヘッダーが無ければ true
+ */
+function isJsonContentType(response: Response): boolean {
+  const contentType = response.headers?.get?.("content-type");
+  if (!contentType) {
+    return true;
+  }
+  return contentType.toLowerCase().includes(JSON_CONTENT_TYPE_HINT);
+}
+
+/**
  * タイムアウト付きfetchを実行する
+ * fetchが reject した場合は ApiNetworkError にラップする
  *
  * @param url - リクエストURL
  * @param options - fetchオプション
  * @returns fetchレスポンス
+ * @throws ApiNetworkError - ネットワーク不通・タイムアウト時
  */
 export async function fetchWithTimeout(url: string, options: RequestInit): Promise<Response> {
   const controller = new AbortController();
@@ -59,6 +167,11 @@ export async function fetchWithTimeout(url: string, options: RequestInit): Promi
 
   try {
     return await fetch(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === ABORT_ERROR_NAME) {
+      throw new ApiNetworkError(TIMEOUT_ERROR_MESSAGE, error);
+    }
+    throw new ApiNetworkError(NETWORK_ERROR_MESSAGE, error);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -87,8 +200,98 @@ function buildHeaders(
   return headers;
 }
 
+/** JSONパース失敗を示す内部センチネル */
+const PARSE_FAILED = Symbol("parse-failed");
+
+type ParseResult = unknown | typeof PARSE_FAILED;
+
+/**
+ * レスポンス本文をJSONとしてパースする
+ * パースに失敗した場合は PARSE_FAILED を返す
+ *
+ * @param response - fetchレスポンス
+ * @returns パース結果。失敗時は PARSE_FAILED
+ */
+async function tryParseJson(response: Response): Promise<ParseResult> {
+  try {
+    return await response.json();
+  } catch {
+    return PARSE_FAILED;
+  }
+}
+
+/**
+ * 成功レスポンスの本文をパースする
+ * パース失敗時は ApiParseError をスローする
+ *
+ * @param response - fetchレスポンス
+ * @returns パース済み本文
+ * @throws ApiParseError - JSONパース失敗時
+ */
+async function parseSuccessBody<T>(response: Response): Promise<T> {
+  const parsed = await tryParseJson(response);
+  if (parsed === PARSE_FAILED) {
+    throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
+  }
+  if (!isJsonContentType(response)) {
+    throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
+  }
+  return parsed as T;
+}
+
+/**
+ * 業務エラー形式かどうかを判定する
+ * `{ success: false, error: { ... } }` の形を許容する
+ *
+ * @param value - 判定対象
+ * @returns 業務エラー形式なら true
+ */
+function isBusinessErrorPayload(value: unknown): boolean {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const maybe = value as { success?: unknown; error?: unknown };
+  return maybe.success === false && typeof maybe.error === "object" && maybe.error !== null;
+}
+
+/**
+ * 非2xxレスポンスの本文を扱う
+ * 業務エラーJSONならそのまま返し、そうでなければ ApiHttpError をスローする
+ *
+ * @param response - fetchレスポンス
+ * @returns 業務エラー本文
+ * @throws ApiHttpError - 非JSONまたは業務エラー形式でない場合
+ */
+async function handleErrorResponse<T>(response: Response): Promise<T> {
+  const parsed = await tryParseJson(response);
+  if (parsed === PARSE_FAILED) {
+    throw new ApiHttpError(response.status, HTTP_ERROR_MESSAGE);
+  }
+  if (!isBusinessErrorPayload(parsed)) {
+    throw new ApiHttpError(response.status, HTTP_ERROR_MESSAGE);
+  }
+  return parsed as T;
+}
+
+/**
+ * レスポンスを解釈して本文を返す
+ * 2xx → 成功パース、非2xx → 業務エラーJSON or ApiHttpError
+ *
+ * @param response - fetchレスポンス
+ * @returns パース済み本文
+ * @throws ApiParseError - 2xxだがJSONパース失敗時
+ * @throws ApiHttpError - 非2xxかつ業務エラー形式でない場合
+ */
+async function interpretResponse<T>(response: Response): Promise<T> {
+  if (isSuccessStatus(response.status)) {
+    return parseSuccessBody<T>(response);
+  }
+  return handleErrorResponse<T>(response);
+}
+
 /**
  * リフレッシュトークンで新しいアクセストークンを取得する
+ * 非JSON応答・ネットワーク失敗を含むあらゆる失敗は SessionExpiredError にラップする
  *
  * @returns 新しいアクセストークン
  * @throws SessionExpiredError - リフレッシュに失敗した場合
@@ -101,24 +304,41 @@ async function refreshAccessToken(): Promise<string> {
     throw new SessionExpiredError();
   }
 
-  const response = await fetchWithTimeout(`${getBaseUrl()}${REFRESH_TOKEN_PATH}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken }),
-  });
+  try {
+    const response = await fetchWithTimeout(`${getBaseUrl()}${REFRESH_TOKEN_PATH}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
 
-  const data = (await response.json()) as RefreshTokenResponse | { success: false };
+    if (!isSuccessStatus(response.status)) {
+      await clearAuthTokens();
+      throw new SessionExpiredError();
+    }
 
-  if (!data.success) {
+    const parsed = await tryParseJson(response);
+    if (parsed === PARSE_FAILED || parsed === null || typeof parsed !== "object") {
+      await clearAuthTokens();
+      throw new SessionExpiredError();
+    }
+
+    const maybe = parsed as { success?: unknown };
+    if (maybe.success !== true) {
+      await clearAuthTokens();
+      throw new SessionExpiredError();
+    }
+
+    const data = parsed as RefreshTokenResponse;
+    await setAuthToken(data.data.token);
+    await setRefreshToken(data.data.refreshToken);
+    return data.data.token;
+  } catch (error) {
+    if (error instanceof SessionExpiredError) {
+      throw error;
+    }
     await clearAuthTokens();
     throw new SessionExpiredError();
   }
-
-  const newToken = (data as RefreshTokenResponse).data.token;
-  const newRefreshToken = (data as RefreshTokenResponse).data.refreshToken;
-  await setAuthToken(newToken);
-  await setRefreshToken(newRefreshToken);
-  return newToken;
 }
 
 /**
@@ -129,6 +349,9 @@ async function refreshAccessToken(): Promise<string> {
  * @param options - fetchオプション
  * @returns レスポンスデータ
  * @throws SessionExpiredError - セッションが期限切れでリフレッシュにも失敗した場合
+ * @throws ApiHttpError - 非JSONの非2xx応答を受信した場合
+ * @throws ApiParseError - 2xx応答のJSONパースに失敗した場合
+ * @throws ApiNetworkError - ネットワーク不通・タイムアウト時
  */
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
   const token = await getAuthToken();
@@ -140,8 +363,8 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
     headers,
   });
 
-  if (response.status !== 401) {
-    return (await response.json()) as T;
+  if (response.status !== HTTP_STATUS_UNAUTHORIZED) {
+    return interpretResponse<T>(response);
   }
 
   const newToken = await refreshAccessToken();
@@ -152,10 +375,10 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
     headers: retryHeaders,
   });
 
-  if (retryResponse.status === 401) {
+  if (retryResponse.status === HTTP_STATUS_UNAUTHORIZED) {
     await clearAuthTokens();
     throw new SessionExpiredError();
   }
 
-  return (await retryResponse.json()) as T;
+  return interpretResponse<T>(retryResponse);
 }

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -85,9 +85,6 @@ export class ApiHttpError extends ApiError {
  * fetch自体が失敗した場合（オフライン、タイムアウト等）にスローする
  */
 export class ApiNetworkError extends ApiError {
-  /** 元のエラー */
-  public readonly cause?: unknown;
-
   constructor(message: string, cause?: unknown) {
     super(message);
     this.name = "ApiNetworkError";
@@ -168,12 +165,14 @@ function isSuccessStatus(status: number): boolean {
 }
 
 /**
- * Content-TypeヘッダーがJSONを示しているかどうかを判定する
+ * レスポンスをJSONとしてパースすべきかどうかを判定する
+ * Content-TypeがJSONを示している場合、またはContent-Typeヘッダーが存在しない場合に true を返す
+ * Content-TypeなしはJSONとして扱う（一部サーバーがヘッダーを省略するため）
  *
  * @param response - fetchレスポンス
- * @returns JSONを示している、またはヘッダーが無ければ true
+ * @returns JSONとしてパースすべきなら true
  */
-function isJsonContentType(response: Response): boolean {
+function shouldParseAsJson(response: Response): boolean {
   const contentType = response.headers.get("content-type");
   if (!contentType) {
     return true;
@@ -256,7 +255,7 @@ async function tryParseJson(response: Response): Promise<unknown> {
  * @throws ApiParseError - Content-TypeがJSON以外、またはJSONパース失敗時
  */
 async function parseSuccessBody<T>(response: Response): Promise<T> {
-  if (!isJsonContentType(response)) {
+  if (!shouldParseAsJson(response)) {
     throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
   }
   const parsed = await tryParseJson(response);

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -26,6 +26,9 @@ const HTTP_STATUS_SUCCESS_MAX = 300;
 /** JSONのContent-Type判定用の文字列 */
 const JSON_CONTENT_TYPE_HINT = "json";
 
+/** getBaseUrl のフォールバックURL */
+const DEFAULT_API_BASE_URL = "http://localhost:8787";
+
 /** Abortエラーの識別名 */
 const ABORT_ERROR_NAME = "AbortError";
 
@@ -116,6 +119,29 @@ type RefreshTokenResponse = {
 };
 
 /**
+ * リフレッシュトークンAPIのレスポンスを型ガードで検証する
+ *
+ * @param value - 検証対象
+ * @returns RefreshTokenResponse 型なら true
+ */
+function isRefreshTokenResponse(value: unknown): value is RefreshTokenResponse {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("success" in value) || (value as { success: unknown }).success !== true) {
+    return false;
+  }
+  const data = (value as { data?: unknown }).data;
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  return (
+    typeof (data as { token?: unknown }).token === "string" &&
+    typeof (data as { refreshToken?: unknown }).refreshToken === "string"
+  );
+}
+
+/**
  * APIのベースURLを取得する
  *
  * @returns Workers APIのベースURL
@@ -123,9 +149,12 @@ type RefreshTokenResponse = {
 export function getBaseUrl(): string {
   const extra = Constants.expoConfig?.extra;
   if (extra && typeof extra === "object" && "apiUrl" in extra) {
-    return extra.apiUrl as string;
+    const apiUrl = (extra as { apiUrl?: unknown }).apiUrl;
+    if (typeof apiUrl === "string") {
+      return apiUrl;
+    }
   }
-  return "http://localhost:8787";
+  return DEFAULT_API_BASE_URL;
 }
 
 /**
@@ -145,7 +174,7 @@ function isSuccessStatus(status: number): boolean {
  * @returns JSONを示している、またはヘッダーが無ければ true
  */
 function isJsonContentType(response: Response): boolean {
-  const contentType = response.headers?.get?.("content-type");
+  const contentType = response.headers.get("content-type");
   if (!contentType) {
     return true;
   }
@@ -203,8 +232,6 @@ function buildHeaders(
 /** JSONパース失敗を示す内部センチネル */
 const PARSE_FAILED = Symbol("parse-failed");
 
-type ParseResult = unknown | typeof PARSE_FAILED;
-
 /**
  * レスポンス本文をJSONとしてパースする
  * パースに失敗した場合は PARSE_FAILED を返す
@@ -212,7 +239,7 @@ type ParseResult = unknown | typeof PARSE_FAILED;
  * @param response - fetchレスポンス
  * @returns パース結果。失敗時は PARSE_FAILED
  */
-async function tryParseJson(response: Response): Promise<ParseResult> {
+async function tryParseJson(response: Response): Promise<unknown> {
   try {
     return await response.json();
   } catch {
@@ -226,14 +253,14 @@ async function tryParseJson(response: Response): Promise<ParseResult> {
  *
  * @param response - fetchレスポンス
  * @returns パース済み本文
- * @throws ApiParseError - JSONパース失敗時
+ * @throws ApiParseError - Content-TypeがJSON以外、またはJSONパース失敗時
  */
 async function parseSuccessBody<T>(response: Response): Promise<T> {
-  const parsed = await tryParseJson(response);
-  if (parsed === PARSE_FAILED) {
+  if (!isJsonContentType(response)) {
     throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
   }
-  if (!isJsonContentType(response)) {
+  const parsed = await tryParseJson(response);
+  if (parsed === PARSE_FAILED) {
     throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
   }
   return parsed as T;
@@ -293,10 +320,11 @@ async function interpretResponse<T>(response: Response): Promise<T> {
  * リフレッシュトークンで新しいアクセストークンを取得する
  * 非JSON応答・ネットワーク失敗を含むあらゆる失敗は SessionExpiredError にラップする
  *
+ * @param baseUrl - APIのベースURL
  * @returns 新しいアクセストークン
  * @throws SessionExpiredError - リフレッシュに失敗した場合
  */
-async function refreshAccessToken(): Promise<string> {
+async function refreshAccessToken(baseUrl: string): Promise<string> {
   const refreshToken = await getRefreshToken();
 
   if (!refreshToken) {
@@ -305,7 +333,7 @@ async function refreshAccessToken(): Promise<string> {
   }
 
   try {
-    const response = await fetchWithTimeout(`${getBaseUrl()}${REFRESH_TOKEN_PATH}`, {
+    const response = await fetchWithTimeout(`${baseUrl}${REFRESH_TOKEN_PATH}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ refreshToken }),
@@ -317,21 +345,14 @@ async function refreshAccessToken(): Promise<string> {
     }
 
     const parsed = await tryParseJson(response);
-    if (parsed === PARSE_FAILED || parsed === null || typeof parsed !== "object") {
+    if (!isRefreshTokenResponse(parsed)) {
       await clearAuthTokens();
       throw new SessionExpiredError();
     }
 
-    const maybe = parsed as { success?: unknown };
-    if (maybe.success !== true) {
-      await clearAuthTokens();
-      throw new SessionExpiredError();
-    }
-
-    const data = parsed as RefreshTokenResponse;
-    await setAuthToken(data.data.token);
-    await setRefreshToken(data.data.refreshToken);
-    return data.data.token;
+    await setAuthToken(parsed.data.token);
+    await setRefreshToken(parsed.data.refreshToken);
+    return parsed.data.token;
   } catch (error) {
     if (error instanceof SessionExpiredError) {
       throw error;
@@ -354,11 +375,12 @@ async function refreshAccessToken(): Promise<string> {
  * @throws ApiNetworkError - ネットワーク不通・タイムアウト時
  */
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const baseUrl = getBaseUrl();
   const token = await getAuthToken();
   const existingHeaders = (options.headers as Record<string, string>) ?? {};
   const headers = buildHeaders(token, existingHeaders);
 
-  const response = await fetchWithTimeout(`${getBaseUrl()}${path}`, {
+  const response = await fetchWithTimeout(`${baseUrl}${path}`, {
     ...options,
     headers,
   });
@@ -367,10 +389,10 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
     return interpretResponse<T>(response);
   }
 
-  const newToken = await refreshAccessToken();
+  const newToken = await refreshAccessToken(baseUrl);
 
   const retryHeaders = buildHeaders(newToken, existingHeaders);
-  const retryResponse = await fetchWithTimeout(`${getBaseUrl()}${path}`, {
+  const retryResponse = await fetchWithTimeout(`${baseUrl}${path}`, {
     ...options,
     headers: retryHeaders,
   });

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -48,8 +48,8 @@ const PARSE_ERROR_MESSAGE = "レスポンスの解析に失敗しました";
  * APIエラーの基底クラス
  */
 export class ApiError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "ApiError";
   }
 }
@@ -86,9 +86,8 @@ export class ApiHttpError extends ApiError {
  */
 export class ApiNetworkError extends ApiError {
   constructor(message: string, cause?: unknown) {
-    super(message);
+    super(message, { cause });
     this.name = "ApiNetworkError";
-    this.cause = cause;
   }
 }
 

--- a/tests/mobile/lib/api.test.ts
+++ b/tests/mobile/lib/api.test.ts
@@ -18,6 +18,7 @@ jest.mock("@mobile/lib/secure-store", () => ({
 }));
 
 import {
+  ApiError,
   ApiHttpError,
   ApiNetworkError,
   ApiParseError,
@@ -256,15 +257,10 @@ describe("apiFetch", () => {
       );
 
       // Act & Assert
-      await expect(apiFetch("/articles")).rejects.toThrow(ApiHttpError);
-      try {
-        await apiFetch("/articles");
-      } catch (error) {
-        expect(error).toBeInstanceOf(ApiHttpError);
-        if (error instanceof ApiHttpError) {
-          expect(error.status).toBe(500);
-        }
-      }
+      await expect(apiFetch("/articles")).rejects.toMatchObject({
+        status: 500,
+      });
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
     });
 
     it("502で本文が空の場合はApiHttpErrorをスローすること", async () => {
@@ -402,6 +398,7 @@ describe("apiFetch", () => {
 
       // Assert
       expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiError);
       expect(error).toBeInstanceOf(SessionExpiredError);
       expect(error.message).toBe("セッションの有効期限が切れました。再度ログインしてください");
     });
@@ -414,6 +411,7 @@ describe("apiFetch", () => {
 
       // Assert
       expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiError);
       expect(error).toBeInstanceOf(ApiHttpError);
       expect(error.status).toBe(500);
       expect(error.message).toBe("サーバーエラーが発生しました");
@@ -431,6 +429,7 @@ describe("apiFetch", () => {
 
       // Assert
       expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiError);
       expect(error).toBeInstanceOf(ApiNetworkError);
       expect(error.message).toBe("ネットワークに接続できません");
       expect(error.name).toBe("ApiNetworkError");
@@ -445,10 +444,65 @@ describe("apiFetch", () => {
 
       // Assert
       expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiError);
       expect(error).toBeInstanceOf(ApiParseError);
       expect(error.status).toBe(200);
       expect(error.message).toBe("レスポンスの解析に失敗しました");
       expect(error.name).toBe("ApiParseError");
+    });
+  });
+
+  describe("リフレッシュ応答の境界ケース", () => {
+    it("リフレッシュ応答が { success: true } のみ（data なし）のときSessionExpiredErrorになること", async () => {
+      // Arrange
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
+        )
+        .mockResolvedValueOnce(createFetchResponse({ success: true }));
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalled();
+    });
+
+    it("リフレッシュ応答が { success: true, data: null } のときSessionExpiredErrorになること", async () => {
+      // Arrange
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
+        )
+        .mockResolvedValueOnce(createFetchResponse({ success: true, data: null }));
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalled();
+    });
+
+    it("非2xxで { success: false, error: null } のときApiHttpErrorがスローされること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse({ success: false, error: null }, { status: 500 }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
+    });
+
+    it("2xxでContent-Typeがtext/plainかつ有効なJSONのときApiParseErrorが投げられること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse(
+          { success: true, data: {} },
+          {
+            status: 200,
+            contentType: "text/plain",
+          },
+        ),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiParseError);
     });
   });
 

--- a/tests/mobile/lib/api.test.ts
+++ b/tests/mobile/lib/api.test.ts
@@ -17,7 +17,13 @@ jest.mock("@mobile/lib/secure-store", () => ({
   clearAuthTokens: jest.fn(),
 }));
 
-import { apiFetch, SessionExpiredError } from "@mobile/lib/api";
+import {
+  ApiHttpError,
+  ApiNetworkError,
+  ApiParseError,
+  apiFetch,
+  SessionExpiredError,
+} from "@mobile/lib/api";
 import {
   clearAuthTokens,
   getAuthToken,
@@ -37,14 +43,37 @@ const mockClearAuthTokens = clearAuthTokens as jest.MockedFunction<typeof clearA
 const mockFetch = jest.fn();
 (globalThis as Record<string, unknown>).fetch = mockFetch;
 
+/** fetchレスポンスモックのオプション */
+type CreateFetchResponseOptions = {
+  status?: number;
+  contentType?: string | null;
+  jsonImpl?: () => Promise<unknown>;
+  textImpl?: () => Promise<string>;
+};
+
 /**
  * fetchレスポンスのモックヘルパー
  */
-function createFetchResponse(body: unknown, status = 200): Response {
+function createFetchResponse(body: unknown, options: CreateFetchResponseOptions = {}): Response {
+  const { status = 200, contentType = "application/json", jsonImpl, textImpl } = options;
+
+  const headers = {
+    get: (name: string): string | null => {
+      if (name.toLowerCase() === "content-type") {
+        return contentType;
+      }
+      return null;
+    },
+  };
+
   return {
     ok: status >= 200 && status < 300,
     status,
-    json: jest.fn().mockResolvedValue(body),
+    headers,
+    json: jsonImpl ? jest.fn(jsonImpl) : jest.fn().mockResolvedValue(body),
+    text: textImpl
+      ? jest.fn(textImpl)
+      : jest.fn().mockResolvedValue(typeof body === "string" ? body : JSON.stringify(body)),
   } as unknown as Response;
 }
 
@@ -100,7 +129,7 @@ describe("apiFetch", () => {
       const newRefreshToken = "next-refresh-token";
       mockFetch
         .mockResolvedValueOnce(
-          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
         )
         .mockResolvedValueOnce(
           createFetchResponse({
@@ -124,7 +153,7 @@ describe("apiFetch", () => {
       // Arrange
       mockGetRefreshToken.mockResolvedValue(null);
       mockFetch.mockResolvedValue(
-        createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+        createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
       );
 
       // Act & Assert
@@ -136,10 +165,13 @@ describe("apiFetch", () => {
       // Arrange
       mockFetch
         .mockResolvedValueOnce(
-          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
         )
         .mockResolvedValueOnce(
-          createFetchResponse({ success: false, error: { code: "REFRESH_FAILED" } }, 401),
+          createFetchResponse(
+            { success: false, error: { code: "REFRESH_FAILED" } },
+            { status: 401 },
+          ),
         );
 
       // Act & Assert
@@ -153,7 +185,7 @@ describe("apiFetch", () => {
       const newRefreshToken = "next-refresh-token";
       mockFetch
         .mockResolvedValueOnce(
-          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
         )
         .mockResolvedValueOnce(
           createFetchResponse({
@@ -162,7 +194,7 @@ describe("apiFetch", () => {
           }),
         )
         .mockResolvedValueOnce(
-          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, 401),
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
         );
 
       // Act & Assert
@@ -170,12 +202,12 @@ describe("apiFetch", () => {
       expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
     });
 
-    it("401以外のエラーはそのままレスポンスデータを返すこと", async () => {
+    it("401以外のエラーで業務エラーJSONが返った場合はそのままデータを返すこと", async () => {
       // Arrange
       mockFetch.mockResolvedValue(
         createFetchResponse(
           { success: false, error: { code: "NOT_FOUND", message: "見つかりません" } },
-          404,
+          { status: 404 },
         ),
       );
 
@@ -191,6 +223,178 @@ describe("apiFetch", () => {
     });
   });
 
+  describe("HTTPエラー応答の耐性", () => {
+    it("5xxで業務エラーJSONが返った場合はそのままデータを返すこと", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse(
+          {
+            success: false,
+            error: { code: "INTERNAL_ERROR", message: "サーバーエラーが発生しました" },
+          },
+          { status: 500 },
+        ),
+      );
+
+      // Act
+      const result = await apiFetch("/articles");
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: { code: "INTERNAL_ERROR", message: "サーバーエラーが発生しました" },
+      });
+    });
+
+    it("500で非JSONレスポンスが返った場合はApiHttpErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("<html>Internal Server Error</html>", {
+          status: 500,
+          contentType: "text/html; charset=utf-8",
+        }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiHttpError);
+      try {
+        await apiFetch("/articles");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiHttpError);
+        if (error instanceof ApiHttpError) {
+          expect(error.status).toBe(500);
+        }
+      }
+    });
+
+    it("502で本文が空の場合はApiHttpErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("", {
+          status: 502,
+          contentType: "text/plain",
+          jsonImpl: () => Promise.reject(new Error("Unexpected token")),
+          textImpl: () => Promise.resolve(""),
+        }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiHttpError);
+    });
+
+    it("4xxで非JSONレスポンスが返った場合はApiHttpErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("Bad Request", {
+          status: 400,
+          contentType: "text/plain",
+        }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiHttpError);
+    });
+  });
+
+  describe("非JSON応答の耐性", () => {
+    it("2xxでJSONパースに失敗した場合はApiParseErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("<html>Maintenance</html>", {
+          status: 200,
+          contentType: "text/html",
+          jsonImpl: () => Promise.reject(new Error("Unexpected token")),
+        }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiParseError);
+    });
+
+    it("2xxでContent-Typeがapplication/jsonでもパースが失敗したらApiParseErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("not a json", {
+          status: 200,
+          contentType: "application/json",
+          jsonImpl: () => Promise.reject(new Error("Unexpected token")),
+        }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiParseError);
+    });
+
+    it("Content-Typeヘッダーが無い場合でも2xxならパースを試みて成功すれば返すこと", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse(
+          { success: true, data: { id: "1" } },
+          { status: 200, contentType: null },
+        ),
+      );
+
+      // Act
+      const result = await apiFetch<{ success: true; data: { id: string } }>("/articles");
+
+      // Assert
+      expect(result).toEqual({ success: true, data: { id: "1" } });
+    });
+  });
+
+  describe("ネットワークエラーの耐性", () => {
+    it("fetchがTypeErrorでrejectされた場合はApiNetworkErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValue(new TypeError("Network request failed"));
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiNetworkError);
+    });
+
+    it("AbortErrorでタイムアウトした場合はApiNetworkErrorをスローすること", async () => {
+      // Arrange
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      mockFetch.mockRejectedValue(abortError);
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(ApiNetworkError);
+    });
+  });
+
+  describe("リフレッシュAPIの耐性", () => {
+    it("リフレッシュAPIが非JSONを返した場合はSessionExpiredErrorにラップされること", async () => {
+      // Arrange
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
+        )
+        .mockResolvedValueOnce(
+          createFetchResponse("<html>Service Unavailable</html>", {
+            status: 503,
+            contentType: "text/html",
+          }),
+        );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it("リフレッシュAPIがネットワークエラーになった場合はSessionExpiredErrorにラップされること", async () => {
+      // Arrange
+      mockFetch
+        .mockResolvedValueOnce(
+          createFetchResponse({ success: false, error: { code: "AUTH_EXPIRED" } }, { status: 401 }),
+        )
+        .mockRejectedValueOnce(new TypeError("Network request failed"));
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toThrow(SessionExpiredError);
+      expect(mockClearAuthTokens).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("SessionExpiredError", () => {
     it("SessionExpiredErrorはErrorのサブクラスであること", async () => {
       // Arrange & Act
@@ -200,6 +404,51 @@ describe("apiFetch", () => {
       expect(error).toBeInstanceOf(Error);
       expect(error).toBeInstanceOf(SessionExpiredError);
       expect(error.message).toBe("セッションの有効期限が切れました。再度ログインしてください");
+    });
+  });
+
+  describe("ApiHttpError", () => {
+    it("statusプロパティとメッセージを保持すること", () => {
+      // Arrange & Act
+      const error = new ApiHttpError(500, "サーバーエラーが発生しました");
+
+      // Assert
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiHttpError);
+      expect(error.status).toBe(500);
+      expect(error.message).toBe("サーバーエラーが発生しました");
+      expect(error.name).toBe("ApiHttpError");
+    });
+  });
+
+  describe("ApiNetworkError", () => {
+    it("causeとメッセージを保持すること", () => {
+      // Arrange
+      const cause = new TypeError("Network request failed");
+
+      // Act
+      const error = new ApiNetworkError("ネットワークに接続できません", cause);
+
+      // Assert
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiNetworkError);
+      expect(error.message).toBe("ネットワークに接続できません");
+      expect(error.name).toBe("ApiNetworkError");
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe("ApiParseError", () => {
+    it("statusとメッセージを保持すること", () => {
+      // Arrange & Act
+      const error = new ApiParseError(200, "レスポンスの解析に失敗しました");
+
+      // Assert
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ApiParseError);
+      expect(error.status).toBe(200);
+      expect(error.message).toBe("レスポンスの解析に失敗しました");
+      expect(error.name).toBe("ApiParseError");
     });
   });
 

--- a/tests/mobile/lib/api.test.ts
+++ b/tests/mobile/lib/api.test.ts
@@ -256,11 +256,17 @@ describe("apiFetch", () => {
         }),
       );
 
-      // Act & Assert
-      await expect(apiFetch("/articles")).rejects.toMatchObject({
-        status: 500,
-      });
-      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiHttpError);
+      expect((caughtError as ApiHttpError).status).toBe(500);
     });
 
     it("502で本文が空の場合はApiHttpErrorをスローすること", async () => {


### PR DESCRIPTION
## Summary

- `apiFetch` で HTTP エラー（4xx/5xx）を受け取った際に `ApiError` をスローするよう修正
- JSON パース失敗時に `PARSE_FAILED` センチネルで安全にフォールバック
- `isRefreshTokenResponse` 型ガードで refresh token レスポンスの型安全を強化

## Test plan

- [x] `tests/mobile/lib/api.test.ts` — HTTP エラー・非JSON応答・型ガードの各ケースを網羅
- [x] lint / typecheck / test すべて通過済み

🤖 Generated with [Claude Code](https://claude.ai/code)