### PR TITLE
fix(scripts): push後検証スクリプトを追加してサイレントプッシュ失敗を防止

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ bash scripts/create-worktree.sh <issue-number> <kebab-case-description>
    if code_reviewer == "全件 PASS（0件）" and security_reviewer == "全件 PASS（0件）":
        # ループ脱出 → push へ
        Bash: touch <worktree>/.claude/.review-passed
-       Bash: cd <worktree> && git push origin HEAD
+       Bash: cd <worktree> && bash scripts/push-verified.sh
        Bash: gh pr create → PR URL をユーザーに報告
    else:
        # 全指摘（CRITICAL / HIGH / MEDIUM / LOW すべて）を coder に渡す
@@ -182,7 +182,7 @@ bash scripts/poll-pr-review.sh <pr-number>
 poll-pr-review.sh → CHANGES_REQUESTED
   → Agent(coder, mode="acceptEdits") で修正依頼（変更内容を渡す）
   → Agent(code-reviewer, mode="acceptEdits") + Agent(security-reviewer, mode="acceptEdits") で再レビュー
-  → 両方 PASS → マーカー再作成 → git push → poll-pr-review.sh を再実行
+  → 両方 PASS → マーカー再作成 → bash scripts/push-verified.sh → poll-pr-review.sh を再実行
   → APPROVED になるまで繰り返す
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,6 +298,7 @@ oh-my-claudecode やその他のプラグイン由来のエージェントは使
 - Lint / Format は Biome を使う
 - 破壊的な Git コマンドを使わない
 - **レビューが通る前に push しない**（pre-push-review-guard.sh がブロックする）
+- **push は必ず `bash scripts/push-verified.sh` を使う**（`git push origin HEAD` の直接実行は禁止）
 - **code-reviewer と security-reviewer の両方が「全件 PASS（0件）」を返すまで push しない**（CRITICAL / HIGH / MEDIUM / LOW 問わず指摘が 1 件でも残れば修正ループを続ける）
 - **オーケストレーターは main ブランチ上でソースファイルを直接編集しない。worktree 上でもエージェントへの委譲を優先する**
 - **TeamCreate / TaskCreate / SendMessage は使用しない**（Agent ツールで直接 spawn する）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ bash scripts/create-worktree.sh <issue-number> <kebab-case-description>
 --- レビューループ ---
 ② [並列 spawn] Agent(infra-reviewer, mode="acceptEdits")
                Agent(security-reviewer, mode="acceptEdits")
-   両方 PASS → ループ脱出 → マーカー作成 → push → PR 作成
+   両方 PASS → ループ脱出 → マーカー作成 → bash scripts/push-verified.sh → PR 作成
    指摘あり  → Agent(infra-engineer) で修正 → ②へ戻る
 ```
 
@@ -148,7 +148,7 @@ bash scripts/create-worktree.sh <issue-number> <kebab-case-description>
 --- レビューループ ---
 ② [並列 spawn] Agent(ui-reviewer, mode="acceptEdits")
                Agent(code-reviewer, mode="acceptEdits")
-   両方 PASS → ループ脱出 → マーカー作成 → push → PR 作成
+   両方 PASS → ループ脱出 → マーカー作成 → bash scripts/push-verified.sh → PR 作成
    指摘あり  → Agent(ui-designer, mode="acceptEdits") で修正 → ②へ戻る
 ```
 

--- a/scripts/push-verified.sh
+++ b/scripts/push-verified.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 LOCAL_SHA=$(git rev-parse HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
+if [ "${BRANCH}" = "HEAD" ]; then
+  echo "エラー: detached HEAD 状態です。ブランチをチェックアウトしてから実行してください。" >&2
+  exit 1
+fi
+
 echo "ブランチを push 中: ${BRANCH} (${LOCAL_SHA})"
 
 git push origin HEAD

--- a/scripts/push-verified.sh
+++ b/scripts/push-verified.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOCAL_SHA=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+echo "Pushing branch: ${BRANCH} (${LOCAL_SHA})"
+
+git push origin HEAD
+
+git fetch origin "${BRANCH}"
+REMOTE_SHA=$(git rev-parse "origin/${BRANCH}")
+
+if [ "${LOCAL_SHA}" = "${REMOTE_SHA}" ]; then
+  echo "✅ Push verified: ${LOCAL_SHA}"
+else
+  echo "❌ Push verification failed"
+  echo "  Local:  ${LOCAL_SHA}"
+  echo "  Remote: ${REMOTE_SHA}"
+  exit 1
+fi

--- a/scripts/push-verified.sh
+++ b/scripts/push-verified.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
+# push-verified.sh
+# 現在のブランチを push し、ローカルとリモートの SHA が一致することを検証する
+#
+# 使い方:
+#   bash scripts/push-verified.sh
 set -euo pipefail
 
 LOCAL_SHA=$(git rev-parse HEAD)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-echo "Pushing branch: ${BRANCH} (${LOCAL_SHA})"
+echo "ブランチを push 中: ${BRANCH} (${LOCAL_SHA})"
 
 git push origin HEAD
 
@@ -12,10 +17,10 @@ git fetch origin "${BRANCH}"
 REMOTE_SHA=$(git rev-parse "origin/${BRANCH}")
 
 if [ "${LOCAL_SHA}" = "${REMOTE_SHA}" ]; then
-  echo "✅ Push verified: ${LOCAL_SHA}"
+  echo "push 検証成功: ${LOCAL_SHA}"
 else
-  echo "❌ Push verification failed"
-  echo "  Local:  ${LOCAL_SHA}"
-  echo "  Remote: ${REMOTE_SHA}"
+  echo "push 検証失敗" >&2
+  echo "  ローカル:  ${LOCAL_SHA}" >&2
+  echo "  リモート: ${REMOTE_SHA}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- `scripts/push-verified.sh` を新規作成: push後にローカルとリモートの SHA を比較して検証し、不一致の場合はエラーで終了する
- `CLAUDE.md` の絶対ルールセクションに「push は必ず `push-verified.sh` を使う」規則を追記

## 背景

オーケストレーターが `git push origin HEAD` を実行した際に別 worktree の push 出力が混入し、プッシュ成功と誤認した事象（PR #873）を防止するための修正。

## Test plan

- [ ] `bash scripts/push-verified.sh` を実行してローカルとリモートの SHA が一致することを確認
- [ ] 不一致の場合に exit 1 で終了することを確認（手動テスト）

Closes #913

🤖 Generated with [Claude Code](https://claude.ai/code)