### PR TITLE
fix: ci.yml の自動マージに --auto フラグを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,4 +227,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge "${PR_NUMBER}" --squash --delete-branch --repo ${{ github.repository }}
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch --auto --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` の `gh pr merge` に `--auto` を追加
- ブランチ保護ルールの必須チェックが通るまで待ってから自動マージされるようになる

## 変更箇所

```diff
- gh pr merge "${PR_NUMBER}" --squash --delete-branch --repo ${{ github.repository }}
+ gh pr merge "${PR_NUMBER}" --squash --delete-branch --auto --repo ${{ github.repository }}
```

## Test plan

- [ ] 次回の自動マージジョブが正常に `Queued` → `Merged` になることを確認

closes #906

🤖 Generated with [Claude Code](https://claude.ai/code)