### PR TITLE
feat: gh pr create 実行時に poll-pr-review.sh を自動起動する

### DIFF
--- a/.claude/hooks/post-pr-create-poll.sh
+++ b/.claude/hooks/post-pr-create-poll.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# post-pr-create-poll.sh
+# gh pr create 実行後に自動的に poll-pr-review.sh をバックグラウンドで起動する
+#
+# PostToolUse (Bash) フックとして呼び出される
+# ARGUMENTS 環境変数: {"command": "...", "output": "..."}
+
+set -uo pipefail
+
+ARGUMENTS="${ARGUMENTS:-}"
+[[ -z "${ARGUMENTS}" ]] && exit 0
+
+# コマンド文字列を取得
+command_str=$(echo "${ARGUMENTS}" | jq -r '.command // ""' 2>/dev/null || true)
+[[ -z "${command_str}" ]] && exit 0
+
+# gh pr create を含むコマンドのみ処理
+echo "${command_str}" | grep -q "gh pr create" || exit 0
+
+# --dry-run や --web フラグは PR を作成しないのでスキップ
+echo "${command_str}" | grep -qE "(--dry-run|--web)" && exit 0
+
+# worktree パスを cd コマンドから抽出
+# パターン: "cd /path/to/worktree && ..."
+worktree_path=""
+if echo "${command_str}" | grep -qE "^cd "; then
+  raw_path=$(echo "${command_str}" | sed -E 's|^cd ([^ ]+).*|\1|' | head -1)
+  # クォートを除去
+  worktree_path="${raw_path//\'/}"
+  worktree_path="${worktree_path//\"/}"
+fi
+
+if [[ -z "${worktree_path}" ]] || [[ ! -d "${worktree_path}" ]]; then
+  worktree_path="$(pwd)"
+fi
+
+# PR番号を取得（PR が存在しない場合は終了）
+PR_NUMBER=$(cd "${worktree_path}" && gh pr view HEAD --json number --jq '.number' 2>/dev/null || true)
+if [[ -z "${PR_NUMBER}" ]] || ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+  exit 0
+fi
+
+# プロジェクトルートとスクリプトパス
+ROOT=$(git -C "${worktree_path}" rev-parse --show-toplevel 2>/dev/null || true)
+[[ -z "${ROOT}" ]] && exit 0
+
+POLL_SCRIPT="${ROOT}/scripts/poll-pr-review.sh"
+[[ -f "${POLL_SCRIPT}" ]] || exit 0
+
+# 既に同じ PR のポーリングが実行中かチェック
+if pgrep -f "poll-pr-review.sh ${PR_NUMBER}" > /dev/null 2>&1; then
+  echo "[poll-pr] PR #${PR_NUMBER} は既にポーリング中です" >&2
+  exit 0
+fi
+
+# バックグラウンドでポーリング開始
+LOG_FILE="/tmp/poll-pr-${PR_NUMBER}.log"
+nohup bash "${POLL_SCRIPT}" "${PR_NUMBER}" > "${LOG_FILE}" 2>&1 &
+disown $!
+
+echo "[poll-pr] PR #${PR_NUMBER} のポーリングを開始しました (log: ${LOG_FILE})" >&2
+exit 0

--- a/.claude/hooks/post-pr-create-poll.sh
+++ b/.claude/hooks/post-pr-create-poll.sh
@@ -3,38 +3,42 @@
 # gh pr create 実行後に自動的に poll-pr-review.sh をバックグラウンドで起動する
 #
 # PostToolUse (Bash) フックとして呼び出される
-# ARGUMENTS 環境変数: {"command": "...", "output": "..."}
+# ARGUMENTS 環境変数: {"command": "..."}
+# timeout: 15s (gh pr view のネットワーク呼び出しのため他フックより長め)
 
 set -uo pipefail
 
-ARGUMENTS="${ARGUMENTS:-}"
-[[ -z "${ARGUMENTS}" ]] && exit 0
+# jq が必要（他フックと同様の早期チェック）
+command -v jq >/dev/null 2>&1 || exit 0
 
 # コマンド文字列を取得
-command_str=$(echo "${ARGUMENTS}" | jq -r '.command // ""' 2>/dev/null || true)
-[[ -z "${command_str}" ]] && exit 0
+command_str=$(printf '%s' "${ARGUMENTS:-}" | jq -r '.command // ""' 2>/dev/null || true)
+[[ -n "${command_str}" ]] || exit 0
 
