### PR TITLE
feat(follows): FollowButton に楽観更新と失敗時ロールバックを実装 #846

### DIFF
--- a/apps/mobile/src/components/FollowButton.tsx
+++ b/apps/mobile/src/components/FollowButton.tsx
@@ -13,8 +13,11 @@ const FOLLOWING_ICON_COLOR = DARK_COLORS.text;
 /** 未フォローボタンのアイコンカラー */
 const NOT_FOLLOWING_ICON_COLOR = DARK_COLORS.white;
 
-/** ローディングインジケーターカラー */
-const LOADING_COLOR = DARK_COLORS.primary;
+/** フォロー済みブランチのローディングインジケーターカラー */
+const FOLLOWING_LOADING_COLOR = DARK_COLORS.primary;
+
+/** 未フォローブランチのローディングインジケーターカラー（白: 青背景上で視認可能） */
+const NOT_FOLLOWING_LOADING_COLOR = DARK_COLORS.white;
 
 type FollowButtonProps = {
   userId: string;
@@ -64,13 +67,13 @@ export function FollowButton({
         onPress={handlePress}
         disabled={isLoading}
         accessibilityState={{ disabled: isLoading }}
-        className="flex-row items-center justify-center gap-1.5 rounded-lg px-4 py-2 border border-border bg-surface opacity-[var(--opacity)]"
+        className="flex-row items-center justify-center gap-1.5 rounded-lg px-4 py-2 border border-border bg-surface"
         style={isLoading ? { opacity: 0.5 } : undefined}
         accessibilityRole="button"
         accessibilityLabel={isLoading ? "フォロー切り替え中" : "フォロー解除"}
       >
         {isLoading ? (
-          <ActivityIndicator size="small" color={LOADING_COLOR} />
+          <ActivityIndicator size="small" color={FOLLOWING_LOADING_COLOR} />
         ) : (
           <UserMinus size={ICON_SIZE} color={FOLLOWING_ICON_COLOR} />
         )}
@@ -93,7 +96,7 @@ export function FollowButton({
       accessibilityLabel={isLoading ? "フォロー切り替え中" : "フォローする"}
     >
       {isLoading ? (
-        <ActivityIndicator size="small" color={LOADING_COLOR} />
+        <ActivityIndicator size="small" color={NOT_FOLLOWING_LOADING_COLOR} />
       ) : (
         <UserPlus size={ICON_SIZE} color={NOT_FOLLOWING_ICON_COLOR} />
       )}

--- a/apps/mobile/src/components/FollowButton.tsx
+++ b/apps/mobile/src/components/FollowButton.tsx
@@ -25,6 +25,9 @@ type FollowButtonProps = {
 /**
  * フォロー/フォロー解除ボタンコンポーネント
  *
+ * 楽観更新: ボタン押下直後にUIを更新し、API完了を待たない。
+ * API失敗時は元の状態にロールバックする。
+ *
  * @param userId - 対象ユーザーのID
  * @param isFollowing - 現在フォロー中かどうか
  * @param onToggle - フォロー状態変更時のコールバック
@@ -38,44 +41,39 @@ export function FollowButton({
   const [isLoading, setIsLoading] = useState(false);
 
   const handlePress = useCallback(async () => {
+    const prevFollowing = isFollowing;
+
     setIsLoading(true);
+    setIsFollowing(!prevFollowing);
 
     try {
       if (onToggle) {
-        await onToggle(userId, isFollowing);
+        await onToggle(userId, prevFollowing);
       }
-      setIsFollowing((prev) => !prev);
     } catch {
-      /* フォロー状態変更失敗時は状態を維持 */
+      setIsFollowing(prevFollowing);
     } finally {
       setIsLoading(false);
     }
   }, [userId, isFollowing, onToggle]);
-
-  if (isLoading) {
-    return (
-      <Pressable
-        testID="follow-button"
-        disabled
-        className="flex-row items-center justify-center gap-1.5 rounded-lg px-4 py-2 border border-border opacity-50"
-        accessibilityRole="button"
-        accessibilityLabel="フォロー切り替え中"
-      >
-        <ActivityIndicator size="small" color={LOADING_COLOR} />
-      </Pressable>
-    );
-  }
 
   if (isFollowing) {
     return (
       <Pressable
         testID="follow-button"
         onPress={handlePress}
-        className="flex-row items-center justify-center gap-1.5 rounded-lg px-4 py-2 border border-border bg-surface"
+        disabled={isLoading}
+        accessibilityState={{ disabled: isLoading }}
+        className="flex-row items-center justify-center gap-1.5 rounded-lg px-4 py-2 border border-border bg-surface opacity-[var(--opacity)]"
+        style={isLoading ? { opacity: 0.5 } : undefined}
         accessibilityRole="button"
-        accessibilityLabel="フォロー解除"
+        accessibilityLabel={isLoading ? "フォロー切り替え中" : "フォロー解除"}
       >
-        <UserMinus size={ICON_SIZE} color={FOLLOWING_ICON_COLOR} />
+        {isLoading ? (
+          <ActivityIndicator size="small" color={LOADING_COLOR} />
+        ) : (
+          <UserMinus size={ICON_SIZE} color={FOLLOWING_ICON_COLOR} />
+        )}
         <Text testID="follow-button-label" className="text-sm font-medium text-text">
           フォロー中
         </Text>
@@ -87,11 +85,18 @@ export function FollowButton({
     <Pressable
       testID="follow-button"
       onPress={handlePress}
+      disabled={isLoading}
+      accessibilityState={{ disabled: isLoading }}
       className="flex-row items-center justify-center gap-1.5 rounded-lg px-4 py-2 bg-primary"
+      style={isLoading ? { opacity: 0.5 } : undefined}
       accessibilityRole="button"
-      accessibilityLabel="フォローする"
+      accessibilityLabel={isLoading ? "フォロー切り替え中" : "フォローする"}
     >
-      <UserPlus size={ICON_SIZE} color={NOT_FOLLOWING_ICON_COLOR} />
+      {isLoading ? (
+        <ActivityIndicator size="small" color={LOADING_COLOR} />
+      ) : (
+        <UserPlus size={ICON_SIZE} color={NOT_FOLLOWING_ICON_COLOR} />
+      )}
       <Text testID="follow-button-label" className="text-sm font-semibold text-white">
         フォローする
       </Text>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@20.0.3)(vite@8.0.7(@types/node@25.5.0)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
-        specifier: ^4.7.0
+        specifier: 4.77.0
         version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
 
   apps/mobile:
@@ -8219,7 +8219,9 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/tests/mobile/components/FollowButton.test.tsx
+++ b/tests/mobile/components/FollowButton.test.tsx
@@ -176,6 +176,23 @@ describe("FollowButton", () => {
       });
     });
 
+    it("フォロー解除に失敗した場合に元のフォロー状態にロールバックされること", async () => {
+      // Arrange
+      const onToggle = jest.fn().mockRejectedValue(new Error("通信エラー"));
+      const { getByTestId } = await render(
+        <FollowButton userId="user-1" isFollowing={true} onToggle={onToggle} />,
+      );
+
+      // Act
+      await fireEvent.press(getByTestId("follow-button"));
+
+      // Assert - エラー後に元の状態（フォロー中）に戻ること
+      await waitFor(() => {
+        const label = getByTestId("follow-button-label");
+        expect(label.props.children).toBe("フォロー中");
+      });
+    });
+
     it("フォロー中からフォロー解除に楽観更新されること", async () => {
       // Arrange
       let resolveToggle: () => void = () => {};

--- a/tests/mobile/components/FollowButton.test.tsx
+++ b/tests/mobile/components/FollowButton.test.tsx
@@ -134,4 +134,69 @@ describe("FollowButton", () => {
       expect(onToggle).toHaveBeenCalledWith("user-1", false);
     });
   });
+
+  describe("楽観更新", () => {
+    it("onToggle完了前にUI状態が即座に更新されること", async () => {
+      // Arrange
+      let resolveToggle: () => void = () => {};
+      const togglePromise = new Promise<void>((r) => {
+        resolveToggle = r;
+      });
+      const onToggle = jest.fn().mockReturnValue(togglePromise);
+      const { getByTestId } = await render(
+        <FollowButton userId="user-1" isFollowing={false} onToggle={onToggle} />,
+      );
+
+      // Act - タップ直後（API完了前）
+      fireEvent.press(getByTestId("follow-button"));
+
+      // Assert - API完了を待たずに状態が更新されること（楽観更新）
+      await waitFor(() => {
+        const label = getByTestId("follow-button-label");
+        expect(label.props.children).toBe("フォロー中");
+      });
+
+      resolveToggle();
+    });
+
+    it("onToggleがエラーの場合に元の状態にロールバックされること", async () => {
+      // Arrange
+      const onToggle = jest.fn().mockRejectedValue(new Error("通信エラー"));
+      const { getByTestId } = await render(
+        <FollowButton userId="user-1" isFollowing={false} onToggle={onToggle} />,
+      );
+
+      // Act
+      await fireEvent.press(getByTestId("follow-button"));
+
+      // Assert - エラー後に元の状態（未フォロー）に戻ること
+      await waitFor(() => {
+        const label = getByTestId("follow-button-label");
+        expect(label.props.children).toBe("フォローする");
+      });
+    });
+
+    it("フォロー中からフォロー解除に楽観更新されること", async () => {
+      // Arrange
+      let resolveToggle: () => void = () => {};
+      const togglePromise = new Promise<void>((r) => {
+        resolveToggle = r;
+      });
+      const onToggle = jest.fn().mockReturnValue(togglePromise);
+      const { getByTestId } = await render(
+        <FollowButton userId="user-1" isFollowing={true} onToggle={onToggle} />,
+      );
+
+      // Act - タップ直後（API完了前）
+      fireEvent.press(getByTestId("follow-button"));
+
+      // Assert - API完了を待たずに状態が更新されること（楽観更新）
+      await waitFor(() => {
+        const label = getByTestId("follow-button-label");
+        expect(label.props.children).toBe("フォローする");
+      });
+
+      resolveToggle();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- フォローボタンの UI 状態を API 応答を待たず即時変更（楽観更新）
- API エラー時に元の状態にロールバック
- ユーザーの体感レスポンスを向上

## Test plan
- [ ] フォローボタン押下時に即座にUIが変わることを確認
- [ ] API エラー時にロールバックされることを確認

Closes #846

🤖 Generated with [Claude Code](https://claude.ai/code)