### PR TITLE
fix(ci): --auto フラグを削除して直接 squash merge に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,4 +224,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge "${PR_NUMBER}" --squash --delete-branch --auto --repo ${{ github.repository }}
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch --repo ${{ github.repository }}


### PR DESCRIPTION
## Summary

- `gh pr merge` の `--auto` フラグを削除し、直接 squash merge に変更
- リポジトリで `enablePullRequestAutoMerge` が無効なため `--auto` で CI が失敗していた
- `auto-merge` ジョブは全チェック通過後にのみ実行されるため `--auto` は不要

Closes #917

🤖 Generated with [Claude Code](https://claude.ai/code)