-# gh pr create を含むコマンドのみ処理
-echo "${command_str}" | grep -q "gh pr create" || exit 0
+# gh pr create を含むコマンドのみ処理（単語境界を考慮した正規表現）
+# "git commit -m 'gh pr create'" などの誤検知を防ぐ
+echo "${command_str}" | grep -qE '(^|&&[[:space:]]*|;[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
 
-# --dry-run や --web フラグは PR を作成しないのでスキップ
-echo "${command_str}" | grep -qE "(--dry-run|--web)" && exit 0
-
-# worktree パスを cd コマンドから抽出
-# パターン: "cd /path/to/worktree && ..."
+# worktree パスを cd コマンドから抽出（スペースなしパスのみ対応）
 worktree_path=""
-if echo "${command_str}" | grep -qE "^cd "; then
-  raw_path=$(echo "${command_str}" | sed -E 's|^cd ([^ ]+).*|\1|' | head -1)
+if echo "${command_str}" | grep -qE "^cd [^&;[:space:]]"; then
+  raw_path=$(echo "${command_str}" | sed -E 's|^cd ([^[:space:]&;]+).*|\1|' | head -1)
   # クォートを除去
-  worktree_path="${raw_path//\'/}"
-  worktree_path="${worktree_path//\"/}"
+  raw_path="${raw_path//\'/}"
+  raw_path="${raw_path//\"/}"
+  # realpath で正規化
+  if [[ -d "${raw_path}" ]]; then
+    worktree_path=$(cd "${raw_path}" 2>/dev/null && pwd -P) || worktree_path=""
+  fi
 fi
 
-if [[ -z "${worktree_path}" ]] || [[ ! -d "${worktree_path}" ]]; then
-  worktree_path="$(pwd)"
-fi
+# worktree パスが特定できない場合はスキップ（誤った CWD でポーリングしないよう pwd フォールバックは使わない）
+[[ -n "${worktree_path}" ]] || exit 0
 
