### PR TITLE
fix(ci): fix ZAP scan failures - sign-up HTTP 500 and active scan timeout

### DIFF
--- a/scripts/ci/zap-scan.sh
+++ b/scripts/ci/zap-scan.sh
@@ -9,6 +9,9 @@
 #   TURSO_AUTH_TOKEN     - Turso 認証トークン
 #   BETTER_AUTH_SECRET   - Better Auth シークレット
 #   ENVIRONMENT          - 実行環境名
+#
+# ※ BETTER_AUTH_SECRET / ZAP_TEST_EMAIL / ZAP_TEST_PASSWORD が未設定の場合は
+#   CI用ダミー値が自動生成される（secrets 未設定環境での動作保証）
 
 set -euo pipefail
 
@@ -34,6 +37,10 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 API_PORT=8787
+# スキャン全体の最大実行時間（分）
+MAX_SCAN_DURATION_MINS=5
+# 1ルールあたりの最大実行時間（分）
+MAX_RULE_DURATION_MINS=1
 ZAP_HOME=$(mktemp -d)
 SETUP_LOG=/tmp/zap-setup.log
 touch "${SETUP_LOG}"
@@ -50,7 +57,6 @@ trap cleanup EXIT
 # ZAP スキャンは AI エンドポイントを実際に叩く必要はなく、API サーバの起動だけが目的なのでローカルモードで十分。
 # NOTE: wrangler 4.77.0 で動作確認済み。--local フラグの廃止は wrangler のリリースノートを確認すること。
 #       廃止された場合は wrangler dev --env <env> 相当の代替手段を検討する。
-# CI用フォールバック: シークレットが未設定の場合はダミー値を使用
 : "${BETTER_AUTH_SECRET:=$(openssl rand -hex 32)}"
 : "${ZAP_TEST_EMAIL:="zap-test-$(openssl rand -hex 4)@example.com"}"
 : "${ZAP_TEST_PASSWORD:="ZapTest$(openssl rand -hex 8)!"}"
@@ -140,12 +146,23 @@ if [ -n "${TOKEN}" ]; then
 fi
 
 # スキャン時間上限を設定（タイムアウト防止）
-curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/setOptionMaxScanDurationInMins/" \
+ZAP_DURATION_RESULT=$(curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/setOptionMaxScanDurationInMins/" \
   --data-urlencode "apikey=${ZAP_API_KEY}" \
-  --data-urlencode "Integer=5" >> "${SETUP_LOG}" 2>&1
-curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/setOptionMaxRuleDurationInMins/" \
+  --data-urlencode "Integer=${MAX_SCAN_DURATION_MINS}")
+if ! printf '%s' "${ZAP_DURATION_RESULT}" | jq -e '.Result == "OK"' > /dev/null 2>&1; then
+  echo "::error::スキャン全体時間上限の設定に失敗しました: ${ZAP_DURATION_RESULT}"
+  exit 1
+fi
+echo "setOptionMaxScanDurationInMins: ${ZAP_DURATION_RESULT}" >> "${SETUP_LOG}"
+
+ZAP_RULE_RESULT=$(curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/setOptionMaxRuleDurationInMins/" \
   --data-urlencode "apikey=${ZAP_API_KEY}" \
-  --data-urlencode "Integer=1" >> "${SETUP_LOG}" 2>&1
+  --data-urlencode "Integer=${MAX_RULE_DURATION_MINS}")
+if ! printf '%s' "${ZAP_RULE_RESULT}" | jq -e '.Result == "OK"' > /dev/null 2>&1; then
+  echo "::error::スキャンルール時間上限の設定に失敗しました: ${ZAP_RULE_RESULT}"
+  exit 1
+fi
+echo "setOptionMaxRuleDurationInMins: ${ZAP_RULE_RESULT}" >> "${SETUP_LOG}"
 
 echo "アクティブスキャン実行中..."
 SCAN_ID=$(curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/scan/" \

--- a/scripts/ci/zap-scan.sh
+++ b/scripts/ci/zap-scan.sh
@@ -50,6 +50,11 @@ trap cleanup EXIT
 # ZAP スキャンは AI エンドポイントを実際に叩く必要はなく、API サーバの起動だけが目的なのでローカルモードで十分。
 # NOTE: wrangler 4.77.0 で動作確認済み。--local フラグの廃止は wrangler のリリースノートを確認すること。
 #       廃止された場合は wrangler dev --env <env> 相当の代替手段を検討する。
+# CI用フォールバック: シークレットが未設定の場合はダミー値を使用
+: "${BETTER_AUTH_SECRET:=$(openssl rand -hex 32)}"
+: "${ZAP_TEST_EMAIL:="zap-test-$(openssl rand -hex 4)@example.com"}"
+: "${ZAP_TEST_PASSWORD:="ZapTest$(openssl rand -hex 8)!"}"
+
 TURSO_DATABASE_URL="${TURSO_DATABASE_URL}" \
 TURSO_AUTH_TOKEN="${TURSO_AUTH_TOKEN}" \
 BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET}" \
@@ -133,6 +138,14 @@ if [ -n "${TOKEN}" ]; then
       --data-urlencode "initiators=" > /dev/null 2>&1
   )
 fi
+
+# スキャン時間上限を設定（タイムアウト防止）
+curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/setOptionMaxScanDurationInMins/" \
+  --data-urlencode "apikey=${ZAP_API_KEY}" \
+  --data-urlencode "Integer=5" >> "${SETUP_LOG}" 2>&1
+curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/setOptionMaxRuleDurationInMins/" \
+  --data-urlencode "apikey=${ZAP_API_KEY}" \
+  --data-urlencode "Integer=1" >> "${SETUP_LOG}" 2>&1
 
 echo "アクティブスキャン実行中..."
 SCAN_ID=$(curl -s "http://localhost:${ZAP_PORT}/JSON/ascan/action/scan/" \


### PR DESCRIPTION
## Summary

- CI の ZAP セキュリティスキャンで発生していた2つの失敗を修正
- `BETTER_AUTH_SECRET` 等が GitHub Actions secrets 未設定の場合の HTTP 500 を解消
- ZAP アクティブスキャンのタイムアウト（360秒）を解消

## Changes

`scripts/ci/zap-scan.sh` のみ変更:

1. **CI用フォールバック値の追加**（HTTP 500 対策）  
   `BETTER_AUTH_SECRET` / `ZAP_TEST_EMAIL` / `ZAP_TEST_PASSWORD` が未設定の場合、`openssl rand` によるランダム値を自動生成するフォールバックを追加。GitHub secrets 未設定環境でも認証が機能するようになる。

2. **ZAP スキャン時間上限の設定**（タイムアウト対策）  
   スキャン開始前に `setOptionMaxScanDurationInMins=5` と `setOptionMaxRuleDurationInMins=1` を ZAP API で設定。ポーリングループ（360秒）内に確実に完了するようになる。設定 API のレスポンス検証（`.Result == "OK"`）も追加し、設定失敗時は明示的にエラーを出して終了する。

3. **定数化**  
   マジックナンバー `5` / `1` を `MAX_SCAN_DURATION_MINS` / `MAX_RULE_DURATION_MINS` 定数に置き換え。

## Test plan

- [ ] CI ZAP ジョブが `BETTER_AUTH_SECRET_CI` 未設定でも完走すること
- [ ] ZAP アクティブスキャンが 360 秒以内に完了すること
- [ ] `setOptionMaxScanDurationInMins` / `setOptionMaxRuleDurationInMins` 設定失敗時に `exit 1` すること

Closes #893

🤖 Generated with [Claude Code](https://claude.ai/code)