### PR TITLE
refactor(home): ソースフィルターを SOURCE_DEFINITIONS から自動生成 #825

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import { useArticles, useToggleFavorite } from "@/hooks/use-articles";
 import { useNetworkStatus } from "@/hooks/use-network-status";
 import { useOfflineArticles } from "@/hooks/use-offline-articles";
 import { DARK_COLORS } from "@/lib/constants";
+import { SOURCE_FILTER_OPTIONS } from "@/lib/sources";
 import type { ArticleListItem, ArticleSource } from "@/types/article";
 
 /** フィルターチップのアクティブ背景色 */
@@ -25,23 +26,6 @@ const FAVORITE_INACTIVE_COLOR = DARK_COLORS.textMuted;
 
 /** フィルターアイコンサイズ */
 const FILTER_ICON_SIZE = 16;
-
-/** ソースフィルターの選択肢（固有名詞はそのまま、「すべて」のみ翻訳） */
-const SOURCE_FILTER_STATIC: {
-  value: ArticleSource | undefined;
-  staticLabel?: string;
-  i18nKey?: string;
-}[] = [
-  { i18nKey: "home.filterAll", value: undefined },
-  { staticLabel: "Zenn", value: "zenn" },
-  { staticLabel: "Qiita", value: "qiita" },
-  { staticLabel: "はてな", value: "hatena" },
-  { staticLabel: "note", value: "note" },
-  { staticLabel: "Dev.to", value: "devto" },
-  { staticLabel: "Medium", value: "medium" },
-  { staticLabel: "GitHub", value: "github" },
-  { staticLabel: "HN", value: "hackernews" },
-];
 
 /**
  * ホーム画面
@@ -84,8 +68,8 @@ export default function HomeScreen() {
 
   const sourceFilters = useMemo(
     () =>
-      SOURCE_FILTER_STATIC.map((opt) => ({
-        label: opt.i18nKey ? t(opt.i18nKey) : (opt.staticLabel ?? ""),
+      SOURCE_FILTER_OPTIONS.map((opt) => ({
+        label: "i18nKey" in opt ? t(opt.i18nKey) : opt.label,
         value: opt.value,
       })),
     [t],

--- a/apps/mobile/src/lib/sources.ts
+++ b/apps/mobile/src/lib/sources.ts
@@ -95,5 +95,8 @@ export type SourceFilterOption = FilterAllEntry | FilterSourceEntry;
  */
 export const SOURCE_FILTER_OPTIONS: readonly SourceFilterOption[] = [
   { value: undefined, i18nKey: "home.filterAll" },
-  ...SOURCE_DEFINITIONS.map(({ id, label }) => ({ value: id, label })),
+  ...SOURCE_DEFINITIONS.filter(({ id }) => id !== "other").map(({ id, label }) => ({
+    value: id,
+    label,
+  })),
 ];

--- a/apps/mobile/src/lib/sources.ts
+++ b/apps/mobile/src/lib/sources.ts
@@ -71,3 +71,29 @@ export const SUPPORTED_SOURCE_COUNT = SOURCE_DEFINITIONS.length;
 export function getSourceDefinition(source: ArticleSource): SourceDefinition {
   return SOURCE_CONFIG[source] ?? SOURCE_CONFIG.other;
 }
