### PR TITLE
fix(api): 通知設定APIのパスをmobileと統一する #921

### DIFF
--- a/apps/api/src/app/notifications-subapp.ts
+++ b/apps/api/src/app/notifications-subapp.ts
@@ -65,7 +65,7 @@ export async function handleNotificationSettings(
   return fetchWithAuth(
     auth.api.getSession.bind(auth.api),
     (subApp) => {
-      subApp.route("/api", notificationSettingsRoute);
+      subApp.route("/api/users/me", notificationSettingsRoute);
     },
     request,
   );

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -97,6 +97,10 @@ app.on(["GET", "POST", "PATCH", "DELETE"], "/api/articles/**", async (c) => {
   return handleArticles(c.get("db"), c.env, c.get("auth")(), c.req.raw);
 });
 
+app.on(["GET", "PATCH"], "/api/users/me/notification-settings", async (c) => {
+  return handleNotificationSettings(c.get("db"), c.get("auth")(), c.req.raw);
+});
+
 app.on(["GET", "POST", "PATCH", "DELETE"], "/api/users/**", async (c) => {
   return handleUsers(c.get("db"), c.env, c.get("auth")(), c.req.raw);
 });
@@ -107,10 +111,6 @@ app.on(["GET", "POST", "PATCH"], "/api/tags/**", async (c) => {
 
 app.on(["GET", "POST", "PATCH"], "/api/notifications/**", async (c) => {
   return handleNotifications(c.get("db"), c.get("auth")(), c.req.raw);
-});
-
-app.on(["GET", "PATCH"], "/api/notification-settings/**", async (c) => {
-  return handleNotificationSettings(c.get("db"), c.get("auth")(), c.req.raw);
 });
 
 app.on(["GET", "POST"], "/api/subscription/**", async (c) => {

--- a/tests/api/integration/notification-settings.test.ts
+++ b/tests/api/integration/notification-settings.test.ts
@@ -93,7 +93,7 @@ function createTestApp(mockDb: ReturnType<typeof createMockDb>, authenticated = 
     await next();
   });
 
-  app.route("/", route);
+  app.route("/api/users/me", route);
   return app;
 }
 
@@ -104,11 +104,11 @@ describe("通知設定API 統合テスト", () => {
     mockDb = createMockDb();
   });
 
-  describe("GET /notification-settings", () => {
+  describe("GET /api/users/me/notification-settings", () => {
     it("認証済みユーザーが通知設定を取得できること", async () => {
       // Arrange
       const app = createTestApp(mockDb);
-      const req = new Request("http://localhost/notification-settings");
+      const req = new Request("http://localhost/api/users/me/notification-settings");
 
       // Act
       const res = await app.fetch(req);
@@ -123,7 +123,7 @@ describe("通知設定API 統合テスト", () => {
     it("未認証の場合に401エラーを返すこと", async () => {
       // Arrange
       const app = createTestApp(mockDb, false);
-      const req = new Request("http://localhost/notification-settings");
+      const req = new Request("http://localhost/api/users/me/notification-settings");
 
       // Act
       const res = await app.fetch(req);
@@ -137,7 +137,7 @@ describe("通知設定API 統合テスト", () => {
     it("レスポンスにuserIdが含まれないこと", async () => {
       // Arrange
       const app = createTestApp(mockDb);
-      const req = new Request("http://localhost/notification-settings");
+      const req = new Request("http://localhost/api/users/me/notification-settings");
 
       // Act
       const res = await app.fetch(req);
@@ -149,7 +149,7 @@ describe("通知設定API 統合テスト", () => {
     });
   });
 
-  describe("PATCH /notification-settings", () => {
+  describe("PATCH /api/users/me/notification-settings", () => {
     it("通知設定を更新できること", async () => {
       // Arrange
       const updatedSettings = { ...MOCK_NOTIFICATION_SETTINGS, follow: true };
@@ -161,7 +161,7 @@ describe("通知設定API 統合テスト", () => {
           Promise.resolve([MOCK_NOTIFICATION_SETTINGS]).then(resolve),
       });
       const app = createTestApp(mockDb);
-      const req = new Request("http://localhost/notification-settings", {
+      const req = new Request("http://localhost/api/users/me/notification-settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ follow: true }),
@@ -179,7 +179,7 @@ describe("通知設定API 統合テスト", () => {
     it("未認証の場合に401エラーを返すこと", async () => {
       // Arrange
       const app = createTestApp(mockDb, false);
-      const req = new Request("http://localhost/notification-settings", {
+      const req = new Request("http://localhost/api/users/me/notification-settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ follow: true }),
@@ -197,7 +197,7 @@ describe("通知設定API 統合テスト", () => {
     it("更新フィールドが空の場合に422エラーを返すこと", async () => {
       // Arrange
       const app = createTestApp(mockDb);
-      const req = new Request("http://localhost/notification-settings", {
+      const req = new Request("http://localhost/api/users/me/notification-settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -215,7 +215,7 @@ describe("通知設定API 統合テスト", () => {
     it("不正なフィールド型の場合に422エラーを返すこと", async () => {
       // Arrange
       const app = createTestApp(mockDb);
-      const req = new Request("http://localhost/notification-settings", {
+      const req = new Request("http://localhost/api/users/me/notification-settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ follow: "not-a-boolean" }),


### PR DESCRIPTION
## 概要

モバイルアプリは `/api/users/me/notification-settings` を呼び出していたが、API 側は `/api/notification-settings` にマウントしていたため 404 になっていた不具合を修正する。

REST 設計規約（リソース指向 URL・ユーザーのサブリソース表現）に従い、API 側を mobile 側に合わせる形で統一する。

## 変更内容

- `apps/api/src/index.ts`: `/api/notification-settings/**` を削除し、`/api/users/me/notification-settings` を追加。`/api/users/**` catch-all より前に配置してルーティング優先度を確保
- `apps/api/src/app/notifications-subapp.ts`: サブアプリのマウントパスを `/api` から `/api/users/me` に変更
- `tests/api/integration/notification-settings.test.ts`: 統合テストのパスを新エンドポイントに更新

## テスト

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（API 1440 tests / Mobile 884 tests すべて PASS）
- [x] `tests/api/routes/notification-settings.test.ts` が新パスで PASS
- [x] `tests/api/integration/notification-settings.test.ts` が新パスで PASS
- [x] モバイルクライアント (`apps/mobile/src/stores/settings-store.ts`) と API パスが一致

Closes #921

🤖 Reviewed by reviewer agent