### PR TITLE
chore: reviewer系エージェントの .review-passed 作成を Write ツールに変更

### DIFF
--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -137,7 +137,7 @@ EOF
 
 ```bash
 # レビュー通過マーカー作成
-touch {worktree}/.claude/.review-passed
+# Write ツールを使って {worktree}/.claude/.review-passed を作成すること（内容は空でよい）
 
 # push
 cd {worktree} && bash scripts/push-verified.sh

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -131,7 +131,7 @@ EOF
 
 ```bash
 # レビュー通過マーカー作成
-touch {worktree}/.claude/.review-passed
+# Write ツールを使って {worktree}/.claude/.review-passed を作成すること（内容は空でよい）
 
 # push
 cd {worktree} && bash scripts/push-verified.sh

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -129,7 +129,7 @@ EOF
 
 ```bash
 # レビュー通過マーカー作成
-touch {worktree}/.claude/.review-passed
+# Write ツールを使って {worktree}/.claude/.review-passed を作成すること（内容は空でよい）
 
 # push
 cd {worktree} && bash scripts/push-verified.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,7 @@ worktree-isolation-guard.sh により以下の制限がある（mainブランチ
 `.claude/**` や `scripts/` であっても必ず worktree 経由で変更すること。
 
 なお `.omc/state/**` は worktree 上でも Edit/Write がブロックされる（is_blocked_file による）。
-`.claude/.review-passed` は Write ツールまたは `touch`/`cat >` 等の Bash コマンドで作成・変更可能（例: `touch <worktree>/.claude/.review-passed`）。
+`.claude/.review-passed` は Write ツールで作成すること（例: Write ツールで `{worktree}/.claude/.review-passed` を作成、内容は空でよい）。
 
 | 項目 | 詳細 |
 |---|---|


### PR DESCRIPTION
## 概要

`reviewer.md`、`ui-reviewer.md`、`infra-reviewer.md` の 3 ファイルで `.review-passed` マーカーを `touch`（Bash コマンド）で作成していたが、Write ツールで普通に作成するように変更。`CLAUDE.md` の関連注記も更新。

## 変更ファイル

- `.claude/agents/reviewer.md`
- `.claude/agents/ui-reviewer.md`
- `.claude/agents/infra-reviewer.md`
- `CLAUDE.md`

## テスト

- [ ] pnpm lint パス
- [ ] pnpm typecheck パス
- [ ] pnpm test パス

Closes #932

🤖 Reviewed by reviewer agent