### PR TITLE
refactor(onboarding): 対応ソース訴求文を i18n 化・仕様同期 #827

### DIFF
--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -1,6 +1,7 @@
 import { router } from "expo-router";
 import { ArrowRight, BookMarked, Sparkles, Tag } from "lucide-react-native";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, Text, View } from "react-native";
 
 import { LIGHT_COLORS, SUPPORTED_SOURCE_COUNT } from "@/lib/constants";
@@ -8,49 +9,30 @@ import { logger } from "@/lib/logger";
 import { requestTrackingPermission } from "@/lib/tracking";
 import { useUIStore } from "@/stores/ui-store";
 
-/** オンボーディングページのデータ */
-const ONBOARDING_PAGES = [
-  {
-    id: "save",
-    title: "技術記事をワンタップで保存",
-    description: `Zenn、Qiita、dev.toなど${SUPPORTED_SOURCE_COUNT}ソースに対応。気になった記事をすぐ保存できます。`,
-    Icon: BookMarked,
-  },
-  {
-    id: "ai",
-    title: "AIが要約・翻訳",
-    description: "英語記事も日本語で読める。要点だけ把握したいときはAI要約で時短。",
-    Icon: Sparkles,
-  },
-  {
-    id: "organize",
-    title: "お気に入り・タグで整理",
-    description: "タグ付けで記事を分類。お気に入り登録でいつでも素早くアクセス。",
-    Icon: Tag,
-  },
-  {
-    id: "start",
-    title: "さあ、始めましょう",
-    description: "アカウントを作成して、技術知識を効率よく管理しましょう。",
-    Icon: ArrowRight,
-  },
+/** オンボーディングページのメタデータ（IDとアイコンのみ保持） */
+const ONBOARDING_PAGE_META = [
+  { id: "save", Icon: BookMarked },
+  { id: "ai", Icon: Sparkles },
+  { id: "organize", Icon: Tag },
+  { id: "start", Icon: ArrowRight },
 ] as const;
 
 /** ページ数 */
-const PAGE_COUNT = ONBOARDING_PAGES.length;
+const PAGE_COUNT = ONBOARDING_PAGE_META.length;
 
 /**
  * オンボーディング画面
  * 初回起動時のみ表示される4ページのウォークスルー
  */
 export default function OnboardingScreen() {
+  const { t } = useTranslation();
   const hasSeenOnboarding = useUIStore((s) => s.hasSeenOnboarding);
   const setHasSeenOnboarding = useUIStore((s) => s.setHasSeenOnboarding);
 
   const [currentIndex, setCurrentIndex] = useState(0);
 
   const isLastPage = currentIndex === PAGE_COUNT - 1;
-  const currentPage = ONBOARDING_PAGES[currentIndex];
+  const currentPageMeta = ONBOARDING_PAGE_META[currentIndex];
 
   const handleFinish = async () => {
     try {
@@ -75,21 +57,28 @@ export default function OnboardingScreen() {
     return null;
   }
 
+  const pageId = currentPageMeta.id;
+  const pageTitle = t(`onboarding.pages.${pageId}.title`);
+  const pageDescription =
+    pageId === "save"
+      ? t("onboarding.pages.save.description", { count: SUPPORTED_SOURCE_COUNT })
+      : t(`onboarding.pages.${pageId}.description`);
+
   return (
     <View className="flex-1 bg-white">
       <ScrollView contentContainerStyle={{ flexGrow: 1 }} scrollEnabled={false}>
         <View className="flex-1 items-center justify-center px-8">
           <View className="mb-8 h-24 w-24 items-center justify-center rounded-2xl bg-stone-100">
-            <currentPage.Icon size={48} color={LIGHT_COLORS.neutral} strokeWidth={1.5} />
+            <currentPageMeta.Icon size={48} color={LIGHT_COLORS.neutral} strokeWidth={1.5} />
           </View>
           <Text
             testID="onboarding-title"
             className="mb-4 text-center text-2xl font-bold text-stone-900"
           >
-            {currentPage.title}
+            {pageTitle}
           </Text>
           <Text className="text-center text-base leading-relaxed text-stone-500">
-            {currentPage.description}
+            {pageDescription}
           </Text>
         </View>
       </ScrollView>
@@ -98,10 +87,13 @@ export default function OnboardingScreen() {
       <View
         testID="page-indicator"
         className="flex-row items-center justify-center py-4"
-        accessibilityLabel={`${currentIndex + 1}ページ目（全${PAGE_COUNT}ページ）`}
+        accessibilityLabel={t("onboarding.accessibility.pageIndicator", {
+          current: currentIndex + 1,
+          total: PAGE_COUNT,
+        })}
         accessible={true}
       >
-        {ONBOARDING_PAGES.map((page, index) => (
+        {ONBOARDING_PAGE_META.map((page, index) => (
           <View
             key={page.id}
             className={`mx-1 h-2 rounded-full ${
@@ -120,10 +112,10 @@ export default function OnboardingScreen() {
           onPress={handleSkip}
           className="px-4 py-3"
           accessibilityRole="button"
-          accessibilityLabel="スキップ"
-          accessibilityHint="オンボーディングをスキップしてログイン画面に進みます"
+          accessibilityLabel={t("onboarding.skip")}
+          accessibilityHint={t("onboarding.accessibility.skipHint")}
         >
-          <Text className="text-base text-stone-500">スキップ</Text>
+          <Text className="text-base text-stone-500">{t("onboarding.skip")}</Text>
         </Pressable>
 
         {isLastPage ? (
@@ -132,10 +124,10 @@ export default function OnboardingScreen() {
             onPress={handleFinish}
             className="rounded-xl bg-stone-800 px-8 py-3"
             accessibilityRole="button"
-            accessibilityLabel="始める"
-            accessibilityHint="アカウント作成画面に進みます"
+            accessibilityLabel={t("onboarding.start")}
+            accessibilityHint={t("onboarding.accessibility.startHint")}
           >
-            <Text className="text-base font-semibold text-white">始める</Text>
+            <Text className="text-base font-semibold text-white">{t("onboarding.start")}</Text>
           </Pressable>
         ) : (
           <Pressable
@@ -143,10 +135,12 @@ export default function OnboardingScreen() {
             onPress={handleNext}
             className="rounded-xl bg-stone-800 px-8 py-3"
             accessibilityRole="button"
-            accessibilityLabel="次へ"
-            accessibilityHint={`次のページ（${currentIndex + 2}ページ目）に進みます`}
+            accessibilityLabel={t("onboarding.next")}
+            accessibilityHint={t("onboarding.accessibility.nextPageHint", {
+              next: currentIndex + 2,
+            })}
           >
-            <Text className="text-base font-semibold text-white">次へ</Text>
+            <Text className="text-base font-semibold text-white">{t("onboarding.next")}</Text>
           </Pressable>
         )}
       </View>

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -281,7 +281,7 @@
     "pages": {
       "save": {
         "title": "Save Tech Articles with One Tap",
-        "description": "Supports 18 sites including Zenn, Qiita, and dev.to. Save articles you're interested in right away."
+        "description": "Supports {{count}} sources including Zenn, Qiita, and dev.to. Save articles you're interested in right away."
       },
       "ai": {
         "title": "AI Summarizes & Translates",
@@ -298,7 +298,13 @@
     },
     "skip": "Skip",
     "next": "Next",
-    "start": "Get Started"
+    "start": "Get Started",
+    "accessibility": {
+      "pageIndicator": "Page {{current}} of {{total}}",
+      "nextPageHint": "Go to page {{next}}",
+      "skipHint": "Skip onboarding and go to login",
+      "startHint": "Go to account creation"
+    }
   },
   "shareIntent": {
     "loading": "Loading",

--- a/apps/mobile/src/locales/ja.json
+++ b/apps/mobile/src/locales/ja.json
@@ -281,7 +281,7 @@
     "pages": {
       "save": {
         "title": "技術記事をワンタップで保存",
-        "description": "Zenn、Qiita、dev.toなど18サイトに対応。気になった記事をすぐ保存できます。"
+        "description": "Zenn、Qiita、dev.toなど{{count}}ソースに対応。気になった記事をすぐ保存できます。"
       },
       "ai": {
         "title": "AIが要約・翻訳",
@@ -298,7 +298,13 @@
     },
     "skip": "スキップ",
     "next": "次へ",
-    "start": "始める"
+    "start": "始める",
+    "accessibility": {
+      "pageIndicator": "{{current}}ページ目（全{{total}}ページ）",
+      "nextPageHint": "次のページ（{{next}}ページ目）に進みます",
+      "skipHint": "オンボーディングをスキップしてログイン画面に進みます",
+      "startHint": "アカウント作成画面に進みます"
+    }
   },
   "shareIntent": {
     "loading": "読み込み中",

--- a/apps/mobile/src/locales/ko.json
+++ b/apps/mobile/src/locales/ko.json
@@ -281,7 +281,7 @@
     "pages": {
       "save": {
         "title": "기술 기사를 한 번에 저장",
-        "description": "Zenn, Qiita, dev.to 등 18개 사이트를 지원합니다. 관심 있는 기사를 바로 저장하세요."
+        "description": "Zenn, Qiita, dev.to 등 {{count}}개 소스를 지원합니다. 관심 있는 기사를 바로 저장하세요."
       },
       "ai": {
         "title": "AI가 요약하고 번역합니다",
@@ -298,7 +298,13 @@
     },
     "skip": "건너뛰기",
     "next": "다음",
-    "start": "시작하기"
+    "start": "시작하기",
+    "accessibility": {
+      "pageIndicator": "{{current}}페이지（전체 {{total}}페이지）",
+      "nextPageHint": "다음 페이지（{{next}}페이지）로 이동합니다",
+      "skipHint": "온보딩을 건너뛰고 로그인 화면으로 이동합니다",
+      "startHint": "계정 만들기 화면으로 이동합니다"
+    }
   },
   "shareIntent": {
     "loading": "불러오는 중",

--- a/apps/mobile/src/locales/zh-CN.json
+++ b/apps/mobile/src/locales/zh-CN.json
@@ -281,7 +281,7 @@
     "pages": {
       "save": {
         "title": "一键保存技术文章",
-        "description": "支持Zenn、Qiita、dev.to等18个网站，随时保存感兴趣的文章。"
+        "description": "支持Zenn、Qiita、dev.to等{{count}}个来源，随时保存感兴趣的文章。"
       },
       "ai": {
         "title": "AI摘要与翻译",
@@ -298,7 +298,13 @@
     },
     "skip": "跳过",
     "next": "下一步",
-    "start": "开始"
+    "start": "开始",
+    "accessibility": {
+      "pageIndicator": "第{{current}}页（共{{total}}页）",
+      "nextPageHint": "前往第{{next}}页",
+      "skipHint": "跳过引导并前往登录界面",
+      "startHint": "前往创建账户界面"
+    }
   },
   "shareIntent": {
     "loading": "加载中",

--- a/apps/mobile/src/locales/zh-TW.json
+++ b/apps/mobile/src/locales/zh-TW.json
@@ -281,7 +281,7 @@
     "pages": {
       "save": {
         "title": "一鍵儲存技術文章",
-        "description": "支援Zenn、Qiita、dev.to等18個網站，隨時儲存感興趣的文章。"
+        "description": "支援Zenn、Qiita、dev.to等{{count}}個來源，隨時儲存感興趣的文章。"
       },
       "ai": {
         "title": "AI摘要與翻譯",
@@ -298,7 +298,13 @@
     },
     "skip": "跳過",
     "next": "下一步",
-    "start": "開始"
+    "start": "開始",
+    "accessibility": {
+      "pageIndicator": "第{{current}}頁（共{{total}}頁）",
+      "nextPageHint": "前往第{{next}}頁",
+      "skipHint": "跳過引導並前往登入畫面",
+      "startHint": "前往建立帳號畫面"
+    }
   },
   "shareIntent": {
     "loading": "載入中",

--- a/tests/mobile/screens/onboarding.test.tsx
+++ b/tests/mobile/screens/onboarding.test.tsx
@@ -1,10 +1,18 @@
 import OnboardingScreen from "@mobile-app/onboarding";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
+/** テスト用ソース数（sources.ts の SUPPORTED_SOURCE_COUNT と一致させる） */
+const MOCK_SOURCE_COUNT = 19;
+
 jest.mock("expo-router", () => ({
   router: {
     replace: jest.fn(),
   },
+}));
+
+jest.mock("@/lib/constants", () => ({
+  LIGHT_COLORS: { neutral: "#44403c" },
+  SUPPORTED_SOURCE_COUNT: 19,
 }));
 
 const mockSetHasSeenOnboarding = jest.fn().mockResolvedValue(undefined);
@@ -127,6 +135,20 @@ describe("OnboardingScreen", () => {
         expect(mockRouter.replace).toHaveBeenCalledWith("/(auth)/login");
       });
       expect(mockSetHasSeenOnboarding).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("i18n", () => {
+    it("最初のページの説明文にソース数が表示されること", async () => {
+      // Arrange & Act
+      const { getByText } = await render(<OnboardingScreen />);
+
+      // Assert
+      expect(
+        getByText(
+          `Zenn、Qiita、dev.toなど${MOCK_SOURCE_COUNT}ソースに対応。気になった記事をすぐ保存できます。`,
+        ),
+      ).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- オンボーディング画面の対応ソース数をハードコードから翻訳キー経由（`{{count}}` 補間）に変更
- `useTranslation` フックを追加
- 各ロケールファイルに対応するキーを追加

## Test plan
- [ ] オンボーディング画面が正常に表示されることを確認
- [ ] 対応ソース数が正しく表示されることを確認

Closes #827

🤖 Generated with [Claude Code](https://claude.ai/code)