### PR TITLE
fix: poll スクリプトのエラーハンドリングと .gitignore 整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ coverage/
 # OMC (oh-my-claudecode state)
 .omc/
 
+# Claude Code ランタイムロックファイル
+.claude/*.lock
+
 # Claude Code ユーザー設定ディレクトリ（認証情報を含むため除外）
 .claude-user/
 


### PR DESCRIPTION
## Summary

- `.gitignore` に `.claude/*.lock` を追加（Claude Code スケジューラのランタイムロックファイルを除外）

## 背景

main ブランチに直接コミットされていた `2e36135b` の変更を正規フロー（worktree → PR）で取り込む。
poll スクリプト側の修正は origin/main の過去 PR で既に取り込まれていたため、未反映だった `.gitignore` のみ対応。

## Test plan

- [ ] `.claude/scheduled_tasks.lock` が `git status` で untracked にならないことを確認

closes #896

🤖 Generated with [Claude Code](https://claude.ai/code)