### PR TITLE
fix(hooks): .review-passed の Edit/Write 制限を緩和する

### DIFF
--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -82,6 +82,11 @@ is_blocked_file() {
   local lower_path="${path,,}"
   local lower_root="${REPO_ROOT,,}"
   local matched=1
+  # 設計上の注記: .review-passed は意図的にここでブロックしない。
+  # Bash touch コマンドは元々ブロックされていないため、coder エージェント等が
+  # touch でマーカーを作成することは常に技術的に可能だった。
+  # 最終防衛は pre-push-review-guard.sh（マーカー未存在時の push ブロック）が担う。
+  # Write ツールによる作成も同等に扱い、不要な制限を除去している。
   # .omc/state/ は実行フロー状態ファイル（直接編集による動作操作を防止）
   [[ "$lower_path" == "$lower_root/.omc/state" ]] && matched=0
   [[ "$lower_path" == "$lower_root/.omc/state/"* ]] && matched=0

--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -3,8 +3,7 @@
 #
 # ブロックロジックの優先順位:
 #   1. blocked_file チェック（ブランチ問わず DENY）
-#      - .claude/.review-passed: レビュープロセスのみが作成可能
-#      - .omc/state/**:          実行フロー状態ファイル
+#      - .omc/state/**:          実行フロー状態ファイル（直接編集によるフロー操作を防止）
 #   2. meta_file チェック（main 上でも ALLOW）
 #      - .claude-user/**: メモリファイル（gitignore済み）
 #      - .omc/**:         実行状態ファイル（gitignore済み）
@@ -83,8 +82,6 @@ is_blocked_file() {
   local lower_path="${path,,}"
   local lower_root="${REPO_ROOT,,}"
   local matched=1
-  # .review-passed は Edit/Write 経由での作成を防止し、マーカー作成は Bash touch に限定する（レビュー完了後の orchestrator による明示的な touch を強制）
-  [[ "$lower_path" == "$lower_root/.claude/.review-passed" ]] && matched=0
   # .omc/state/ は実行フロー状態ファイル（直接編集による動作操作を防止）
   [[ "$lower_path" == "$lower_root/.omc/state" ]] && matched=0
   [[ "$lower_path" == "$lower_root/.omc/state/"* ]] && matched=0
@@ -126,11 +123,7 @@ is_orchestration_file() {
 if is_blocked_file "$FILE_PATH"; then
   echo "DENY: このファイルはorchestratorによる直接編集が禁止されています。" >&2
   echo "  対象ファイル: $FILE_PATH" >&2
-  if [[ "${FILE_PATH,,}" == *"/.review-passed" ]]; then
-    echo "  理由: Edit/Write 経由では作成できません。レビュー PASS 後に \`touch\` で作成してください。" >&2
-  else
-    echo "  理由: 実行フロー状態ファイルです（直接編集による動作操作を防止）。" >&2
-  fi
+  echo "  理由: 実行フロー状態ファイルです（直接編集による動作操作を防止）。" >&2
   exit 2
 fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,8 +233,8 @@ worktree-isolation-guard.sh により以下の制限がある（mainブランチ
 **main ブランチ上での Edit/Write は全ファイルに対して禁止**（`.claude-user/` と `.omc/` を除く gitignore 済みファイルのみ許可）。
 `.claude/**` や `scripts/` であっても必ず worktree 経由で変更すること。
 
-なお `.claude/.review-passed` と `.omc/state/**` は worktree 上でも Edit/Write がブロックされる（is_blocked_file による）。
-これらのファイルは `touch`/`cat >` 等の Bash コマンドでのみ作成・変更可能（例: `touch <worktree>/.claude/.review-passed`）。
+なお `.omc/state/**` は worktree 上でも Edit/Write がブロックされる（is_blocked_file による）。
+`.claude/.review-passed` は Write ツールまたは `touch`/`cat >` 等の Bash コマンドで作成・変更可能（例: `touch <worktree>/.claude/.review-passed`）。
 
 | 項目 | 詳細 |
 |---|---|


### PR DESCRIPTION
## Summary

- `orchestrator-direct-edit-guard.sh` の `is_blocked_file()` から `.review-passed` のブロックを除去
- Write ツールでも `.review-passed` を直接作成可能にした（Bash `touch` のみだった制限を緩和）
- `CLAUDE.md` の説明を実装に合わせて更新

## 背景

`.review-passed` は Bash `touch` コマンドのみで作成可能だったが、これはオーケストレーターワークフローに不要な制約だった。セキュリティ上の防御は `pre-push-review-guard.sh`（マーカー未存在時の push ブロック）が担っており、Edit/Write ブロックは「うっかりミス防止」に過ぎなかった。

## Test plan

- [ ] `.review-passed` を Write ツールで作成できることを確認
- [ ] `.omc/state/**` は引き続き Edit/Write がブロックされることを確認
- [ ] `git push` 前にマーカーが必要なことは変わっていないことを確認

Closes #886

🤖 Generated with [Claude Code](https://claude.ai/code)