-# PR番号を取得（PR が存在しない場合は終了）
+# git リポジトリ内であることを確認（ディレクトリトラバーサル対策）
+git -C "${worktree_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# PR番号を取得（--dry-run / --web などで PR が未作成の場合は自然にスキップ）
 PR_NUMBER=$(cd "${worktree_path}" && gh pr view HEAD --json number --jq '.number' 2>/dev/null || true)
 if [[ -z "${PR_NUMBER}" ]] || ! [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
   exit 0
@@ -42,20 +46,25 @@ fi
 
 # プロジェクトルートとスクリプトパス
 ROOT=$(git -C "${worktree_path}" rev-parse --show-toplevel 2>/dev/null || true)
-[[ -z "${ROOT}" ]] && exit 0
+[[ -n "${ROOT}" ]] || exit 0
 
 POLL_SCRIPT="${ROOT}/scripts/poll-pr-review.sh"
 [[ -f "${POLL_SCRIPT}" ]] || exit 0
 
+# ユーザー固有のログディレクトリ（/tmp シンボリックリンク攻撃対策）
+LOG_DIR="${TMPDIR:-/tmp}/tech-clip-poll-pr-$(id -u)"
+mkdir -p "${LOG_DIR}" && chmod 700 "${LOG_DIR}" || exit 0
+LOG_FILE="${LOG_DIR}/poll-pr-${PR_NUMBER}.log"
+
 # 既に同じ PR のポーリングが実行中かチェック
-if pgrep -f "poll-pr-review.sh ${PR_NUMBER}" > /dev/null 2>&1; then
+# 末尾アンカーで PR#1 のチェックが PR#12 にマッチする誤検知を防止
+if pgrep -f "poll-pr-review\\.sh ${PR_NUMBER}$" > /dev/null 2>&1; then
   echo "[poll-pr] PR #${PR_NUMBER} は既にポーリング中です" >&2
   exit 0
 fi
 
-# バックグラウンドでポーリング開始
-LOG_FILE="/tmp/poll-pr-${PR_NUMBER}.log"
-nohup bash "${POLL_SCRIPT}" "${PR_NUMBER}" > "${LOG_FILE}" 2>&1 &
+# バックグラウンドでポーリング開始（stdin も /dev/null にリダイレクト）
+nohup bash "${POLL_SCRIPT}" "${PR_NUMBER}" </dev/null >"${LOG_FILE}" 2>&1 &
 disown $!
 
 echo "[poll-pr] PR #${PR_NUMBER} のポーリングを開始しました (log: ${LOG_FILE})" >&2

--- a/.claude/hooks/post-pr-create-poll.sh
+++ b/.claude/hooks/post-pr-create-poll.sh
@@ -17,12 +17,12 @@ command_str=$(printf '%s' "${ARGUMENTS:-}" | jq -r '.command // ""' 2>/dev/null 
 
 # gh pr create を含むコマンドのみ処理（単語境界を考慮した正規表現）
 # "git commit -m 'gh pr create'" などの誤検知を防ぐ
-echo "${command_str}" | grep -qE '(^|&&[[:space:]]*|;[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
+printf '%s\n' "${command_str}" | grep -qE '(^|&&[[:space:]]*|;[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
 
 # worktree パスを cd コマンドから抽出（スペースなしパスのみ対応）
 worktree_path=""
-if echo "${command_str}" | grep -qE "^cd [^&;[:space:]]"; then
-  raw_path=$(echo "${command_str}" | sed -E 's|^cd ([^[:space:]&;]+).*|\1|' | head -1)
+if printf '%s\n' "${command_str}" | grep -qE "^cd [^&;[:space:]]"; then
+  raw_path=$(printf '%s\n' "${command_str}" | sed -E 's|^cd ([^[:space:]&;]+).*|\1|' | head -1)
   # クォートを除去
   raw_path="${raw_path//\'/}"
   raw_path="${raw_path//\"/}"
@@ -53,7 +53,12 @@ POLL_SCRIPT="${ROOT}/scripts/poll-pr-review.sh"
 
 # ユーザー固有のログディレクトリ（/tmp シンボリックリンク攻撃対策）
 LOG_DIR="${TMPDIR:-/tmp}/tech-clip-poll-pr-$(id -u)"
-mkdir -p "${LOG_DIR}" && chmod 700 "${LOG_DIR}" || exit 0
+mkdir -p "${LOG_DIR}" || exit 0
+if [[ -L "${LOG_DIR}" ]]; then
+  echo "[poll-pr] ログディレクトリがシンボリックリンクです。中止します: ${LOG_DIR}" >&2
+  exit 0
+fi
+chmod 700 "${LOG_DIR}" || exit 0
 LOG_FILE="${LOG_DIR}/poll-pr-${PR_NUMBER}.log"
 
 # 既に同じ PR のポーリングが実行中かチェック

--- a/.claude/hooks/post-pr-create-poll.sh
+++ b/.claude/hooks/post-pr-create-poll.sh
@@ -17,7 +17,7 @@ command_str=$(printf '%s' "${ARGUMENTS:-}" | jq -r '.command // ""' 2>/dev/null 
 
 # gh pr create を含むコマンドのみ処理（単語境界を考慮した正規表現）
 # "git commit -m 'gh pr create'" などの誤検知を防ぐ
-printf '%s\n' "${command_str}" | grep -qE '(^|&&[[:space:]]*|;[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
+printf '%s\n' "${command_str}" | grep -qE '(^|&&[[:space:]]*|\|\|[[:space:]]*|;[[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
 
 # worktree パスを cd コマンドから抽出（スペースなしパスのみ対応）
 worktree_path=""

--- a/.claude/hooks/post-pr-create-poll.sh
+++ b/.claude/hooks/post-pr-create-poll.sh
@@ -60,6 +60,10 @@ if [[ -L "${LOG_DIR}" ]]; then
 fi
 chmod 700 "${LOG_DIR}" || exit 0
 LOG_FILE="${LOG_DIR}/poll-pr-${PR_NUMBER}.log"
+if [[ -L "${LOG_FILE}" ]]; then
+  echo "[poll-pr] ログファイルがシンボリックリンクです。中止します: ${LOG_FILE}" >&2
+  exit 0
+fi
 
 # 既に同じ PR のポーリングが実行中かチェック
 # 末尾アンカーで PR#1 のチェックが PR#12 にマッチする誤検知を防止

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -150,6 +150,12 @@
             "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/post-push-cleanup.sh\"",
             "timeout": 5,
             "statusMessage": "Cleaning up review marker..."
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/.claude/hooks/post-pr-create-poll.sh\"",
+            "timeout": 15,
+            "statusMessage": "Starting PR review polling..."
           }
         ]
       }

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -73,8 +73,9 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   fi
 
   # LGTM / Approve 系コメントも検出する
+  # "Approve 相当"（Approved の前に d がないケース）やマージ可能判定も含む
   approve_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-    [.comments[] | select(.body | test("✅.*PASS|全件 PASS|全件PASS|LGTM|Approved|指摘.*0.*件|0.*件.*指摘"; "i"))] | length
