### PR TITLE
design(theme): ライト/ダークテーマのブランドカラー方針を再設計 #855

### DIFF
--- a/apps/mobile/src/lib/constants.ts
+++ b/apps/mobile/src/lib/constants.ts
@@ -57,19 +57,31 @@ type ThemeColors = {
 /**
  * ライト/ダーク共通で使う意味ベースのカラー
  *
- * アーキテクチャ:
+ * ## アーキテクチャ
  * - SEMANTIC_COLORS（共有）→ LIGHT_COLORS（ライトテーマ）にスプレッド
  * - SEMANTIC_COLORS（共有）→ DARK_COLORS（ダークテーマ）にスプレッド
- * - error / success / warning / accent / favorite / neutral / white はここで一元管理
+ * - error / success / warning / favorite / neutral / white はここで一元管理
+ *
+ * ## accent トークンについて
+ * 現在 accent = "#14b8a6" は Primary と同値。
+ * TODO(#855): Primary に一本化し accent トークンを削除する（docs/mobile-theme.md 移行タスク#2 参照）
+ *
+ * ## 新色を追加するルール
+ * - 既存トークンでカバーできない意味的状態が新たに生まれたときのみ追加する
+ * - グラデーション・ネオン・蛍光系カラーは禁止（AIっぽい印象を避けるため）
+ * - 追加時は docs/mobile-theme.md にも記載すること
  */
 const SEMANTIC_COLORS = {
-  /** アクセントカラー */
+  /**
+   * アクセントカラー（Primary と同値）
+   * @deprecated Primary に一本化予定。docs/mobile-theme.md 移行タスク#2 参照
+   */
   accent: "#14b8a6",
-  /** エラー色 */
+  /** エラー色（危険操作・失敗状態） */
   error: "#ef4444",
-  /** 成功色 */
+  /** 成功色（完了・OK状態） */
   success: "#22c55e",
-  /** 警告色 */
+  /** 警告色（注意が必要な状態） */
   warning: "#f59e0b",
   /** お気に入りやいいねに使う赤色 */
   favorite: "#ef4444",
@@ -82,6 +94,14 @@ const SEMANTIC_COLORS = {
 /**
  * ライトテーマカラー定義
  * SEMANTIC_COLORS の共有セマンティック色 + ライト固有のレイアウト色で構成
+ *
+ * ## Primary カラーについて
+ * primary = "#14b8a6"（Teal）をブランドメインカラーとして採用。
+ * ダークテーマも同色に統一する予定。docs/mobile-theme.md 参照
+ *
+ * ## サーフェスカラーについて
+ * background / surface / card / border はテーマ固有の値であり、
+ * テーマ切替時に LIGHT_COLORS / DARK_COLORS を useColorScheme で動的に選択すること
  */
 export const LIGHT_COLORS = {
   /** 背景色 */
@@ -114,6 +134,11 @@ export const LIGHT_COLORS = {
 /**
  * ダークテーマカラー定義
  * SEMANTIC_COLORS の共有セマンティック色 + ダーク固有のレイアウト色で構成
+ *
+ * ## Primary カラーについて
+ * 現在 primary = "#6366f1"（Indigo）はライトテーマ（Teal #14b8a6）と色相が異なり、
+ * ブランドが分裂している。
+ * TODO(#855): "#14b8a6"（Teal）に統一する。docs/mobile-theme.md 移行タスク#1 参照
  */
 export const DARK_COLORS = {
   /** アプリ全体の背景色 */
@@ -124,9 +149,15 @@ export const DARK_COLORS = {
   card: "#1a1a2e",
   /** 境界線色 */
   border: "#2d2d44",
-  /** プライマリアクション色 */
+  /**
+   * プライマリアクション色
+   * TODO(#855): "#14b8a6"（Teal）に変更してブランドカラーを統一する
+   */
   primary: "#6366f1",
-  /** プライマリの明色 */
+  /**
+   * プライマリの明色
+   * TODO(#855): primary 変更後は "#5eead4"（Teal-300）に合わせる
+   */
   primaryLight: "#818cf8",
   /** 主要テキスト色 */
   text: "#e2e8f0",

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -1,25 +1,50 @@
-/** @type {import('tailwindcss').Config} */
+/**
+ * TechClip Mobile - Tailwind / NativeWind カラー設定
+ *
+ * ## 現状の注意
+ * この設定はダークテーマの値のみを登録している。
+ * ライトテーマ対応は docs/mobile-theme.md の移行タスク#3 で実施予定。
+ *
+ * ## Primary カラーについて
+ * primary.DEFAULT = "#6366f1"（Indigo）は将来 "#14b8a6"（Teal）に変更予定。
+ * ブランドカラー方針は docs/mobile-theme.md を参照すること。
+ *
+ * ## 新色を追加するルール
+ * - 追加前に docs/mobile-theme.md のカラー方針を確認する
+ * - グラデーション・ネオン・蛍光系カラーは禁止
+ * - LIGHT_COLORS / DARK_COLORS（constants.ts）と値を同期させること
+ *
+ * @type {import('tailwindcss').Config}
+ */
 module.exports = {
   content: ["./app/**/*.{ts,tsx}", "./src/**/*.{ts,tsx}"],
   presets: [require("nativewind/preset")],
   theme: {
     extend: {
       colors: {
+        // サーフェスカラー（ダークテーマ固有）
+        // TODO(#855): ライトテーマ対応時に CSS 変数または dark: バリアントに移行する
         background: "#0a0a0f",
         surface: "#13131a",
         card: "#1a1a2e",
+        // Primary カラー
+        // TODO(#855): "#14b8a6"（Teal）に統一する（docs/mobile-theme.md 移行タスク#1 参照）
         primary: {
           DEFAULT: "#6366f1",
           light: "#818cf8",
           dark: "#4f46e5",
         },
+        // accent は Primary（Teal）と同値のため将来削除予定
+        // TODO(#855): 削除して primary を使用する（docs/mobile-theme.md 移行タスク#2 参照）
         accent: "#f59e0b",
+        // テキストカラー（ダークテーマ固有）
         text: {
           DEFAULT: "#e2e8f0",
           muted: "#94a3b8",
           dim: "#64748b",
         },
         border: "#2d2d44",
+        // セマンティックカラー（ライト/ダーク共通）
         success: "#22c55e",
         error: "#ef4444",
         warning: "#f59e0b",

--- a/apps/mobile/tailwind.config.js
+++ b/apps/mobile/tailwind.config.js
@@ -34,8 +34,8 @@ module.exports = {
           light: "#818cf8",
           dark: "#4f46e5",
         },
-        // accent は Primary（Teal）と同値のため将来削除予定
-        // TODO(#855): 削除して primary を使用する（docs/mobile-theme.md 移行タスク#2 参照）
+        // ⚠️ この値 (#f59e0b=Amber) は constants.ts の accent (#14b8a6=Teal) と異なる。
+        // TODO(#855): constants.ts と値を合わせたうえで、移行タスク#2 で削除する。
         accent: "#f59e0b",
         // テキストカラー（ダークテーマ固有）
         text: {

--- a/docs/mobile-theme.md
+++ b/docs/mobile-theme.md
@@ -89,13 +89,16 @@ Primary スケール（Tailwind Teal ベース）
 セマンティックカラーはライト / ダーク共通で同一値を使用する。
 色だけで意味を伝えないよう、アイコンやラベルと組み合わせること。
 
-| トークン | 値 | 用途 |
-|---------|-----|------|
-| `success` | `#22c55e` | 成功状態（完了、OK） |
-| `error` | `#ef4444` | エラー状態、危険操作 |
-| `warning` | `#f59e0b` | 警告、注意が必要な状態 |
-| `info` | `#3b82f6` | 情報、ヒント |
-| `favorite` | `#ef4444` | お気に入り / いいね（赤） |
+| トークン | 値 | 用途 | 現在の定義場所 |
+|---------|-----|------|--------------|
+| `success` | `#22c55e` | 成功状態（完了、OK） | `SEMANTIC_COLORS` |
+| `error` | `#ef4444` | エラー状態、危険操作 | `SEMANTIC_COLORS` |
+| `warning` | `#f59e0b` | 警告、注意が必要な状態 | `SEMANTIC_COLORS` |
+| `info` | `#3b82f6` | 情報、ヒント | `LIGHT_COLORS` / `DARK_COLORS`（タスク #7 で `SEMANTIC_COLORS` に移行予定） |
+| `favorite` | `#ef4444` | お気に入り / いいね（赤） | `SEMANTIC_COLORS` |
+
+> **注意**: `info` は現状 `LIGHT_COLORS` / `DARK_COLORS` に定義されている。
+> 両テーマで同一値（`#3b82f6`）を使用しており、将来 `SEMANTIC_COLORS` に集約する予定（移行タスク #7）。
 
 セマンティックカラーの `successSurface` / `dangerSurface` はテーマ固有のため、
 ライト / ダークそれぞれに定義する（現状どおり `LIGHT_COLORS` / `DARK_COLORS` に含める）。
@@ -145,6 +148,7 @@ Primary スケール（Tailwind Teal ベース）
 | 4 | `_layout.tsx` の `|| true` を除去し、`useColorScheme` に完全対応 | `_layout.tsx` |
 | 5 | `article/[id].tsx` のカラー参照をテーマ動的切替に対応 | `article/[id].tsx` |
 | 6 | `ThemeColors` 型から `accent` トークンを削除（Primary 一本化後） | `constants.ts` |
+| 7 | `LIGHT_COLORS.info` / `DARK_COLORS.info` を `SEMANTIC_COLORS` に移動 | `constants.ts` |
 
 ---
 

--- a/docs/mobile-theme.md
+++ b/docs/mobile-theme.md
@@ -143,7 +143,7 @@ Primary スケール（Tailwind Teal ベース）
 | # | 内容 | 関連ファイル |
 |---|------|-------------|
 | 1 | `DARK_COLORS.primary` を `#6366f1` → `#14b8a6` に変更 | `constants.ts`, `tailwind.config.js` |
-| 2 | `SEMANTIC_COLORS.accent` を削除し `primary` に一本化 | `constants.ts` |
+| 2 | `SEMANTIC_COLORS.accent` を削除し `primary` に一本化 | `constants.ts`, `tailwind.config.js` |
 | 3 | `tailwind.config.js` にライトテーマ対応の CSS 変数 or `dark:` バリアントを追加 | `tailwind.config.js`, `global.css` |
 | 4 | `_layout.tsx` の `|| true` を除去し、`useColorScheme` に完全対応 | `_layout.tsx` |
 | 5 | `article/[id].tsx` のカラー参照をテーマ動的切替に対応 | `article/[id].tsx` |

--- a/docs/mobile-theme.md
+++ b/docs/mobile-theme.md
@@ -1,0 +1,156 @@
+# モバイルアプリ テーマカラー設計方針
+
+## 概要
+
+TechClip モバイルアプリのライト / ダークテーマにおけるブランドカラーの設計方針を明文化する。
+現状の色設計の問題点を整理し、今後の変更判断の基準を定める。
+
+---
+
+## 現状の問題点
+
+### 1. Primary カラーのブランド分裂
+
+| テーマ | Primary 色 | 色相 |
+|--------|-----------|------|
+| ライト (`LIGHT_COLORS.primary`) | `#14b8a6` | Teal（青緑） |
+| ダーク (`DARK_COLORS.primary`) | `#6366f1` | Indigo（青紫） |
+
+ブランドを象徴する Primary カラーが、ライト / ダークで異なる色相を使用しており、
+ブランド統一感が失われている。
+
+### 2. tailwind.config.js がダーク専用
+
+`tailwind.config.js` の `colors` 定義はダークテーマの値のみが登録されており、
+ライトテーマでの NativeWind ユーティリティクラス利用が想定されていない。
+
+### 3. ライトテーマが事実上無効
+
+`app/(tabs)/_layout.tsx` に以下のコードがあり、ライトテーマが強制的に無効化されている。
+
+```typescript
+// TODO: ライトモード対応時に `|| true` を除去
+const isDark = colorScheme === "dark" || true;
+```
+
+`article/[id].tsx` も `DARK_COLORS` のみを参照し、ライトテーマ対応コードが存在しない。
+
+---
+
+## カラー方針の定義
+
+### Primary（ブランドメインカラー）
+
+**決定事項: `#14b8a6`（Teal）をブランド Primary として統一する**
+
+- ライト / ダーク共通のブランドアイデンティティを表現する
+- CTA ボタン、選択状態、リンク、アクティブタブに使用する
+- Indigo（`#6366f1`）は `DARK_COLORS.primary` から削除し Teal に統一する
+
+```
+Primary スケール（Tailwind Teal ベース）
+  primary-50:  #f0fdfa  ← ライト: 薄い背景
+  primary-100: #ccfbf1
+  primary-200: #99f6e4
+  primary-300: #5eead4  ← primaryLight（ライト）
+  primary-400: #2dd4bf
+  primary-500: #14b8a6  ← PRIMARY（両テーマ共通）
+  primary-600: #0d9488  ← primaryDark（ライト）
+  primary-700: #0f766e  ← primaryDark（ダーク）
+  primary-800: #115e59
+  primary-900: #134e4a
+  primary-950: #042f2e  ← ダーク: 薄い強調背景
+```
+
+### Accent（アクセントカラー）
+
+**決定事項: `#14b8a6`（Teal）を Primary と兼用し、独立した Accent は廃止する**
+
+- 現在 `SEMANTIC_COLORS.accent` = `#14b8a6` は Primary と同一値
+- Primary / Accent の二重管理を廃止し、`primary` トークンに一本化する
+- 独立した Accent カラーが必要な場合は Secondary として別途定義する
+
+### Surface（サーフェスカラー）
+
+サーフェスはテーマ固有の色であり、ライト / ダークで異なる値を持つ。
+
+| トークン | ライト | ダーク | 用途 |
+|---------|--------|--------|------|
+| `background` | `#fafaf9` | `#0a0a0f` | 全体の背景 |
+| `surface` | `#ffffff` | `#13131a` | セクション / ヘッダー背景 |
+| `card` | `#ffffff` | `#1a1a2e` | カード / モーダル背景 |
+| `border` | `#e7e5e4` | `#2d2d44` | 区切り線 / 枠線 |
+
+サーフェスカラーは **テーマ切替時に必ず切り替わる**ことを前提に設計する。
+`const` で固定せず、`useColorScheme` の値に基づいて動的に選択する。
+
+### Semantic（セマンティックカラー）
+
+セマンティックカラーはライト / ダーク共通で同一値を使用する。
+色だけで意味を伝えないよう、アイコンやラベルと組み合わせること。
+
+| トークン | 値 | 用途 |
+|---------|-----|------|
+| `success` | `#22c55e` | 成功状態（完了、OK） |
+| `error` | `#ef4444` | エラー状態、危険操作 |
+| `warning` | `#f59e0b` | 警告、注意が必要な状態 |
+| `info` | `#3b82f6` | 情報、ヒント |
+| `favorite` | `#ef4444` | お気に入り / いいね（赤） |
+
+セマンティックカラーの `successSurface` / `dangerSurface` はテーマ固有のため、
+ライト / ダークそれぞれに定義する（現状どおり `LIGHT_COLORS` / `DARK_COLORS` に含める）。
+
+### テキストカラー
+
+| トークン | ライト | ダーク | 用途 |
+|---------|--------|--------|------|
+| `text` | `#1c1917` | `#e2e8f0` | 本文テキスト |
+| `textMuted` | `#57534e` | `#94a3b8` | 補助テキスト、説明文 |
+| `textDim` | `#78716c` | `#64748b` | 非アクティブ状態、メタ情報 |
+
+---
+
+## 新色を追加する際のルール
+
+### 追加できる状況
+
+1. **既存トークンでカバーできない意味的な状態**が新たに生まれたとき
+   - 例: `premium`（有料機能の強調）、`caution`（warningより軽微な注意）
+2. **ブランドの第2アクセントカラー**（Secondary）が製品上必要になったとき
+
+### 追加してはいけない状況
+
+- 既存トークンで表現可能なケース（色の微調整だけで新トークン不要）
+- デザインの気分転換や「見た目が良い」だけの理由
+- グラデーション・ネオン・蛍光系カラー（AIっぽい印象を生むため禁止）
+
+### 追加手順
+
+1. `docs/mobile-theme.md`（本ドキュメント）の該当セクションにトークンを追記する
+2. `apps/mobile/src/lib/constants.ts` の `ThemeColors` 型と `LIGHT_COLORS` / `DARK_COLORS`（またはSEMANTIC_COLORS）に追加する
+3. `apps/mobile/tailwind.config.js` に対応するユーティリティクラスを追加する
+4. 使用箇所のコンポーネントに NativeWind クラスまたはトークン参照を追加する
+
+---
+
+## 移行タスク
+
+以下は今後のチケットで対応する作業一覧。
+
+| # | 内容 | 関連ファイル |
+|---|------|-------------|
+| 1 | `DARK_COLORS.primary` を `#6366f1` → `#14b8a6` に変更 | `constants.ts`, `tailwind.config.js` |
+| 2 | `SEMANTIC_COLORS.accent` を削除し `primary` に一本化 | `constants.ts` |
+| 3 | `tailwind.config.js` にライトテーマ対応の CSS 変数 or `dark:` バリアントを追加 | `tailwind.config.js`, `global.css` |
+| 4 | `_layout.tsx` の `|| true` を除去し、`useColorScheme` に完全対応 | `_layout.tsx` |
+| 5 | `article/[id].tsx` のカラー参照をテーマ動的切替に対応 | `article/[id].tsx` |
+| 6 | `ThemeColors` 型から `accent` トークンを削除（Primary 一本化後） | `constants.ts` |
+
+---
+
+## 参照
+
+- 実装ファイル: `apps/mobile/src/lib/constants.ts`
+- Tailwind 設定: `apps/mobile/tailwind.config.js`
+- デザイン規約: `.claude/rules/frontend-design.md`
+- 親 Issue: #823


### PR DESCRIPTION
## Summary
- `docs/mobile-theme.md` を新規作成: ブランドカラーポリシー、プライマリ/セカンダリ/ニュートラルカラーの設計方針を文書化

## Test plan
- [ ] ドキュメントが完全であることを確認

Closes #855

🤖 Generated with [Claude Code](https://claude.ai/code)