### PR TITLE
fix: poll-pr-review.sh の jq パースエラーバグを修正

### DIFF
--- a/scripts/poll-pr-review.sh
+++ b/scripts/poll-pr-review.sh
@@ -87,16 +87,32 @@ while (( elapsed < TIMEOUT_SECONDS )); do
   # 複数ラウンドにわたるレビューで古いコメントが残り続けることを防ぐため、
   # bot コメントの「最新1件のみ」を見て判定する。
   # createdAt で昇順ソートし最後の1件（最新）を取得する。
-  latest_bot_comment_body=$(printf '%s' "${pr_data}" | jq -r '
-    [.comments[]
-     | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude|claude)$"; "i"))]
-    | sort_by(.createdAt)
-    | last
-    | .body // ""
-  ' 2>/dev/null || true)
+  #
+  # NOTE: jq は JSON 入力を期待するため、pr_data（gh の JSON 出力）を 1 度だけ渡し、
+  #       jq パイプライン内で .body | test(...) を完結させる。
+  #       raw テキストを bash 変数に取り出してから再度 jq に渡すのは
+  #       パースエラーの原因となるため禁止。
+  bot_comment_eval=$(printf '%s' "${pr_data}" | jq -c '
+    ([ (.comments // [])[]
+       | select((.author.login // "") | test("^(github-actions\\[bot\\]|claude\\[bot\\]|claude-code\\[bot\\]|app/claude|claude)$"; "i")) ]
+     | sort_by(.createdAt)
+     | last) as $latest
+    | ($latest.body // "") as $body
+    | {
+        has_comment: ($latest != null),
+        body: $body,
+        changes_requested: ($body | test("(?s)🔄.*Request Changes|CHANGES_REQUESTED"; "i")),
+        approved: ($body | test("(?s)全件 ?PASS(?!\\w)|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*\\bPASS\\b|指摘[^0-9]?0(?![0-9])"; "i"))
+      }
+  ' 2>/dev/null || echo '{}')
 
-  if [[ -n "${latest_bot_comment_body}" ]]; then
-    if printf '%s' "${latest_bot_comment_body}" | jq -e 'test("(?s)🔄.*Request Changes|CHANGES_REQUESTED"; "i")' >/dev/null 2>&1; then
+  has_comment=$(printf '%s' "${bot_comment_eval}" | jq -r '.has_comment // false')
+  if [[ "${has_comment}" == "true" ]]; then
+    changes_requested=$(printf '%s' "${bot_comment_eval}" | jq -r '.changes_requested // false')
+    approved=$(printf '%s' "${bot_comment_eval}" | jq -r '.approved // false')
+    latest_bot_comment_body=$(printf '%s' "${bot_comment_eval}" | jq -r '.body // ""')
+
+    if [[ "${changes_requested}" == "true" ]]; then
       echo "CHANGES_REQUESTED"
       echo ""
       echo "--- Review Content (from comments) ---"
@@ -104,15 +120,7 @@ while (( elapsed < TIMEOUT_SECONDS )); do
       exit 1
     fi
 
-    # LGTM / Approve 系コメントも検出する
-    # 誤検知防止のため特定のフレーズのみ対象とする:
-    #   "全件 PASS" / "全件PASS": レビュアーエージェントの PASS 宣言
-    #   "✅.*\bPASS\b": CI/レビュー結果の ✅ + PASS（単語境界で "passed" 等の誤検知防止）
-    #   "\bLGTM\b": 標準的な承認表現（単語境界で LGTMFAIL 等の誤検知防止）
-    #   "Approve 相当": Claude bot の承認コメントフレーズ
-    #   "マージ可能(?:です|と判断|。|！|$)": Claude bot の承認判定フレーズ（「マージ可能性がある」等の誤検知防止）
-    #   "指摘[^0-9]?0(?![0-9])": 「指摘0件」のような確定0件表現（10件等との誤検知防止）
-    if printf '%s' "${latest_bot_comment_body}" | jq -e 'test("(?s)全件 ?PASS(?!\\w)|\\bLGTM\\b|Approve 相当|マージ可能(?:です|と判断|。|！|$)|✅.*\\bPASS\\b|指摘[^0-9]?0(?![0-9])"; "i")' >/dev/null 2>&1; then
+    if [[ "${approved}" == "true" ]]; then
       echo "APPROVED"
       exit 0
     fi

--- a/tests/scripts/poll-pr-review.bats
+++ b/tests/scripts/poll-pr-review.bats
@@ -19,14 +19,15 @@ teardown() {
 
 # gh コマンドをモックする共通ヘルパー
 # $1: gh が返す JSON
+# JSON ファイルに書き出し、mock gh スクリプトから cat するため
+# バッククォートや変数展開などの特殊文字を安全に扱える
 mock_gh_with_json() {
     local json="$1"
     local fake_bin_dir="$TMPDIR/fake_bin"
+    local json_file="$TMPDIR/mock_response.json"
     mkdir -p "$fake_bin_dir"
-    cat > "$fake_bin_dir/gh" <<GHEOF
-#!/usr/bin/env bash
-printf '%s' '${json//\'/\'\\\'\'}'
-GHEOF
+    printf '%s' "$json" > "$json_file"
+    printf '#!/usr/bin/env bash\ncat %s\n' "$json_file" > "$fake_bin_dir/gh"
     chmod +x "$fake_bin_dir/gh"
     export PATH="$fake_bin_dir:$PATH"
 }

--- a/tests/scripts/poll-pr-review.bats
+++ b/tests/scripts/poll-pr-review.bats
@@ -1,0 +1,366 @@
+#!/usr/bin/env bats
+# poll-pr-review.sh のテスト
+#
+# テスト環境: bats-core
+# 実行: bats tests/scripts/poll-pr-review.bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/poll-pr-review.sh"
+
+setup() {
+    TMPDIR=$(mktemp -d)
+    # タイムアウトを最小に設定してテストを速くする
+    export POLL_PR_REVIEW_TIMEOUT_SECONDS=1
+    export POLL_PR_REVIEW_INTERVAL_SECONDS=1
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+# gh コマンドをモックする共通ヘルパー
+# $1: gh が返す JSON
+mock_gh_with_json() {
+    local json="$1"
+    local fake_bin_dir="$TMPDIR/fake_bin"
+    mkdir -p "$fake_bin_dir"
+    cat > "$fake_bin_dir/gh" <<GHEOF
+#!/usr/bin/env bash
+printf '%s' '${json//\'/\'\\\'\'}'
+GHEOF
+    chmod +x "$fake_bin_dir/gh"
+    export PATH="$fake_bin_dir:$PATH"
+}
+
+# @test: AC-1 - bot コメントに「全件 PASS」を含む場合 APPROVED を返すこと
+@test "bot コメントに「全件 PASS」を含む場合 APPROVED を返せること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "全件 PASS\n\n指摘事項はありません。",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"APPROVED"* ]]
+}
+
+# @test: AC-1 - bot コメントに「LGTM」を含む場合 APPROVED を返すこと
+@test "bot コメントに「LGTM」を含む場合 APPROVED を返せること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "LGTM\n\nマージして問題ありません。",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"APPROVED"* ]]
+}
+
+# @test: AC-2 - bot コメントに「🔄 Request Changes」を含む場合 CHANGES_REQUESTED を返すこと
+@test "bot コメントに「🔄 Request Changes」を含む場合 CHANGES_REQUESTED を返せること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "🔄 Request Changes\n\n- 指摘1: コードを修正してください",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CHANGES_REQUESTED"* ]]
+}
+
+# @test: AC-2 - CHANGES_REQUESTED 時はコメント本文が出力されること
+@test "CHANGES_REQUESTED 時にコメント本文が stdout に出力されること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "🔄 Request Changes\n\n- 指摘1: コードを修正してください",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Review Content"* ]]
+}
+
+# @test: AC-3 - 判定パターン非該当時は TIMEOUT（タイムアウト設定が短いため）
+@test "判定パターン非該当のコメントの場合 TIMEOUT になること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "レビュー中です。しばらくお待ちください。",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"TIMEOUT"* ]]
+}
+
+# @test: AC-4 - formal review APPROVED が最優先されること
+@test "formal review が APPROVED の場合 bot コメントより優先して APPROVED を返せること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": "APPROVED",
+  "reviews": [
+    {
+      "author": {"login": "reviewer1"},
+      "state": "APPROVED",
+      "body": "LGTM"
+    }
+  ],
+  "comments": []
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"APPROVED"* ]]
+}
+
+# @test: AC-4 - formal review CHANGES_REQUESTED が最優先されること
+@test "formal review が CHANGES_REQUESTED の場合 bot コメントより優先して CHANGES_REQUESTED を返せること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": "CHANGES_REQUESTED",
+  "reviews": [
+    {
+      "author": {"login": "reviewer1"},
+      "state": "CHANGES_REQUESTED",
+      "body": "修正が必要です。"
+    }
+  ],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "全件 PASS",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CHANGES_REQUESTED"* ]]
+}
+
+# @test: AC-5 - 絵文字・改行・特殊文字を含むコメントでもパースエラーが起きないこと
+@test "絵文字や改行を含む bot コメントでも jq パースエラーが発生しないこと" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "✅ 全件 PASS\n\n## サマリー\n指摘0件\n\n```typescript\nconst x = 1;\n```\n\n🎉 マージ可能です",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert（APPROVED になりjqエラーで終了しないこと）
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"APPROVED"* ]]
+}
+
+# @test: AC-6 - bot コメントが 0 件の場合 PENDING で TIMEOUT になること
+@test "bot コメントが 0 件の場合 jq エラーなく TIMEOUT になること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": []
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"TIMEOUT"* ]]
+}
+
+# @test: AC-6 - comments フィールド自体がない場合も TIMEOUT になること
+@test "comments フィールドが存在しない場合も jq エラーなく TIMEOUT になること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": []
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"TIMEOUT"* ]]
+}
+
+# @test: 最新のコメントのみが判定対象になること
+@test "複数 bot コメントがある場合 最新（最後の）コメントのみが判定対象になること" {
+    # Arrange: 古いコメントは APPROVED フレーズ、最新は CHANGES_REQUESTED フレーズ
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "全件 PASS",
+      "createdAt": "2024-01-01T00:00:00Z"
+    },
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "🔄 Request Changes\n\n- 修正が必要です",
+      "createdAt": "2024-01-02T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert: 最新コメントの CHANGES_REQUESTED が採用されること
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CHANGES_REQUESTED"* ]]
+}
+
+# @test: bot 以外のコメントは無視されること
+@test "bot 以外のユーザーコメントは無視されること" {
+    # Arrange: 一般ユーザーのコメントに APPROVED フレーズがあっても無視
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "human-user"},
+      "body": "全件 PASS だと思います",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert: bot コメントではないので PENDING → TIMEOUT
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"TIMEOUT"* ]]
+}

