### PR TITLE
refactor(i18n): profile・followers・settings のハードコード文言を翻訳キーへ移行 #849

### DIFF
--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -15,7 +15,7 @@ export default function ProfileScreen() {
   const router = useRouter();
 
   /** プロフィール画面のプレースホルダーユーザーデータ */
-  const PLACEHOLDER_USER: ProfileHeaderUser = {
+  const placeholderUser: ProfileHeaderUser = {
     name: t("profile.guestUser"),
     bio: null,
     avatarUrl: null,
@@ -29,7 +29,7 @@ export default function ProfileScreen() {
 
   return (
     <ScrollView className="flex-1 bg-background">
-      <ProfileHeader user={PLACEHOLDER_USER} onSettingsPress={handleSettingsPress} />
+      <ProfileHeader user={placeholderUser} onSettingsPress={handleSettingsPress} />
       <View className="flex-1 items-center justify-center px-4 py-12">
         <Text className="text-base text-text-muted text-center">{t("profile.loginPrompt")}</Text>
       </View>

--- a/apps/mobile/app/(tabs)/profile.tsx
+++ b/apps/mobile/app/(tabs)/profile.tsx
@@ -1,16 +1,8 @@
 import { useRouter } from "expo-router";
+import { useTranslation } from "react-i18next";
 import { ScrollView, Text, View } from "react-native";
 import type { ProfileHeaderUser } from "@/components/ProfileHeader";
 import { ProfileHeader } from "@/components/ProfileHeader";
-
-/** プロフィール画面のプレースホルダーユーザーデータ */
-const PLACEHOLDER_USER: ProfileHeaderUser = {
-  name: "ゲストユーザー",
-  bio: null,
-  avatarUrl: null,
-  followersCount: 0,
-  followingCount: 0,
-};
 
 /**
  * プロフィール画面
@@ -19,7 +11,17 @@ const PLACEHOLDER_USER: ProfileHeaderUser = {
  * 認証実装後にAPIからユーザーデータを取得する予定。
  */
 export default function ProfileScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
+
+  /** プロフィール画面のプレースホルダーユーザーデータ */
+  const PLACEHOLDER_USER: ProfileHeaderUser = {
+    name: t("profile.guestUser"),
+    bio: null,
+    avatarUrl: null,
+    followersCount: 0,
+    followingCount: 0,
+  };
 
   const handleSettingsPress = () => {
     router.push("/(tabs)/settings");
@@ -29,9 +31,7 @@ export default function ProfileScreen() {
     <ScrollView className="flex-1 bg-background">
       <ProfileHeader user={PLACEHOLDER_USER} onSettingsPress={handleSettingsPress} />
       <View className="flex-1 items-center justify-center px-4 py-12">
-        <Text className="text-base text-text-muted text-center">
-          ログインすると保存した記事やお気に入りが表示されます
-        </Text>
+        <Text className="text-base text-text-muted text-center">{t("profile.loginPrompt")}</Text>
       </View>
     </ScrollView>
   );

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,3 +1,4 @@
+import Constants from "expo-constants";
 import { useRouter } from "expo-router";
 import {
   Bell,
@@ -289,7 +290,9 @@ export default function SettingsScreen() {
       </View>
 
       <View className="px-4 py-6">
-        <Text className="text-center text-xs text-text-dim">TechClip v0.0.1</Text>
+        <Text className="text-center text-xs text-text-dim">
+          {t("settings.version")} {Constants.expoConfig?.version ?? ""}
+        </Text>
       </View>
     </ScrollView>
   );

--- a/apps/mobile/app/profile/[id].tsx
+++ b/apps/mobile/app/profile/[id].tsx
@@ -88,7 +88,7 @@ export default function UserProfileScreen() {
           className="mt-4 bg-primary rounded-lg px-6 py-3"
           accessibilityRole="button"
           accessibilityLabel={t("common.retry")}
-          accessibilityHint={t("profile.fetchError")}
+          accessibilityHint={t("profile.retryHint")}
         >
           <Text className="text-white font-semibold">{t("common.retry")}</Text>
         </Pressable>
@@ -97,7 +97,7 @@ export default function UserProfileScreen() {
           className="mt-3"
           accessibilityRole="button"
           accessibilityLabel={t("profile.back")}
-          accessibilityHint={t("profile.back")}
+          accessibilityHint={t("profile.backHint")}
         >
           <Text className="text-primary">{t("profile.back")}</Text>
         </Pressable>

--- a/apps/mobile/app/profile/[id].tsx
+++ b/apps/mobile/app/profile/[id].tsx
@@ -1,6 +1,7 @@
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { ArrowLeft } from "lucide-react-native";
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
 
 import { FollowButton } from "@/components/FollowButton";
@@ -41,6 +42,7 @@ function createPlaceholderUser(id: string): ProfileHeaderUser {
  * ProfileHeaderコンポーネントを再利用。
  */
 export default function UserProfileScreen() {
+  const { t } = useTranslation();
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
 
@@ -65,7 +67,7 @@ export default function UserProfileScreen() {
         className="flex-1 bg-background items-center justify-center"
       >
         <ActivityIndicator size="large" color={PRIMARY_COLOR} />
-        <Text className="text-text-muted mt-3">読み込み中...</Text>
+        <Text className="text-text-muted mt-3">{t("profile.loadingUser")}</Text>
       </View>
     );
   }
@@ -76,9 +78,7 @@ export default function UserProfileScreen() {
         testID="user-profile-error"
         className="flex-1 bg-background items-center justify-center px-4"
       >
-        <Text className="text-text-muted text-base text-center">
-          ユーザー情報の取得に失敗しました
-        </Text>
+        <Text className="text-text-muted text-base text-center">{t("profile.fetchError")}</Text>
         <Pressable
           onPress={() => {
             setIsError(false);
@@ -87,19 +87,19 @@ export default function UserProfileScreen() {
           }}
           className="mt-4 bg-primary rounded-lg px-6 py-3"
           accessibilityRole="button"
-          accessibilityLabel="再試行"
-          accessibilityHint="ユーザー情報の取得を再試行します"
+          accessibilityLabel={t("common.retry")}
+          accessibilityHint={t("profile.fetchError")}
         >
-          <Text className="text-white font-semibold">再試行</Text>
+          <Text className="text-white font-semibold">{t("common.retry")}</Text>
         </Pressable>
         <Pressable
           onPress={handleBack}
           className="mt-3"
           accessibilityRole="button"
-          accessibilityLabel="戻る"
-          accessibilityHint="前の画面に戻ります"
+          accessibilityLabel={t("profile.back")}
+          accessibilityHint={t("profile.back")}
         >
-          <Text className="text-primary">戻る</Text>
+          <Text className="text-primary">{t("profile.back")}</Text>
         </Pressable>
       </View>
     );
@@ -112,7 +112,7 @@ export default function UserProfileScreen() {
           testID="user-profile-back-button"
           onPress={handleBack}
           accessibilityRole="button"
-          accessibilityLabel="戻る"
+          accessibilityLabel={t("profile.back")}
           hitSlop={8}
         >
           <ArrowLeft size={BACK_ICON_SIZE} color={TEXT_COLOR} />
@@ -130,10 +130,12 @@ export default function UserProfileScreen() {
 
         <View className="px-4">
           <View className="border-t border-border pt-4">
-            <Text className="text-base font-semibold text-text mb-3">保存した記事</Text>
+            <Text className="text-base font-semibold text-text mb-3">
+              {t("profile.savedArticles")}
+            </Text>
             <View className="items-center py-8">
               <Text className="text-text-muted text-sm text-center">
-                このユーザーの公開記事はまだありません
+                {t("profile.noPublicArticles")}
               </Text>
             </View>
           </View>

--- a/apps/mobile/app/profile/edit.tsx
+++ b/apps/mobile/app/profile/edit.tsx
@@ -3,6 +3,7 @@ import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import { ArrowLeft, Camera } from "lucide-react-native";
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ActivityIndicator, Alert, Pressable, ScrollView, Text, View } from "react-native";
 
 import { Button } from "@/components/ui/Button";
@@ -61,6 +62,9 @@ type ProfileFormData = {
 /** バリデーションエラーの型 */
 type FormErrors = Partial<Record<keyof ProfileFormData, string>>;
 
+/** t関数の型 */
+type TFunction = (key: string, opts?: Record<string, unknown>) => string;
+
 /**
  * ユーザー名の頭文字を取得する
  *
@@ -79,39 +83,40 @@ function getInitials(name: string): string {
  * フォームデータのバリデーションを実行する
  *
  * @param data - バリデーション対象のフォームデータ
+ * @param t - 翻訳関数
  * @returns エラーオブジェクト。エラーがない場合は空オブジェクト
  */
-export function validateProfileForm(data: ProfileFormData): FormErrors {
+export function validateProfileForm(data: ProfileFormData, t: TFunction): FormErrors {
   const errors: FormErrors = {};
 
   if (!data.name.trim()) {
-    errors.name = "名前を入力してください";
+    errors.name = t("profile.edit.validation.nameRequired");
   }
   if (data.name.length > NAME_MAX_LENGTH) {
-    errors.name = `名前は${NAME_MAX_LENGTH}文字以内で入力してください`;
+    errors.name = t("profile.edit.validation.nameTooLong", { max: NAME_MAX_LENGTH });
   }
 
   if (data.username && !USERNAME_REGEX.test(data.username)) {
-    errors.username = "ユーザー名は英数字とアンダースコアのみ使用できます";
+    errors.username = t("profile.edit.validation.usernameInvalid");
   }
   if (data.username.length > USERNAME_MAX_LENGTH) {
-    errors.username = `ユーザー名は${USERNAME_MAX_LENGTH}文字以内で入力してください`;
+    errors.username = t("profile.edit.validation.usernameTooLong", { max: USERNAME_MAX_LENGTH });
   }
 
   if (data.bio.length > BIO_MAX_LENGTH) {
-    errors.bio = `自己紹介は${BIO_MAX_LENGTH}文字以内で入力してください`;
+    errors.bio = t("profile.edit.validation.bioTooLong", { max: BIO_MAX_LENGTH });
   }
 
   if (data.twitterUrl && data.twitterUrl.length > SNS_LINK_MAX_LENGTH) {
-    errors.twitterUrl = `URLは${SNS_LINK_MAX_LENGTH}文字以内で入力してください`;
+    errors.twitterUrl = t("profile.edit.validation.urlTooLong", { max: SNS_LINK_MAX_LENGTH });
   }
 
   if (data.githubUrl && data.githubUrl.length > SNS_LINK_MAX_LENGTH) {
-    errors.githubUrl = `URLは${SNS_LINK_MAX_LENGTH}文字以内で入力してください`;
+    errors.githubUrl = t("profile.edit.validation.urlTooLong", { max: SNS_LINK_MAX_LENGTH });
   }
 
   if (data.websiteUrl && data.websiteUrl.length > SNS_LINK_MAX_LENGTH) {
-    errors.websiteUrl = `URLは${SNS_LINK_MAX_LENGTH}文字以内で入力してください`;
+    errors.websiteUrl = t("profile.edit.validation.urlTooLong", { max: SNS_LINK_MAX_LENGTH });
   }
 
   return errors;
@@ -124,6 +129,7 @@ export function validateProfileForm(data: ProfileFormData): FormErrors {
  * NativeWindダークテーマ対応。
  */
 export default function ProfileEditScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const user = useAuthStore((s) => s.user);
   const { toast, show: showToast, dismiss: dismissToast } = useToast();
@@ -164,7 +170,7 @@ export default function ProfileEditScreen() {
     const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
 
     if (!permissionResult.granted) {
-      Alert.alert("権限エラー", "画像ライブラリへのアクセスが許可されていません");
+      Alert.alert(t("common.errorTitle"), t("profile.edit.permissionError"));
       return;
     }
 
@@ -178,10 +184,10 @@ export default function ProfileEditScreen() {
     if (!result.canceled && result.assets[0]) {
       setAvatarUri(result.assets[0].uri);
     }
-  }, []);
+  }, [t]);
 
   const handleSave = useCallback(async () => {
-    const validationErrors = validateProfileForm(formData);
+    const validationErrors = validateProfileForm(formData, t);
 
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
@@ -192,14 +198,14 @@ export default function ProfileEditScreen() {
 
     try {
       await new Promise((resolve) => setTimeout(resolve, 500));
-      showToast("プロフィールを更新しました", "success");
+      showToast(t("profile.edit.saveSuccess"), "success");
       router.back();
     } catch {
-      Alert.alert("エラー", "プロフィールの保存に失敗しました");
+      Alert.alert(t("common.errorTitle"), t("profile.edit.saveFailed"));
     } finally {
       setIsSaving(false);
     }
-  }, [formData, router, showToast]);
+  }, [formData, router, showToast, t]);
 
   const displayName = formData.name || user?.name || "";
 
@@ -216,12 +222,12 @@ export default function ProfileEditScreen() {
           testID="profile-edit-back-button"
           onPress={handleBack}
           accessibilityRole="button"
-          accessibilityLabel="戻る"
+          accessibilityLabel={t("profile.back")}
           hitSlop={8}
         >
           <ArrowLeft size={BACK_ICON_SIZE} color={TEXT_COLOR} />
         </Pressable>
-        <Text className="text-lg font-bold text-text">プロフィール編集</Text>
+        <Text className="text-lg font-bold text-text">{t("profile.edit.title")}</Text>
         <View style={{ width: BACK_ICON_SIZE }} />
       </View>
 
@@ -235,7 +241,7 @@ export default function ProfileEditScreen() {
             testID="profile-edit-avatar-button"
             onPress={handlePickAvatar}
             accessibilityRole="button"
-            accessibilityLabel="アバター画像を変更"
+            accessibilityLabel={t("profile.edit.avatarLabel")}
           >
             {avatarUri ? (
               <Image
@@ -292,8 +298,8 @@ export default function ProfileEditScreen() {
 
         <View className="px-4 gap-4">
           <Input
-            label="名前"
-            placeholder="名前を入力"
+            label={t("profile.edit.nameLabel")}
+            placeholder={t("profile.edit.namePlaceholder")}
             value={formData.name}
             onChangeText={(text) => updateField("name", text)}
             error={errors.name}
@@ -301,8 +307,8 @@ export default function ProfileEditScreen() {
           />
 
           <Input
-            label="ユーザー名"
-            placeholder="username"
+            label={t("profile.edit.usernameLabel")}
+            placeholder={t("profile.edit.usernamePlaceholder")}
             value={formData.username}
             onChangeText={(text) => updateField("username", text)}
             error={errors.username}
@@ -310,8 +316,8 @@ export default function ProfileEditScreen() {
           />
 
           <Input
-            label="自己紹介"
-            placeholder="自己紹介を入力"
+            label={t("profile.edit.bioLabel")}
+            placeholder={t("profile.edit.bioPlaceholder")}
             value={formData.bio}
             onChangeText={(text) => updateField("bio", text)}
             error={errors.bio}
@@ -319,7 +325,9 @@ export default function ProfileEditScreen() {
           />
 
           <View className="pt-2">
-            <Text className="text-text font-semibold text-base mb-3">SNSリンク</Text>
+            <Text className="text-text font-semibold text-base mb-3">
+              {t("profile.edit.snsLinks")}
+            </Text>
 
             <View className="gap-4">
               <Input
@@ -361,7 +369,7 @@ export default function ProfileEditScreen() {
               </View>
             ) : (
               <Button onPress={handleSave} disabled={isSaving}>
-                保存する
+                {t("profile.edit.saveButton")}
               </Button>
             )}
           </View>

--- a/apps/mobile/app/profile/followers.tsx
+++ b/apps/mobile/app/profile/followers.tsx
@@ -83,6 +83,7 @@ function createPlaceholderFollowing(): UserItem[] {
 type UserListItemProps = {
   item: UserItem;
   onPress: (userId: string) => void;
+  userProfileLabel: string;
 };
 
 /**
@@ -90,9 +91,9 @@ type UserListItemProps = {
  *
  * @param item - 表示するユーザーデータ
  * @param onPress - タップ時のコールバック
+ * @param userProfileLabel - アクセシビリティラベル（翻訳済み文字列）
  */
-function UserListItem({ item, onPress }: UserListItemProps) {
-  const { t } = useTranslation();
+function UserListItem({ item, onPress, userProfileLabel }: UserListItemProps) {
   const handlePress = useCallback(() => {
     onPress(item.id);
   }, [item.id, onPress]);
@@ -102,7 +103,7 @@ function UserListItem({ item, onPress }: UserListItemProps) {
       testID={`user-item-${item.id}`}
       onPress={handlePress}
       accessibilityRole="button"
-      accessibilityLabel={t("profile.followers.userProfileLabel", { name: item.name })}
+      accessibilityLabel={userProfileLabel}
       className="flex-row items-center gap-3 px-4 py-3 border-b border-border"
     >
       {item.avatarUrl ? (
@@ -185,8 +186,14 @@ export default function FollowersScreen() {
   }, []);
 
   const renderItem = useCallback(
-    ({ item }: { item: UserItem }) => <UserListItem item={item} onPress={handleUserPress} />,
-    [handleUserPress],
+    ({ item }: { item: UserItem }) => (
+      <UserListItem
+        item={item}
+        onPress={handleUserPress}
+        userProfileLabel={t("profile.followers.userProfileLabel", { name: item.name })}
+      />
+    ),
+    [handleUserPress, t],
   );
 
   const keyExtractor = useCallback((item: UserItem) => item.id, []);

--- a/apps/mobile/app/profile/followers.tsx
+++ b/apps/mobile/app/profile/followers.tsx
@@ -2,6 +2,7 @@ import { Image } from "expo-image";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { ArrowLeft } from "lucide-react-native";
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ActivityIndicator, FlatList, Pressable, Text, View } from "react-native";
 
 import { DARK_COLORS } from "@/lib/constants";
@@ -91,6 +92,7 @@ type UserListItemProps = {
  * @param onPress - タップ時のコールバック
  */
 function UserListItem({ item, onPress }: UserListItemProps) {
+  const { t } = useTranslation();
   const handlePress = useCallback(() => {
     onPress(item.id);
   }, [item.id, onPress]);
@@ -100,7 +102,7 @@ function UserListItem({ item, onPress }: UserListItemProps) {
       testID={`user-item-${item.id}`}
       onPress={handlePress}
       accessibilityRole="button"
-      accessibilityLabel={`${item.name}のプロフィールを表示`}
+      accessibilityLabel={t("profile.followers.userProfileLabel", { name: item.name })}
       className="flex-row items-center gap-3 px-4 py-3 border-b border-border"
     >
       {item.avatarUrl ? (
@@ -154,6 +156,7 @@ function UserListItem({ item, onPress }: UserListItemProps) {
  * クエリパラメータ `tab` で初期タブを指定可能（"followers" | "following"）。
  */
 export default function FollowersScreen() {
+  const { t } = useTranslation();
   const { tab } = useLocalSearchParams<{ tab?: string }>();
   const router = useRouter();
 
@@ -193,13 +196,15 @@ export default function FollowersScreen() {
       return null;
     }
     const message =
-      activeTab === "followers" ? "フォロワーはまだいません" : "フォロー中のユーザーはいません";
+      activeTab === "followers"
+        ? t("profile.followers.noFollowers")
+        : t("profile.followers.noFollowing");
     return (
       <View testID="followers-empty" className="items-center py-12 px-4">
         <Text className="text-text-muted text-sm text-center">{message}</Text>
       </View>
     );
-  }, [activeTab, isLoading]);
+  }, [activeTab, isLoading, t]);
 
   return (
     <View testID="followers-screen" className="flex-1 bg-background">
@@ -208,13 +213,15 @@ export default function FollowersScreen() {
           testID="followers-back-button"
           onPress={handleBack}
           accessibilityRole="button"
-          accessibilityLabel="戻る"
+          accessibilityLabel={t("common.back")}
           hitSlop={8}
         >
           <ArrowLeft size={BACK_ICON_SIZE} color={TEXT_COLOR} />
         </Pressable>
         <Text className="text-lg font-bold text-text">
-          {activeTab === "followers" ? "フォロワー" : "フォロー中"}
+          {activeTab === "followers"
+            ? t("profile.followers.followersTab")
+            : t("profile.followers.followingTab")}
         </Text>
         <View style={{ width: BACK_ICON_SIZE }} />
       </View>
@@ -239,7 +246,7 @@ export default function FollowersScreen() {
                 : "text-sm text-text-muted"
             }
           >
-            フォロワー
+            {t("profile.followers.followersTab")}
           </Text>
         </Pressable>
         <Pressable
@@ -261,7 +268,7 @@ export default function FollowersScreen() {
                 : "text-sm text-text-muted"
             }
           >
-            フォロー中
+            {t("profile.followers.followingTab")}
           </Text>
         </Pressable>
       </View>
@@ -269,7 +276,7 @@ export default function FollowersScreen() {
       {isLoading ? (
         <View testID="followers-loading" className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={PRIMARY_COLOR} />
-          <Text className="text-text-muted mt-3">読み込み中...</Text>
+          <Text className="text-text-muted mt-3">{t("profile.followers.loading")}</Text>
         </View>
       ) : (
         <FlatList

--- a/apps/mobile/src/components/ProfileHeader.tsx
+++ b/apps/mobile/src/components/ProfileHeader.tsx
@@ -1,5 +1,6 @@
 import { Image } from "expo-image";
 import { Settings } from "lucide-react-native";
+import { useTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
 
 import { DARK_COLORS } from "@/lib/constants";
@@ -73,6 +74,7 @@ function formatCount(count: number): string {
  * @param onSettingsPress - 設定アイコンタップ時のコールバック
  */
 export function ProfileHeader({ user, onSettingsPress }: ProfileHeaderProps) {
+  const { t } = useTranslation();
   return (
     <View testID="profile-header" className="px-4 pt-4 pb-6 bg-surface border-b border-border">
       <View className="flex-row items-start justify-between mb-4">
@@ -119,7 +121,7 @@ export function ProfileHeader({ user, onSettingsPress }: ProfileHeaderProps) {
             testID="profile-settings-button"
             onPress={onSettingsPress}
             accessibilityRole="button"
-            accessibilityLabel="設定"
+            accessibilityLabel={t("tabs.settings")}
             hitSlop={8}
             className="p-1"
           >
@@ -133,13 +135,13 @@ export function ProfileHeader({ user, onSettingsPress }: ProfileHeaderProps) {
           <Text testID="profile-followers-count" className="text-lg font-bold text-text">
             {formatCount(user.followersCount)}
           </Text>
-          <Text className="text-xs text-text-muted">フォロワー</Text>
+          <Text className="text-xs text-text-muted">{t("profile.followers.followersTab")}</Text>
         </View>
         <View className="items-center">
           <Text testID="profile-following-count" className="text-lg font-bold text-text">
             {formatCount(user.followingCount)}
           </Text>
-          <Text className="text-xs text-text-muted">フォロー中</Text>
+          <Text className="text-xs text-text-muted">{t("profile.followers.followingTab")}</Text>
         </View>
       </View>
     </View>

--- a/apps/mobile/src/components/ui/skeletons/ProfileSkeleton.tsx
+++ b/apps/mobile/src/components/ui/skeletons/ProfileSkeleton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { View } from "react-native";
 
 import { Skeleton } from "../Skeleton";
@@ -21,11 +22,12 @@ const STAT_WIDTH = 60;
  * プロフィール画面のローディングスケルトン
  */
 export function ProfileSkeleton() {
+  const { t } = useTranslation();
   return (
     <View
       className="items-center px-4 pt-8"
-      accessibilityLabel="プロフィールを読み込み中"
-      accessibilityHint="しばらくお待ちください"
+      accessibilityLabel={t("profile.loadingUser")}
+      accessibilityHint={t("common.loading")}
       accessible={true}
     >
       <Skeleton width={AVATAR_SIZE} height={AVATAR_SIZE} borderRadius={40} />

--- a/apps/mobile/src/components/ui/skeletons/ProfileSkeleton.tsx
+++ b/apps/mobile/src/components/ui/skeletons/ProfileSkeleton.tsx
@@ -27,7 +27,7 @@ export function ProfileSkeleton() {
     <View
       className="items-center px-4 pt-8"
       accessibilityLabel={t("profile.loadingUser")}
-      accessibilityHint={t("common.loading")}
+      accessibilityHint={t("profile.loadingHint")}
       accessible={true}
     >
       <Skeleton width={AVATAR_SIZE} height={AVATAR_SIZE} borderRadius={40} />

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -156,6 +156,9 @@
     "guestUser": "Guest",
     "loadingUser": "Loading...",
     "fetchError": "Failed to fetch user info",
+    "retryHint": "Retry fetching user info",
+    "backHint": "Go back to the previous screen",
+    "loadingHint": "Please wait a moment",
     "back": "Back",
     "edit": {
       "title": "Edit Profile",

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -159,6 +159,9 @@
     "back": "Back",
     "edit": {
       "title": "Edit Profile",
+      "nameLabel": "Name",
+      "usernameLabel": "Username",
+      "bioLabel": "Bio",
       "namePlaceholder": "Enter your name",
       "usernamePlaceholder": "username",
       "bioPlaceholder": "Enter your bio",

--- a/apps/mobile/src/locales/ja.json
+++ b/apps/mobile/src/locales/ja.json
@@ -156,6 +156,9 @@
     "guestUser": "ゲストユーザー",
     "loadingUser": "読み込み中...",
     "fetchError": "ユーザー情報の取得に失敗しました",
+    "retryHint": "ユーザー情報の取得を再試行します",
+    "backHint": "前の画面に戻ります",
+    "loadingHint": "しばらくお待ちください",
     "back": "戻る",
     "edit": {
       "title": "プロフィール編集",

--- a/apps/mobile/src/locales/ja.json
+++ b/apps/mobile/src/locales/ja.json
@@ -159,6 +159,9 @@
     "back": "戻る",
     "edit": {
       "title": "プロフィール編集",
+      "nameLabel": "名前",
+      "usernameLabel": "ユーザー名",
+      "bioLabel": "自己紹介",
       "namePlaceholder": "名前を入力",
       "usernamePlaceholder": "username",
       "bioPlaceholder": "自己紹介を入力",

--- a/apps/mobile/src/locales/ko.json
+++ b/apps/mobile/src/locales/ko.json
@@ -162,6 +162,9 @@
     "back": "뒤로",
     "edit": {
       "title": "프로필 편집",
+      "nameLabel": "이름",
+      "usernameLabel": "사용자 이름",
+      "bioLabel": "자기소개",
       "namePlaceholder": "이름을 입력하세요",
       "usernamePlaceholder": "username",
       "bioPlaceholder": "자기소개를 입력하세요",

--- a/apps/mobile/src/locales/ko.json
+++ b/apps/mobile/src/locales/ko.json
@@ -156,6 +156,9 @@
     "guestUser": "게스트 사용자",
     "loadingUser": "불러오는 중...",
     "fetchError": "사용자 정보를 불러오는데 실패했습니다",
+    "retryHint": "사용자 정보를 다시 불러옵니다",
+    "backHint": "이전 화면으로 돌아갑니다",
+    "loadingHint": "잠시 기다려 주세요",
     "back": "뒤로",
     "edit": {
       "title": "프로필 편집",

--- a/apps/mobile/src/locales/zh-CN.json
+++ b/apps/mobile/src/locales/zh-CN.json
@@ -162,6 +162,9 @@
     "back": "返回",
     "edit": {
       "title": "编辑个人资料",
+      "nameLabel": "姓名",
+      "usernameLabel": "用户名",
+      "bioLabel": "简介",
       "namePlaceholder": "请输入姓名",
       "usernamePlaceholder": "username",
       "bioPlaceholder": "请输入个人简介",

--- a/apps/mobile/src/locales/zh-CN.json
+++ b/apps/mobile/src/locales/zh-CN.json
@@ -156,6 +156,9 @@
     "guestUser": "访客用户",
     "loadingUser": "加载中...",
     "fetchError": "获取用户信息失败",
+    "retryHint": "重新获取用户信息",
+    "backHint": "返回上一个页面",
+    "loadingHint": "请稍候",
     "back": "返回",
     "edit": {
       "title": "编辑个人资料",

--- a/apps/mobile/src/locales/zh-TW.json
+++ b/apps/mobile/src/locales/zh-TW.json
@@ -156,6 +156,9 @@
     "guestUser": "訪客用戶",
     "loadingUser": "載入中...",
     "fetchError": "取得用戶資訊失敗",
+    "retryHint": "重新取得用戶資訊",
+    "backHint": "返回上一個頁面",
+    "loadingHint": "請稍候",
     "back": "返回",
     "edit": {
       "title": "編輯個人資料",

--- a/apps/mobile/src/locales/zh-TW.json
+++ b/apps/mobile/src/locales/zh-TW.json
@@ -162,6 +162,9 @@
     "back": "返回",
     "edit": {
       "title": "編輯個人資料",
+      "nameLabel": "姓名",
+      "usernameLabel": "使用者名稱",
+      "bioLabel": "簡介",
       "namePlaceholder": "請輸入姓名",
       "usernamePlaceholder": "username",
       "bioPlaceholder": "請輸入個人簡介",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,7 +96,7 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@20.0.3)(vite@8.0.7(@types/node@25.5.0)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
-        specifier: ^4.7.0
+        specifier: 4.77.0
         version: 4.77.0(@cloudflare/workers-types@4.20260317.1)
 
   apps/mobile:


### PR DESCRIPTION
## Summary
- profile・followers・settings 周辺の6画面で `useTranslation` を導入
- ハードコード日本語文字列を翻訳キーに置き換え
- 全5ロケールに対応するキーを追加

## Test plan
- [ ] 各画面が正常に表示されることを確認
- [ ] 英語切り替え時に英語テキストが表示されることを確認

Closes #849

🤖 Generated with [Claude Code](https://claude.ai/code)