### PR TITLE
fix(ci): PR #890 の変更を continue-on-error なしで取り込む

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -9,12 +9,6 @@ runs:
         nix_path: nixpkgs=channel:nixpkgs-unstable
     - uses: DeterminateSystems/magic-nix-cache-action@6221693898146dc97e38ad0e013488a16477a4c4  # v9
       continue-on-error: true
-    - uses: cachix/cachix-action@18cf96c7c98e048e10a83abd92116114cd8504be  # v14
-      with:
-        name: devenv
-      continue-on-error: true
     - name: Install deps (nix develop)
       shell: bash
-      env:
-        NIXPKGS_ALLOW_UNFREE: "1"
-      run: nix develop --command pnpm install --frozen-lockfile
+      run: nix develop .#ci --command pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,6 @@ on:
       - '.omc/**'
       - 'tests/e2e/maestro/**'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 # デフォルトで全権限を read-only にし、各ジョブで必要な権限のみを上書きする
 permissions: read-all
 
@@ -138,15 +135,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.2.2
       - uses: ./.github/actions/nix-setup
       - name: 実行権限チェック
-        run: nix develop --command ./scripts/check-executable-shell-files.sh
+        run: nix develop .#ci --command ./scripts/check-executable-shell-files.sh
       - name: Lint
-        run: nix develop --command pnpm lint
+        run: nix develop .#ci --command pnpm lint
       - name: Typecheck
-        run: nix develop --command pnpm typecheck
+        run: nix develop .#ci --command pnpm typecheck
       - name: Test
-        run: nix develop --command ./scripts/run-and-fail-on-stderr.sh pnpm test
+        run: nix develop .#ci --command ./scripts/run-and-fail-on-stderr.sh pnpm test
       - name: Audit
-        run: nix develop --command pnpm audit --prod
+        run: nix develop .#ci --command pnpm audit --prod
 
   # ── Step 4（並列）: hooks テスト（hooks 変更時のみ）──────────────────────
   hooks-test:
@@ -161,9 +158,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.2.2
       - uses: ./.github/actions/nix-setup
       - name: 実行権限チェック
-        run: nix develop --command ./scripts/check-executable-shell-files.sh
+        run: nix develop .#ci --command ./scripts/check-executable-shell-files.sh
       - name: hooksテスト
-        run: nix develop --command bats tests/hooks/
+        run: nix develop .#ci --command bats tests/hooks/
 
   # ── Step 5（並列）: ZAP セキュリティスキャン（PR + コード変更時のみ）────
   zap:
@@ -190,7 +187,7 @@ jobs:
         run: |
           ZAP_PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
           export ZAP_PORT
-          nix develop --command bash scripts/ci/zap-scan.sh
+          nix develop .#ci --command bash scripts/ci/zap-scan.sh
       - name: Upload ZAP Report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,8 @@
             git
             jq
             curl
+            openssl
+            python3
             zap
             bats
             shellcheck

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,23 @@
         };
       in
       {
+        devShells.ci = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nodejs_22
+            pnpm
+            turbo
+            biome
+            gh
+            git
+            jq
+            curl
+            zap
+            bats
+            shellcheck
+            actionlint
+          ];
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             nodejs_22


### PR DESCRIPTION
## 概要

PR #890 の有効な改善（devShells.ci 追加、nix-setup 簡略化、CI トリガー除外）を、`continue-on-error: true` なしで取り込む。

ZAP スキャンのタイムアウト根本原因は PR #895 で修正済みのため、`continue-on-error` は不要。

## 変更内容

- `flake.nix`: `devShells.ci` を追加（CI 専用ミニマルシェル、ローカル専用ツールを除外）
- `.github/actions/nix-setup/action.yml`: cachix-action・NIXPKGS_ALLOW_UNFREE を削除、`nix develop .#ci` を使用
- `.github/workflows/ci.yml`: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 削除、docs/md を paths-ignore に追加、全 `nix develop` を `nix develop .#ci` に変更

## ZAP について

`continue-on-error: true` は **追加しない**。PR #895 のタイムアウト根本修正（スキャン時間上限設定）で十分。

closes #909

🤖 Generated with [Claude Code](https://claude.ai/code)