--- a/tests/scripts/poll-pr-review.bats
+++ b/tests/scripts/poll-pr-review.bats
@@ -27,7 +27,7 @@ mock_gh_with_json() {
     local json_file="$TMPDIR/mock_response.json"
     mkdir -p "$fake_bin_dir"
     printf '%s' "$json" > "$json_file"
-    printf '#!/usr/bin/env bash\ncat %s\n' "$json_file" > "$fake_bin_dir/gh"
+    printf '#!/usr/bin/env bash\ncat "%s"\n' "$json_file" > "$fake_bin_dir/gh"
     chmod +x "$fake_bin_dir/gh"
     export PATH="$fake_bin_dir:$PATH"
 }
@@ -364,4 +364,31 @@ EOF
     # Assert: bot コメントではないので PENDING → TIMEOUT
     [ "$status" -eq 2 ]
     [[ "$output" == *"TIMEOUT"* ]]
+}
+
+@test "changes_requested と approved が両方マッチする場合は CHANGES_REQUESTED が優先されること" {
+    # Arrange
+    local json
+    json=$(cat <<'EOF'
+{
+  "reviewDecision": null,
+  "reviews": [],
+  "comments": [
+    {
+      "author": {"login": "claude[bot]"},
+      "body": "🔄 Request Changes\n\n## 指摘\n- xxx\n\n全件 PASS",
+      "createdAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+EOF
+)
+    mock_gh_with_json "$json"
+
+    # Act
+    run bash "$SCRIPT" "123"
+
+    # Assert
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"CHANGES_REQUESTED"* ]]
 }


### PR DESCRIPTION
## 概要

`scripts/poll-pr-review.sh` で bot コメントの raw Markdown テキストを `jq -e 'test(...)'` にパイプしていたバグを修正。jq は JSON 入力を期待するが raw テキストが渡されるためパースエラーが発生し、エラーが `>/dev/null 2>&1` で隠蔽されることで CHANGES_REQUESTED / APPROVED の両判定が常に失敗していた。

## 変更ファイル

- `scripts/poll-pr-review.sh` - jq パイプライン内で `.body | test(...)` を完結させる方式に変更
- `tests/scripts/poll-pr-review.bats` - 新規追加（12件のテスト）

## テスト

- [ ] pnpm lint パス
- [ ] pnpm typecheck パス
- [ ] pnpm test パス
- [ ] bats テスト 12/12 パス

Closes #930

🤖 Reviewed by reviewer agent