+
+/** ソースフィルターの「すべて」エントリ */
+type FilterAllEntry = {
+  value: undefined;
+  i18nKey: "home.filterAll";
+};
+
+/** ソースフィルターのソースエントリ */
+type FilterSourceEntry = {
+  value: ArticleSource;
+  label: string;
+};
+
+/** ソースフィルターの選択肢の型 */
+export type SourceFilterOption = FilterAllEntry | FilterSourceEntry;
+
+/**
+ * ホーム画面ソースフィルターの選択肢
+ *
+ * SOURCE_DEFINITIONS から導出する。先頭は「すべて」エントリ（i18nKey）、
+ * 続いて SOURCE_DEFINITIONS の全ソースを label 付きで並べる。
+ */
+export const SOURCE_FILTER_OPTIONS: readonly SourceFilterOption[] = [
+  { value: undefined, i18nKey: "home.filterAll" },
+  ...SOURCE_DEFINITIONS.map(({ id, label }) => ({ value: id, label })),
+];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@20.0.3)(vite@8.0.7(@types/node@25.5.0)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
-        specifier: ^4.7.0
+        specifier: 4.77.0
         version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
 
   apps/mobile:

--- a/tests/mobile/lib/sources.test.ts
+++ b/tests/mobile/lib/sources.test.ts
@@ -105,7 +105,7 @@ describe("SOURCE_FILTER_OPTIONS", () => {
 
     // Assert
     expect(first.value).toBeUndefined();
-    expect(first.i18nKey).toBe("home.filterAll");
+    expect("i18nKey" in first && first.i18nKey).toBe("home.filterAll");
   });
 
   it("SOURCE_DEFINITIONS の各ソースが含まれること", () => {
@@ -125,8 +125,8 @@ describe("SOURCE_FILTER_OPTIONS", () => {
     // Assert
     for (const opt of sourceOptions) {
       expect(typeof opt.value).toBe("string");
-      expect(typeof opt.label).toBe("string");
-      expect(opt.label.length).toBeGreaterThan(0);
+      expect("label" in opt && typeof opt.label).toBe("string");
+      expect("label" in opt && opt.label.length).toBeGreaterThan(0);
     }
   });
 
@@ -144,7 +144,9 @@ describe("SOURCE_FILTER_OPTIONS", () => {
 
     // Assert: 全ソース定義に対応するエントリが存在する
     for (const def of SOURCE_DEFINITIONS) {
-      const found = sourceOptions.some((opt) => opt.value === def.id && opt.label === def.label);
+      const found = sourceOptions.some(
+        (opt) => opt.value === def.id && "label" in opt && opt.label === def.label,
+      );
       expect(found).toBe(true);
     }
   });

--- a/tests/mobile/lib/sources.test.ts
+++ b/tests/mobile/lib/sources.test.ts
@@ -2,6 +2,7 @@ import {
   getSourceDefinition,
   SOURCE_CONFIG,
   SOURCE_DEFINITIONS,
+  SOURCE_FILTER_OPTIONS,
   SUPPORTED_SOURCE_COUNT,
   SUPPORTED_SOURCES,
 } from "@/lib/sources";
@@ -93,18 +94,12 @@ describe("SOURCE_CONFIG", () => {
 
 describe("SOURCE_FILTER_OPTIONS", () => {
   it("SOURCE_FILTER_OPTIONSをインポートできること", () => {
-    // Arrange
-    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
-
     // Assert
     expect(SOURCE_FILTER_OPTIONS).toBeDefined();
     expect(Array.isArray(SOURCE_FILTER_OPTIONS)).toBe(true);
   });
 
   it("先頭要素が「すべて」エントリ（value: undefined）であること", () => {
-    // Arrange
-    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
-
     // Act
     const first = SOURCE_FILTER_OPTIONS[0];
 
@@ -115,8 +110,7 @@ describe("SOURCE_FILTER_OPTIONS", () => {
 
   it("SOURCE_DEFINITIONS の各ソースが含まれること", () => {
     // Arrange
-    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
-    const sourceValues = SOURCE_FILTER_OPTIONS.slice(1).map((opt: { value: string }) => opt.value);
+    const sourceValues = SOURCE_FILTER_OPTIONS.slice(1).map((opt) => opt.value);
 
     // Assert
     for (const def of SOURCE_DEFINITIONS) {
@@ -126,7 +120,6 @@ describe("SOURCE_FILTER_OPTIONS", () => {
 
   it("各ソースエントリに value と label が含まれること", () => {
     // Arrange
-    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
     const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
 
     // Assert
@@ -138,13 +131,21 @@ describe("SOURCE_FILTER_OPTIONS", () => {
   });
 
   it("手書き配列でなくSOURCE_DEFINITIONSと件数が一致すること", () => {
-    // Arrange
-    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
-
     // Act: 先頭の「すべて」エントリを除く
     const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
 
     // Assert
     expect(sourceOptions.length).toBe(SOURCE_DEFINITIONS.length);
+  });
+
+  it("SOURCE_FILTER_OPTIONSがSOURCE_DEFINITIONSの全ソースを含むこと", () => {
+    // Arrange
+    const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
+
+    // Assert: 全ソース定義に対応するエントリが存在する
+    for (const def of SOURCE_DEFINITIONS) {
+      const found = sourceOptions.some((opt) => opt.value === def.id && opt.label === def.label);
+      expect(found).toBe(true);
+    }
   });
 });

--- a/tests/mobile/lib/sources.test.ts
+++ b/tests/mobile/lib/sources.test.ts
@@ -93,10 +93,14 @@ describe("SOURCE_CONFIG", () => {
 });
 
 describe("SOURCE_FILTER_OPTIONS", () => {
-  it("SOURCE_FILTER_OPTIONSをインポートできること", () => {
+  it("SOURCE_FILTER_OPTIONSが配列であること", () => {
     // Assert
-    expect(SOURCE_FILTER_OPTIONS).toBeDefined();
     expect(Array.isArray(SOURCE_FILTER_OPTIONS)).toBe(true);
+  });
+
+  it("SOURCE_FILTER_OPTIONSに要素が存在すること", () => {
+    // Assert
+    expect(SOURCE_FILTER_OPTIONS.length).toBeGreaterThan(0);
   });
 
   it("先頭要素が「すべて」エントリ（value: undefined）であること", () => {
@@ -108,14 +112,23 @@ describe("SOURCE_FILTER_OPTIONS", () => {
     expect("i18nKey" in first && first.i18nKey).toBe("home.filterAll");
   });
 
-  it("SOURCE_DEFINITIONS の各ソースが含まれること", () => {
+  it("otherを除くSOURCE_DEFINITIONSの各ソースが含まれること", () => {
+    // Arrange
+    const sourceValues = SOURCE_FILTER_OPTIONS.slice(1).map((opt) => opt.value);
+    const filteredDefs = SOURCE_DEFINITIONS.filter(({ id }) => id !== "other");
+
+    // Assert
+    for (const def of filteredDefs) {
+      expect(sourceValues).toContain(def.id);
+    }
+  });
+
+  it("otherがSOURCE_FILTER_OPTIONSに含まれないこと", () => {
     // Arrange
     const sourceValues = SOURCE_FILTER_OPTIONS.slice(1).map((opt) => opt.value);
 
     // Assert
-    for (const def of SOURCE_DEFINITIONS) {
-      expect(sourceValues).toContain(def.id);
-    }
+    expect(sourceValues).not.toContain("other");
   });
 
   it("各ソースエントリに value と label が含まれること", () => {
@@ -130,20 +143,22 @@ describe("SOURCE_FILTER_OPTIONS", () => {
     }
   });
 
-  it("手書き配列でなくSOURCE_DEFINITIONSと件数が一致すること", () => {
-    // Act: 先頭の「すべて」エントリを除く
+  it("other除外後のSOURCE_DEFINITIONSと件数が一致すること", () => {
+    // Arrange: 先頭の「すべて」エントリを除く
     const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
+    const filteredDefs = SOURCE_DEFINITIONS.filter(({ id }) => id !== "other");
 
     // Assert
-    expect(sourceOptions.length).toBe(SOURCE_DEFINITIONS.length);
+    expect(sourceOptions.length).toBe(filteredDefs.length);
   });
 
-  it("SOURCE_FILTER_OPTIONSがSOURCE_DEFINITIONSの全ソースを含むこと", () => {
+  it("SOURCE_FILTER_OPTIONSがother除外済みSOURCE_DEFINITIONSの全ソースを含むこと", () => {
     // Arrange
     const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
+    const filteredDefs = SOURCE_DEFINITIONS.filter(({ id }) => id !== "other");
 
-    // Assert: 全ソース定義に対応するエントリが存在する
-    for (const def of SOURCE_DEFINITIONS) {
+    // Assert: other以外の全ソース定義に対応するエントリが存在する
+    for (const def of filteredDefs) {
       const found = sourceOptions.some(
         (opt) => opt.value === def.id && "label" in opt && opt.label === def.label,
       );

--- a/tests/mobile/lib/sources.test.ts
+++ b/tests/mobile/lib/sources.test.ts
@@ -90,3 +90,61 @@ describe("SOURCE_CONFIG", () => {
     expect(SOURCE_CONFIG.youtube.id).toBe("youtube");
   });
 });
+
+describe("SOURCE_FILTER_OPTIONS", () => {
+  it("SOURCE_FILTER_OPTIONSをインポートできること", () => {
+    // Arrange
+    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
+
+    // Assert
+    expect(SOURCE_FILTER_OPTIONS).toBeDefined();
+    expect(Array.isArray(SOURCE_FILTER_OPTIONS)).toBe(true);
+  });
+
+  it("先頭要素が「すべて」エントリ（value: undefined）であること", () => {
+    // Arrange
+    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
+
+    // Act
+    const first = SOURCE_FILTER_OPTIONS[0];
+
+    // Assert
+    expect(first.value).toBeUndefined();
+    expect(first.i18nKey).toBe("home.filterAll");
+  });
+
+  it("SOURCE_DEFINITIONS の各ソースが含まれること", () => {
+    // Arrange
+    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
+    const sourceValues = SOURCE_FILTER_OPTIONS.slice(1).map((opt: { value: string }) => opt.value);
+
+    // Assert
+    for (const def of SOURCE_DEFINITIONS) {
+      expect(sourceValues).toContain(def.id);
+    }
+  });
+
+  it("各ソースエントリに value と label が含まれること", () => {
+    // Arrange
+    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
+    const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
+
+    // Assert
+    for (const opt of sourceOptions) {
+      expect(typeof opt.value).toBe("string");
+      expect(typeof opt.label).toBe("string");
+      expect(opt.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("手書き配列でなくSOURCE_DEFINITIONSと件数が一致すること", () => {
+    // Arrange
+    const { SOURCE_FILTER_OPTIONS } = require("@/lib/sources");
+
+    // Act: 先頭の「すべて」エントリを除く
+    const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
+
+    // Assert
+    expect(sourceOptions.length).toBe(SOURCE_DEFINITIONS.length);
+  });
+});

--- a/tests/mobile/screens/index.test.tsx
+++ b/tests/mobile/screens/index.test.tsx
@@ -1,6 +1,7 @@
 import { useArticles, useToggleFavorite } from "@mobile/hooks/use-articles";
 import { useNetworkStatus } from "@mobile/hooks/use-network-status";
 import { useOfflineArticles } from "@mobile/hooks/use-offline-articles";
+import { SOURCE_DEFINITIONS } from "@mobile/lib/sources";
 import HomeScreen from "@mobile-app/(tabs)/index";
 import { render, waitFor } from "@testing-library/react-native";
 
@@ -150,6 +151,34 @@ describe("HomeScreen", () => {
 
     await waitFor(() => {
       expect(queryByLabelText("フィルター")).toBeNull();
+    });
+  });
+
+  it("SOURCE_FILTER_OPTIONSがSOURCE_DEFINITIONSの全ソースを含むこと", () => {
+    // Arrange: SOURCE_FILTER_OPTIONS は SOURCE_DEFINITIONS から導出されている
+    const { SOURCE_FILTER_OPTIONS } = require("@mobile/lib/sources");
+    const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
+
+    // Assert: 全ソース定義に対応するエントリが存在する
+    for (const def of SOURCE_DEFINITIONS) {
+      const found = sourceOptions.some(
+        (opt: { value: string; label: string }) => opt.value === def.id && opt.label === def.label,
+      );
+      expect(found).toBe(true);
+    }
+  });
+
+  it("手書き配列にしかなかった'HN'ラベルが存在せずHacker Newsラベルが存在すること", async () => {
+    // Arrange
+    (useArticles as jest.Mock).mockReturnValue(DEFAULT_USE_ARTICLES_MOCK);
+
+    // Act
+    const { queryByLabelText, getByLabelText } = await render(<HomeScreen />);
+
+    await waitFor(() => {
+      // 旧手書き配列では "HN" だったが sources.ts では "Hacker News" が正しいラベル
+      expect(queryByLabelText("HN")).toBeNull();
+      expect(getByLabelText("Hacker News")).toBeTruthy();
     });
   });
 });

--- a/tests/mobile/screens/index.test.tsx
+++ b/tests/mobile/screens/index.test.tsx
@@ -1,7 +1,6 @@
 import { useArticles, useToggleFavorite } from "@mobile/hooks/use-articles";
 import { useNetworkStatus } from "@mobile/hooks/use-network-status";
 import { useOfflineArticles } from "@mobile/hooks/use-offline-articles";
-import { SOURCE_DEFINITIONS } from "@mobile/lib/sources";
 import HomeScreen from "@mobile-app/(tabs)/index";
 import { render, waitFor } from "@testing-library/react-native";
 
@@ -152,20 +151,6 @@ describe("HomeScreen", () => {
     await waitFor(() => {
       expect(queryByLabelText("フィルター")).toBeNull();
     });
-  });
-
-  it("SOURCE_FILTER_OPTIONSがSOURCE_DEFINITIONSの全ソースを含むこと", () => {
-    // Arrange: SOURCE_FILTER_OPTIONS は SOURCE_DEFINITIONS から導出されている
-    const { SOURCE_FILTER_OPTIONS } = require("@mobile/lib/sources");
-    const sourceOptions = SOURCE_FILTER_OPTIONS.slice(1);
-
-    // Assert: 全ソース定義に対応するエントリが存在する
-    for (const def of SOURCE_DEFINITIONS) {
-      const found = sourceOptions.some(
-        (opt: { value: string; label: string }) => opt.value === def.id && opt.label === def.label,
-      );
-      expect(found).toBe(true);
-    }
   });
 
   it("手書き配列にしかなかった'HN'ラベルが存在せずHacker Newsラベルが存在すること", async () => {

--- a/tests/mobile/screens/index.test.tsx
+++ b/tests/mobile/screens/index.test.tsx
@@ -78,7 +78,7 @@ describe("HomeScreen", () => {
     const { getByText } = await render(<HomeScreen />);
 
     await waitFor(() => {
-      expect(getByText("テスト記事1")).toBeTruthy();
+      expect(getByText("テスト記事1")).not.toBeNull();
     });
   });
 
@@ -96,7 +96,7 @@ describe("HomeScreen", () => {
 
     await waitFor(() => {
       expect(useOfflineArticles).toHaveBeenCalledTimes(1);
-      expect(getByText("テスト記事1")).toBeTruthy();
+      expect(getByText("テスト記事1")).not.toBeNull();
     });
   });
 
@@ -113,7 +113,7 @@ describe("HomeScreen", () => {
     const { getByText } = await render(<HomeScreen />);
 
     await waitFor(() => {
-      expect(getByText("オフライン：キャッシュがありません")).toBeTruthy();
+      expect(getByText("オフライン：キャッシュがありません")).not.toBeNull();
     });
   });
 
@@ -126,7 +126,7 @@ describe("HomeScreen", () => {
     const { getByText } = await render(<HomeScreen />);
 
     await waitFor(() => {
-      expect(getByText("読み込み中...")).toBeTruthy();
+      expect(getByText("読み込み中...")).not.toBeNull();
     });
   });
 

--- a/tests/mobile/screens/index.test.tsx
+++ b/tests/mobile/screens/index.test.tsx
@@ -130,7 +130,7 @@ describe("HomeScreen", () => {
     });
   });
 
-  it("エラー時に再試行UIが表示されること", async () => {
+  it("エラー時にエラーメッセージが表示されること", async () => {
     (useArticles as jest.Mock).mockReturnValue({
       ...DEFAULT_USE_ARTICLES_MOCK,
       isError: true,
@@ -140,8 +140,21 @@ describe("HomeScreen", () => {
     const { getByText } = await render(<HomeScreen />);
 
     await waitFor(() => {
-      expect(getByText("記事の取得に失敗しました")).toBeTruthy();
-      expect(getByText("再試行")).toBeTruthy();
+      expect(getByText("記事の取得に失敗しました")).not.toBeNull();
+    });
+  });
+
+  it("エラー時に再試行ボタンが表示されること", async () => {
+    (useArticles as jest.Mock).mockReturnValue({
+      ...DEFAULT_USE_ARTICLES_MOCK,
+      isError: true,
+      data: undefined,
+    });
+
+    const { getByText } = await render(<HomeScreen />);
+
+    await waitFor(() => {
+      expect(getByText("再試行")).not.toBeNull();
     });
   });
 

--- a/tests/mobile/screens/index.test.tsx
+++ b/tests/mobile/screens/index.test.tsx
@@ -153,17 +153,29 @@ describe("HomeScreen", () => {
     });
   });
 
-  it("手書き配列にしかなかった'HN'ラベルが存在せずHacker Newsラベルが存在すること", async () => {
+  it("手書き配列にしかなかった'HN'ラベルが存在しないこと", async () => {
     // Arrange
     (useArticles as jest.Mock).mockReturnValue(DEFAULT_USE_ARTICLES_MOCK);
 
     // Act
-    const { queryByLabelText, getByLabelText } = await render(<HomeScreen />);
+    const { queryByLabelText } = await render(<HomeScreen />);
 
+    // Assert
     await waitFor(() => {
-      // 旧手書き配列では "HN" だったが sources.ts では "Hacker News" が正しいラベル
       expect(queryByLabelText("HN")).toBeNull();
-      expect(getByLabelText("Hacker News")).toBeTruthy();
+    });
+  });
+
+  it("sources.tsで定義されたHacker Newsラベルが存在すること", async () => {
+    // Arrange
+    (useArticles as jest.Mock).mockReturnValue(DEFAULT_USE_ARTICLES_MOCK);
+
+    // Act
+    const { getByLabelText } = await render(<HomeScreen />);
+
+    // Assert
+    await waitFor(() => {
+      expect(getByLabelText("Hacker News")).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- `SOURCE_FILTER_OPTIONS` 配列を `SOURCE_DEFINITIONS` から導出するように変更
- ホーム画面のハードコードされたフィルターリストを削除
- 新ソース追加時に自動でフィルターに反映される

## Test plan
- [ ] ホーム画面のソースフィルターが正常に動作することを確認
- [ ] 既存テストがパスすることを確認

Closes #825

🤖 Generated with [Claude Code](https://claude.ai/code)