### PR TITLE
fix: add auto flag to resolve CI circular dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,4 +224,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr merge "${PR_NUMBER}" --squash --delete-branch --repo ${{ github.repository }}
+          gh pr merge "${PR_NUMBER}" --squash --delete-branch --auto --repo ${{ github.repository }}


### PR DESCRIPTION
## 概要

- `auto-merge` ジョブの `gh pr merge` コマンドに `--auto` フラグを追加
- CI / auto-merge チェックの循環デッドロックを解消

## 問題

`CI / auto-merge` ジョブが即時マージを試みる際、リポジトリルールセットが「`CI / auto-merge` チェックが PASS していること」を必須要件にしているため:

1. ジョブ開始 → チェックが IN PROGRESS
2. `gh pr merge` 実行 → 必須チェックが未完了でブロック
3. ジョブが exit 1 で失敗 → チェックが FAILURE
4. PR が永久にブロック

## 修正

`--auto` フラグにより GitHub ネイティブの auto-merge キューを使用:
- ジョブは正常終了（exit 0）→ チェックが PASS
- 全要件充足後に GitHub が自動マージ

前提: リポジトリの `allow_auto_merge` 設定を `true` に変更済み。

## やること

- [x] `--auto` フラグを `gh pr merge` コマンドに追加

closes #934