+    [.comments[] | select(.body | test("✅.*PASS|全件 PASS|全件PASS|LGTM|Approved?|マージ可能|指摘.*0.*件|0.*件.*指摘"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -62,6 +62,8 @@ while (( elapsed < TIMEOUT_SECONDS )); do
 
   review_decision=$(printf '%s' "${pr_data}" | jq -r '.reviewDecision // ""')
 
+  # 正式レビューの APPROVED を最優先で処理する
+  # ヒューマンレビュアーによる正式 Approve はコメント形式の bot 判定より優先する
   if [[ "${review_decision}" == "APPROVED" ]]; then
     echo "APPROVED"
     exit 0
@@ -84,6 +86,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   # コメント形式のレビュー（Claude bot 等が PR comment で投稿する場合）も検出する
   # 「🔄 Request Changes」または明示的な CHANGES_REQUESTED マーカーを含むコメントのみ対象
   # 誤検知防止のため author.login で Claude bot / github-actions bot に限定する
+  # app/claude: GitHub App として動作する Claude bot の login 形式
   changes_comment_count=$(printf '%s' "${pr_data}" | jq '
     [.comments[]
      | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
@@ -91,6 +94,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   ' 2>/dev/null || echo "0")
 
   if [[ "${changes_comment_count}" -gt 0 ]]; then
+    # app/claude: GitHub App として動作する Claude bot の login 形式
     comment_content=$(printf '%s' "${pr_data}" | jq -r '
       [.comments[]
        | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
@@ -114,10 +118,11 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   #   "Approve 相当": Claude bot の承認コメントフレーズ
   #   "マージ可能(?:です|と判断|。|！|$)": Claude bot の承認判定フレーズ（「マージ可能性がある」等の誤検知防止）
   #   "指摘[^0-9]?0(?![0-9])": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
+  # app/claude: GitHub App として動作する Claude bot の login 形式
   approve_comment_count=$(printf '%s' "${pr_data}" | jq '
     [.comments[]
      | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
-     | select(.body | test("(?s)全件 ?PASS|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*\\bPASS\\b|指摘[^0-9]?0(?![0-9])"; "i"))] | length
+     | select(.body | test("(?s)全件 ?PASS(?!\\w)|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*\\bPASS\\b|指摘[^0-9]?0(?![0-9])"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -29,16 +29,25 @@ TIMEOUT_SECONDS="${POLL_PR_REVIEW_TIMEOUT_SECONDS:-1800}"
 # ポーリング間隔（デフォルト: 60秒）
 POLL_INTERVAL_SECONDS="${POLL_PR_REVIEW_INTERVAL_SECONDS:-60}"
 
+if [[ ! "${TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || (( TIMEOUT_SECONDS <= 0 )); then
+  echo "エラー: POLL_PR_REVIEW_TIMEOUT_SECONDS は正の整数で指定してください: ${TIMEOUT_SECONDS}" >&2
+  exit 1
+fi
+if [[ ! "${POLL_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] || (( POLL_INTERVAL_SECONDS <= 0 )); then
+  echo "エラー: POLL_PR_REVIEW_INTERVAL_SECONDS は正の整数で指定してください: ${POLL_INTERVAL_SECONDS}" >&2
+  exit 1
+fi
+
 # 中断シグナルを受けたらクリーンに終了する
 trap 'echo "INTERRUPTED" >&2; exit 130' INT TERM
 
 elapsed=0
 
 while (( elapsed < TIMEOUT_SECONDS )); do
-  gh_output=$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // ""' 2>&1) || {
-    echo "WARN: gh pr view 失敗（認証失効・ネットワーク断の可能性）: ${gh_output}" >&2
+  if ! gh_output=$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null); then
+    echo "WARN: gh pr view 失敗（認証失効・ネットワーク断の可能性）" >&2
     gh_output=""
-  }
+  fi
   review_decision="${gh_output}"
 
   if [[ "${review_decision}" == "APPROVED" ]]; then
@@ -62,14 +71,18 @@ while (( elapsed < TIMEOUT_SECONDS )); do
 
   # コメント形式のレビュー（Claude bot 等が PR comment で投稿する場合）も検出する
   # 「🔄 Request Changes」または明示的な CHANGES_REQUESTED マーカーを含むコメントのみ対象
-  # 誤検知防止のため "Request Changes" 単独は除外し、🔄 と組み合わせた場合のみ対象とする
+  # 誤検知防止のため author.login で Claude bot / github-actions bot に限定する
   changes_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-    [.comments[] | select(.body | test("🔄.*Request Changes|CHANGES_REQUESTED"; "i"))] | length
+    [.comments[]
+     | select((.author.login // "") | test("github-actions\\[bot\\]|claude|app/claude"; "i"))
+     | select(.body | test("(?s)🔄.*Request Changes|CHANGES_REQUESTED"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${changes_comment_count}" -gt 0 ]]; then
     comment_content=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-      [.comments[] | select(.body | test("🔄.*Request Changes|CHANGES_REQUESTED"; "i"))]
+      [.comments[]
+       | select((.author.login // "") | test("github-actions\\[bot\\]|claude|app/claude"; "i"))
+       | select(.body | test("(?s)🔄.*Request Changes|CHANGES_REQUESTED"; "i"))]
       | map("[@" + (.author.login // "unknown") + "]:\n" + .body)
       | join("\n\n---\n\n")
     ' 2>/dev/null || true)
@@ -81,7 +94,8 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   fi
 
   # LGTM / Approve 系コメントも検出する
-  # 誤検知防止のため特定のフレーズのみ対象とする:
+  # 誤検知防止のため author.login で Claude bot / github-actions bot に限定し、
+  # 特定のフレーズのみ対象とする:
   #   "全件 PASS" / "全件PASS": レビュアーエージェントの PASS 宣言
   #   "✅.*PASS": CI/レビュー結果の ✅ + PASS
   #   "LGTM": 標準的な承認表現
@@ -89,7 +103,9 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   #   "マージ可能": Claude bot の承認判定フレーズ
   #   "指摘[^0-9]?0[^0-9]": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
   approve_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-    [.comments[] | select(.body | test("全件 ?PASS|LGTM|Approve 相当|マージ可能|✅.*PASS|指摘[^0-9]?0[^0-9]"; "i"))] | length
+    [.comments[]
+     | select((.author.login // "") | test("github-actions\\[bot\\]|claude|app/claude"; "i"))
+     | select(.body | test("全件 ?PASS|LGTM|Approve 相当|マージ可能|✅.*PASS|指摘[^0-9]?0[^0-9]"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -15,12 +15,12 @@ set -uo pipefail
 PR_NUMBER="${1:-}"
 
 if [[ -z "${PR_NUMBER}" ]]; then
-  echo "usage: scripts/poll-pr-review.sh <pr-number>" >&2
+  echo "使い方: bash scripts/poll-pr-review.sh <PR番号>" >&2
   exit 1
 fi
 
 if [[ ! "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
-  echo "error: pr-number は数値で指定してください: ${PR_NUMBER}" >&2
+  echo "エラー: PR番号は数値で指定してください: ${PR_NUMBER}" >&2
   exit 1
 fi
 
@@ -29,10 +29,17 @@ TIMEOUT_SECONDS="${POLL_PR_REVIEW_TIMEOUT_SECONDS:-1800}"
 # ポーリング間隔（デフォルト: 60秒）
 POLL_INTERVAL_SECONDS="${POLL_PR_REVIEW_INTERVAL_SECONDS:-60}"
 
+# 中断シグナルを受けたらクリーンに終了する
+trap 'echo "INTERRUPTED" >&2; exit 130' INT TERM
+
 elapsed=0
 
 while (( elapsed < TIMEOUT_SECONDS )); do
-  review_decision=$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null || true)
+  gh_output=$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // ""' 2>&1) || {
+    echo "WARN: gh pr view 失敗（認証失効・ネットワーク断の可能性）: ${gh_output}" >&2
+    gh_output=""
+  }
+  review_decision="${gh_output}"
 
   if [[ "${review_decision}" == "APPROVED" ]]; then
     echo "APPROVED"
@@ -54,14 +61,15 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   fi
 
   # コメント形式のレビュー（Claude bot 等が PR comment で投稿する場合）も検出する
-  # "Request Changes" または "🔄" を含むコメントを CHANGES_REQUESTED として扱う
+  # 「🔄 Request Changes」または明示的な CHANGES_REQUESTED マーカーを含むコメントのみ対象
+  # 誤検知防止のため "Request Changes" 単独は除外し、🔄 と組み合わせた場合のみ対象とする
   changes_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-    [.comments[] | select(.body | test("Request Changes|🔄|CHANGES_REQUESTED"; "i"))] | length
+    [.comments[] | select(.body | test("🔄.*Request Changes|CHANGES_REQUESTED"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${changes_comment_count}" -gt 0 ]]; then
     comment_content=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-      [.comments[] | select(.body | test("Request Changes|🔄|CHANGES_REQUESTED"; "i"))]
+      [.comments[] | select(.body | test("🔄.*Request Changes|CHANGES_REQUESTED"; "i"))]
       | map("[@" + (.author.login // "unknown") + "]:\n" + .body)
       | join("\n\n---\n\n")
     ' 2>/dev/null || true)
@@ -73,9 +81,15 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   fi
 
   # LGTM / Approve 系コメントも検出する
-  # "Approve 相当"（Approved の前に d がないケース）やマージ可能判定も含む
+  # 誤検知防止のため特定のフレーズのみ対象とする:
+  #   "全件 PASS" / "全件PASS": レビュアーエージェントの PASS 宣言
+  #   "✅.*PASS": CI/レビュー結果の ✅ + PASS
+  #   "LGTM": 標準的な承認表現
+  #   "Approve 相当": Claude bot の承認コメントフレーズ
+  #   "マージ可能": Claude bot の承認判定フレーズ
+  #   "指摘[^0-9]?0[^0-9]": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
   approve_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
-    [.comments[] | select(.body | test("✅.*PASS|全件 PASS|全件PASS|LGTM|Approved?|マージ可能|指摘.*0.*件|0.*件.*指摘"; "i"))] | length
+    [.comments[] | select(.body | test("全件 ?PASS|LGTM|Approve 相当|マージ可能|✅.*PASS|指摘[^0-9]?0[^0-9]"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -44,11 +44,17 @@ trap 'echo "INTERRUPTED" >&2; exit 130' INT TERM
 elapsed=0
 
 while (( elapsed < TIMEOUT_SECONDS )); do
-  if ! gh_output=$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // ""' 2>/dev/null); then
+  pr_data=$(gh pr view "${PR_NUMBER}" --json reviewDecision,reviews,comments 2>/dev/null || true)
+  if [[ -z "${pr_data}" ]]; then
     echo "WARN: gh pr view 失敗（認証失効・ネットワーク断の可能性）" >&2
-    gh_output=""
+    remaining=$(( TIMEOUT_SECONDS - elapsed ))
+    sleep_time=$(( POLL_INTERVAL_SECONDS < remaining ? POLL_INTERVAL_SECONDS : remaining ))
+    sleep "${sleep_time}"
+    elapsed=$(( elapsed + sleep_time ))
+    continue
   fi
-  review_decision="${gh_output}"
+
+  review_decision=$(printf '%s' "${pr_data}" | jq -r '.reviewDecision // ""')
 
   if [[ "${review_decision}" == "APPROVED" ]]; then
     echo "APPROVED"
@@ -56,7 +62,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   fi
 
   if [[ "${review_decision}" == "CHANGES_REQUESTED" ]]; then
-    review_content=$(gh pr view "${PR_NUMBER}" --json reviews --jq '
+    review_content=$(printf '%s' "${pr_data}" | jq -r '
       .reviews
       | map(select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED"))
       | map("[" + .state + "] " + (.author.login // "unknown") + ":\n" + (.body // ""))
@@ -65,23 +71,23 @@ while (( elapsed < TIMEOUT_SECONDS )); do
     echo "CHANGES_REQUESTED"
     echo ""
     echo "--- Review Content (formal review) ---"
-    echo "${review_content}"
+    printf '%s\n' "${review_content}"
     exit 1
   fi
 
   # コメント形式のレビュー（Claude bot 等が PR comment で投稿する場合）も検出する
   # 「🔄 Request Changes」または明示的な CHANGES_REQUESTED マーカーを含むコメントのみ対象
   # 誤検知防止のため author.login で Claude bot / github-actions bot に限定する
-  changes_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
+  changes_comment_count=$(printf '%s' "${pr_data}" | jq '
     [.comments[]
-     | select((.author.login // "") | test("github-actions\\[bot\\]|claude|app/claude"; "i"))
+     | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
      | select(.body | test("(?s)🔄.*Request Changes|CHANGES_REQUESTED"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${changes_comment_count}" -gt 0 ]]; then
-    comment_content=$(gh pr view "${PR_NUMBER}" --json comments --jq '
+    comment_content=$(printf '%s' "${pr_data}" | jq -r '
       [.comments[]
-       | select((.author.login // "") | test("github-actions\\[bot\\]|claude|app/claude"; "i"))
+       | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
        | select(.body | test("(?s)🔄.*Request Changes|CHANGES_REQUESTED"; "i"))]
       | map("[@" + (.author.login // "unknown") + "]:\n" + .body)
       | join("\n\n---\n\n")
@@ -89,7 +95,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
     echo "CHANGES_REQUESTED"
     echo ""
     echo "--- Review Content (from comments) ---"
-    echo "${comment_content}"
+    printf '%s\n' "${comment_content}"
     exit 1
   fi
 
@@ -97,15 +103,15 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   # 誤検知防止のため author.login で Claude bot / github-actions bot に限定し、
   # 特定のフレーズのみ対象とする:
   #   "全件 PASS" / "全件PASS": レビュアーエージェントの PASS 宣言
-  #   "✅.*PASS": CI/レビュー結果の ✅ + PASS
-  #   "LGTM": 標準的な承認表現
+  #   "✅.*PASS": CI/レビュー結果の ✅ + PASS（dotall フラグで複数行対応）
+  #   "\bLGTM\b": 標準的な承認表現（単語境界で LGTMFAIL 等の誤検知防止）
   #   "Approve 相当": Claude bot の承認コメントフレーズ
-  #   "マージ可能": Claude bot の承認判定フレーズ
-  #   "指摘[^0-9]?0[^0-9]": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
-  approve_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
+  #   "マージ可能(?:です|と判断|。|！|$)": Claude bot の承認判定フレーズ（「マージ可能性がある」等の誤検知防止）
+  #   "指摘[^0-9]?0(?![0-9])": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
+  approve_comment_count=$(printf '%s' "${pr_data}" | jq '
     [.comments[]
-     | select((.author.login // "") | test("github-actions\\[bot\\]|claude|app/claude"; "i"))
-     | select(.body | test("全件 ?PASS|LGTM|Approve 相当|マージ可能|✅.*PASS|指摘[^0-9]?0[^0-9]"; "i"))] | length
+     | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
+     | select(.body | test("(?s)全件 ?PASS|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*PASS|指摘[^0-9]?0(?![0-9])"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then
@@ -117,8 +123,10 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   minutes_total=$(( TIMEOUT_SECONDS / 60 ))
   echo "PENDING: レビュー待ち (${minutes_elapsed}/${minutes_total} 分経過)" >&2
 
-  sleep "${POLL_INTERVAL_SECONDS}"
-  elapsed=$(( elapsed + POLL_INTERVAL_SECONDS ))
+  remaining=$(( TIMEOUT_SECONDS - elapsed ))
+  sleep_time=$(( POLL_INTERVAL_SECONDS < remaining ? POLL_INTERVAL_SECONDS : remaining ))
+  sleep "${sleep_time}"
+  elapsed=$(( elapsed + sleep_time ))
 done
 
 echo "TIMEOUT"

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -94,7 +94,6 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   ' 2>/dev/null || echo "0")
 
   if [[ "${changes_comment_count}" -gt 0 ]]; then
-    # app/claude: GitHub App として動作する Claude bot の login 形式
     comment_content=$(printf '%s' "${pr_data}" | jq -r '
       [.comments[]
        | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
@@ -118,7 +117,6 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   #   "Approve 相当": Claude bot の承認コメントフレーズ
   #   "マージ可能(?:です|と判断|。|！|$)": Claude bot の承認判定フレーズ（「マージ可能性がある」等の誤検知防止）
   #   "指摘[^0-9]?0(?![0-9])": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
-  # app/claude: GitHub App として動作する Claude bot の login 形式
   approve_comment_count=$(printf '%s' "${pr_data}" | jq '
     [.comments[]
      | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -48,9 +48,38 @@ while (( elapsed < TIMEOUT_SECONDS )); do
     ' 2>/dev/null || true)
     echo "CHANGES_REQUESTED"
     echo ""
-    echo "--- Review Content ---"
+    echo "--- Review Content (formal review) ---"
     echo "${review_content}"
     exit 1
+  fi
+
+  # コメント形式のレビュー（Claude bot 等が PR comment で投稿する場合）も検出する
+  # "Request Changes" または "🔄" を含むコメントを CHANGES_REQUESTED として扱う
+  changes_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
+    [.comments[] | select(.body | test("Request Changes|🔄|CHANGES_REQUESTED"; "i"))] | length
+  ' 2>/dev/null || echo "0")
+
+  if [[ "${changes_comment_count}" -gt 0 ]]; then
+    comment_content=$(gh pr view "${PR_NUMBER}" --json comments --jq '
+      [.comments[] | select(.body | test("Request Changes|🔄|CHANGES_REQUESTED"; "i"))]
+      | map("[@" + (.author.login // "unknown") + "]:\n" + .body)
+      | join("\n\n---\n\n")
+    ' 2>/dev/null || true)
+    echo "CHANGES_REQUESTED"
+    echo ""
+    echo "--- Review Content (from comments) ---"
+    echo "${comment_content}"
+    exit 1
+  fi
+
+  # LGTM / Approve 系コメントも検出する
+  approve_comment_count=$(gh pr view "${PR_NUMBER}" --json comments --jq '
+    [.comments[] | select(.body | test("✅.*PASS|全件 PASS|全件PASS|LGTM|Approved|指摘.*0.*件|0.*件.*指摘"; "i"))] | length
+  ' 2>/dev/null || echo "0")
+
+  if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then
+    echo "APPROVED"
+    exit 0
   fi
 
   minutes_elapsed=$(( elapsed / 60 ))

--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -38,6 +38,12 @@ if [[ ! "${POLL_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] || (( POLL_INTERVAL_SECONDS <=
   exit 1
 fi
 
+# jq の存在確認（未インストール時はサイレントに誤動作するため事前チェック）
+if ! command -v jq >/dev/null 2>&1; then
+  echo "エラー: jq が必要です。nix develop で環境に入ってから実行してください。" >&2
+  exit 1
+fi
+
 # 中断シグナルを受けたらクリーンに終了する
 trap 'echo "INTERRUPTED" >&2; exit 130' INT TERM
 
@@ -103,7 +109,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   # 誤検知防止のため author.login で Claude bot / github-actions bot に限定し、
   # 特定のフレーズのみ対象とする:
   #   "全件 PASS" / "全件PASS": レビュアーエージェントの PASS 宣言
-  #   "✅.*PASS": CI/レビュー結果の ✅ + PASS（dotall フラグで複数行対応）
+  #   "✅.*\bPASS\b": CI/レビュー結果の ✅ + PASS（単語境界で "passed" 等の誤検知防止）
   #   "\bLGTM\b": 標準的な承認表現（単語境界で LGTMFAIL 等の誤検知防止）
   #   "Approve 相当": Claude bot の承認コメントフレーズ
   #   "マージ可能(?:です|と判断|。|！|$)": Claude bot の承認判定フレーズ（「マージ可能性がある」等の誤検知防止）
@@ -111,7 +117,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   approve_comment_count=$(printf '%s' "${pr_data}" | jq '
     [.comments[]
      | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude)$"; "i"))
-     | select(.body | test("(?s)全件 ?PASS|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*PASS|指摘[^0-9]?0(?![0-9])"; "i"))] | length
+     | select(.body | test("(?s)全件 ?PASS|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*\\bPASS\\b|指摘[^0-9]?0(?![0-9])"; "i"))] | length
   ' 2>/dev/null || echo "0")
 
   if [[ "${approve_comment_count}" -gt 0 ]] && [[ "${changes_comment_count}" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- `post-pr-create-poll.sh`: `gh pr create` 実行を PostToolUse hook で検出し、`poll-pr-review.sh` をバックグラウンドで自動起動
- `poll-pr-review.sh`: PR レビュー結果をポーリング（APPROVED/CHANGES_REQUESTED/TIMEOUT を返す）
  - ループ内の `gh pr view` を1回に統合（API コール削減）
  - `(?s)` dotall フラグ、`\bLGTM\b` 単語境界、`マージ可能(?:...)` 制限、`(?![0-9])` 負の先読みで誤検知防止
  - author.login フィルターを完全一致アンカー `^(github-actions\[bot\]|claude\[bot\]|...)$` に強化
  - sleep を残り時間でキャップしタイムアウト超過を防止
  - `printf '%s\n'` でエスケープシーケンス誤解釈を防止
  - LOG_FILE シンボリックリンクチェック追加

## Test plan

- [ ] `gh pr create` 実行後にポーリングログが `/tmp/tech-clip-poll-pr-<uid>/poll-pr-<N>.log` に生成されること
- [ ] APPROVED/CHANGES_REQUESTED を正しく検出すること
- [ ] 同一 PR の二重ポーリングが起動しないこと

🤖 Generated with [Claude Code](https://claude.ai/code)