### PR TITLE
fix(mobile): 日本語ハードコード文言をi18nキーに置き換える #924

### DIFF
--- a/apps/mobile/app/(tabs)/search.tsx
+++ b/apps/mobile/app/(tabs)/search.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "expo-router";
 import { Search, X } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ActivityIndicator, FlatList, Pressable, Text, TextInput, View } from "react-native";
 
 import { ArticleCard } from "@/components/ArticleCard";
@@ -21,6 +22,7 @@ const CLEAR_ICON_SIZE = 18;
  * 検索結果はArticleCardで表示し、無限スクロールに対応。
  */
 export default function SearchScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const colors = useColors();
   const [inputValue, setInputValue] = useState("");
@@ -96,24 +98,24 @@ export default function SearchScreen() {
       return (
         <View className="flex-1 items-center justify-center py-20">
           <Search size={48} color={colors.border} />
-          <Text className="text-text-muted text-base mt-4">キーワードで記事を検索</Text>
-          <Text className="text-text-dim text-sm mt-1">タイトルや内容から検索できます</Text>
+          <Text className="text-text-muted text-base mt-4">{t("search.hint")}</Text>
+          <Text className="text-text-dim text-sm mt-1">{t("search.hintSub")}</Text>
         </View>
       );
     }
     return (
       <View className="flex-1 items-center justify-center py-20">
         <Text className="text-text-muted text-base">
-          {isError ? "検索に失敗しました" : `「${debouncedQuery}」に一致する記事がありません`}
+          {isError ? t("search.error") : t("article.noMatch", { query: debouncedQuery })}
         </Text>
         {isError && (
           <Pressable onPress={() => refetch()} className="mt-4">
-            <Text className="text-primary">再試行</Text>
+            <Text className="text-primary">{t("common.retry")}</Text>
           </Pressable>
         )}
       </View>
     );
-  }, [isLoading, debouncedQuery, isError, refetch, colors.border]);
+  }, [isLoading, debouncedQuery, isError, refetch, colors.border, t]);
 
   return (
     <View className="flex-1 bg-background">
@@ -123,7 +125,7 @@ export default function SearchScreen() {
           <TextInput
             ref={inputRef}
             className="flex-1 text-text text-base py-1"
-            placeholder="記事を検索..."
+            placeholder={t("search.placeholder")}
             placeholderTextColor={colors.textDim}
             value={inputValue}
             onChangeText={setInputValue}
@@ -135,7 +137,7 @@ export default function SearchScreen() {
             <Pressable
               onPress={handleClear}
               accessibilityRole="button"
-              accessibilityLabel="検索をクリア"
+              accessibilityLabel={t("search.clearLabel")}
               hitSlop={8}
             >
               <X size={CLEAR_ICON_SIZE} color={colors.textDim} />
@@ -147,7 +149,7 @@ export default function SearchScreen() {
       {isLoading && debouncedQuery ? (
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator size="large" color={colors.primary} />
-          <Text className="text-text-muted mt-3">検索中...</Text>
+          <Text className="text-text-muted mt-3">{t("search.searching")}</Text>
         </View>
       ) : (
         <FlatList

--- a/apps/mobile/app/share-intent.tsx
+++ b/apps/mobile/app/share-intent.tsx
@@ -1,6 +1,7 @@
 import { router } from "expo-router";
 import { useShareIntent } from "expo-share-intent";
 import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
 /**
@@ -22,6 +23,7 @@ function isValidHttpUrl(urlString: string): boolean {
  * 受け取ったURLをバリデーションしてSave画面にプリセットする。
  */
 export default function ShareIntentScreen() {
+  const { t } = useTranslation();
   const { shareIntent, isReady, error, resetShareIntent } = useShareIntent();
   /** 二重遷移を防ぐガード */
   const hasNavigated = useRef(false);
@@ -48,8 +50,8 @@ export default function ShareIntentScreen() {
         className="flex-1 items-center justify-center bg-background"
         accessibilityLabel="share-intent-loading"
       >
-        <ActivityIndicator size="large" accessibilityLabel="読み込み中" />
-        <Text className="sr-only">読み込み中</Text>
+        <ActivityIndicator size="large" accessibilityLabel={t("shareIntent.loading")} />
+        <Text className="sr-only">{t("shareIntent.loading")}</Text>
       </View>
     );
   }
@@ -64,15 +66,15 @@ export default function ShareIntentScreen() {
           className="text-text text-base text-center mb-6"
           accessibilityLabel="share-intent-error-message"
         >
-          共有データの読み取りに失敗しました
+          {t("shareIntent.error")}
         </Text>
         <Pressable
           onPress={() => router.back()}
           className="rounded-lg bg-primary px-6 py-3"
           accessibilityRole="button"
-          accessibilityLabel="閉じる"
+          accessibilityLabel={t("shareIntent.close")}
         >
-          <Text className="text-white font-medium">閉じる</Text>
+          <Text className="text-white font-medium">{t("shareIntent.close")}</Text>
         </Pressable>
       </View>
     );
@@ -87,15 +89,15 @@ export default function ShareIntentScreen() {
         className="text-text text-base text-center mb-6"
         accessibilityLabel="share-intent-not-found-message"
       >
-        URLが見つかりません
+        {t("shareIntent.notFound")}
       </Text>
       <Pressable
         onPress={() => router.back()}
         className="rounded-lg bg-primary px-6 py-3"
         accessibilityRole="button"
-        accessibilityLabel="閉じる"
+        accessibilityLabel={t("shareIntent.close")}
       >
-        <Text className="text-white font-medium">閉じる</Text>
+        <Text className="text-white font-medium">{t("shareIntent.close")}</Text>
       </Pressable>
     </View>
   );

--- a/apps/mobile/src/components/ArticleCard.tsx
+++ b/apps/mobile/src/components/ArticleCard.tsx
@@ -1,6 +1,7 @@
 import { Image } from "expo-image";
 import { Heart } from "lucide-react-native";
 import { memo } from "react";
+import { useTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
 
 import { SourceBadge } from "@/components/ui";
@@ -43,6 +44,7 @@ export const ArticleCard = memo(function ArticleCard({
   onPress,
   onToggleFavorite,
 }: ArticleCardProps) {
+  const { t } = useTranslation();
   const language = useSettingsStore((s) => s.language);
   const colors = useColors();
 
@@ -96,7 +98,9 @@ export const ArticleCard = memo(function ArticleCard({
                 onToggleFavorite();
               }}
               accessibilityRole="button"
-              accessibilityLabel={article.isFavorite ? "お気に入り解除" : "お気に入り追加"}
+              accessibilityLabel={
+                article.isFavorite ? t("article.removeFromFavorites") : t("article.addToFavorites")
+              }
               hitSlop={8}
             >
               {article.isFavorite ? (

--- a/tests/mobile/components/ArticleCard.test.tsx
+++ b/tests/mobile/components/ArticleCard.test.tsx
@@ -188,4 +188,32 @@ describe("ArticleCard", () => {
       expect(getByText("2025/3/15")).toBeDefined();
     });
   });
+
+  describe("アクセシビリティラベル（i18n）", () => {
+    it("お気に入りでない場合のアクセシビリティラベルにi18nキーが使われること（日本語）", async () => {
+      // Arrange
+      const article = { ...BASE_ARTICLE, isFavorite: false };
+
+      // Act
+      const { getByLabelText } = await render(
+        <ArticleCard article={article} onPress={() => {}} onToggleFavorite={() => {}} />,
+      );
+
+      // Assert
+      expect(getByLabelText("お気に入り追加")).toBeDefined();
+    });
+
+    it("お気に入りの場合のアクセシビリティラベルにi18nキーが使われること（日本語）", async () => {
+      // Arrange
+      const article = { ...BASE_ARTICLE, isFavorite: true };
+
+      // Act
+      const { getByLabelText } = await render(
+        <ArticleCard article={article} onPress={() => {}} onToggleFavorite={() => {}} />,
+      );
+
+      // Assert
+      expect(getByLabelText("お気に入り解除")).toBeDefined();
+    });
+  });
 });

--- a/tests/mobile/screens/search.test.tsx
+++ b/tests/mobile/screens/search.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * 検索画面テスト
+ *
+ * i18n キーを使用したテキスト・アクセシビリティラベルが正しく表示されることを確認する。
+ */
+import { useSearchArticles, useToggleFavorite } from "@mobile/hooks/use-articles";
+import { useColors } from "@mobile/hooks/use-colors";
+import SearchScreen from "@mobile-app/(tabs)/search";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native";
+
+import { setMockLocale } from "../helpers/i18n-test-utils";
+
+jest.mock("@mobile/hooks/use-articles", () => ({
+  useSearchArticles: jest.fn(),
+  useToggleFavorite: jest.fn(),
+}));
+
+jest.mock("@mobile/hooks/use-colors", () => ({
+  useColors: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+  })),
+}));
+
+jest.mock("@mobile/components/ArticleCard", () => ({
+  ArticleCard: ({ article }: { article: { title: string } }) =>
+    require("react").createElement(require("react-native").Text, null, article.title),
+}));
+
+/** useSearchArticles のデフォルトモック値 */
+const DEFAULT_SEARCH_MOCK = {
+  data: undefined,
+  fetchNextPage: jest.fn(),
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  isLoading: false,
+  isError: false,
+  refetch: jest.fn(),
+};
+
+/** useColors のデフォルトモック値 */
+const DEFAULT_COLORS_MOCK = {
+  primary: "#14b8a6",
+  border: "#e7e5e4",
+  textDim: "#a8a29e",
+  textMuted: "#78716c",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setMockLocale("ja");
+  (useSearchArticles as jest.Mock).mockReturnValue(DEFAULT_SEARCH_MOCK);
+  (useToggleFavorite as jest.Mock).mockReturnValue({ mutate: jest.fn() });
+  (useColors as jest.Mock).mockReturnValue(DEFAULT_COLORS_MOCK);
+});
+
+describe("SearchScreen", () => {
+  describe("初期表示（i18n）", () => {
+    it("検索入力欄のプレースホルダーにi18nキーが使われること（日本語）", async () => {
+      // Arrange & Act
+      await render(<SearchScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("記事を検索...")).toBeDefined();
+      });
+    });
+
+    it("検索ヒントテキストにi18nキーが使われること（日本語）", async () => {
+      // Arrange & Act
+      await render(<SearchScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("キーワードで記事を検索")).toBeDefined();
+      });
+    });
+
+    it("検索ヒントサブテキストにi18nキーが使われること（日本語）", async () => {
+      // Arrange & Act
+      await render(<SearchScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("タイトルや内容から検索できます")).toBeDefined();
+      });
+    });
+  });
+
+  describe("クリアボタン（i18n）", () => {
+    it("クリアボタンのアクセシビリティラベルにi18nキーが使われること（日本語）", async () => {
+      // Arrange
+      await render(<SearchScreen />);
+      const input = screen.getByPlaceholderText("記事を検索...");
+
+      // Act
+      await fireEvent.changeText(input, "react");
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByLabelText("検索をクリア")).toBeDefined();
+      });
+    });
+  });
+
+  describe("ローディング状態（i18n）", () => {
+    it("検索中テキストにi18nキーが使われること（日本語）", async () => {
+      // Arrange
+      (useSearchArticles as jest.Mock).mockReturnValue({
+        ...DEFAULT_SEARCH_MOCK,
+        isLoading: true,
+      });
+      await render(<SearchScreen />);
+      const input = screen.getByPlaceholderText("記事を検索...");
+
+      // Act
+      await fireEvent.changeText(input, "react");
+
+      // Assert
+      await waitFor(
+        () => {
+          expect(screen.getByText("検索中...")).toBeDefined();
+        },
+        { timeout: 1500 },
+      );
+    });
+  });
+
+  describe("エラー状態（i18n）", () => {
+    it("エラーテキストにi18nキーが使われること（日本語）", async () => {
+      // Arrange
+      (useSearchArticles as jest.Mock).mockReturnValue({
+        ...DEFAULT_SEARCH_MOCK,
+        isError: true,
+        data: { pages: [{ items: [] }] },
+      });
+
+      await render(<SearchScreen />);
+      const input = screen.getByPlaceholderText("記事を検索...");
+
+      // Act
+      await fireEvent.changeText(input, "react");
+
+      // Assert
+      await waitFor(
+        () => {
+          expect(screen.getByText("検索に失敗しました")).toBeDefined();
+        },
+        { timeout: 1500 },
+      );
+    });
+
+    it("エラー時の再試行ボタンにi18nキーが使われること（日本語）", async () => {
+      // Arrange
+      (useSearchArticles as jest.Mock).mockReturnValue({
+        ...DEFAULT_SEARCH_MOCK,
+        isError: true,
+        data: { pages: [{ items: [] }] },
+      });
+
+      await render(<SearchScreen />);
+      const input = screen.getByPlaceholderText("記事を検索...");
+
+      // Act
+      await fireEvent.changeText(input, "react");
+
+      // Assert
+      await waitFor(
+        () => {
+          expect(screen.getByText("再試行")).toBeDefined();
+        },
+        { timeout: 1500 },
+      );
+    });
+  });
+
+  describe("英語ロケール（i18n）", () => {
+    beforeEach(() => {
+      setMockLocale("en");
+    });
+
+    afterEach(() => {
+      setMockLocale("ja");
+    });
+
+    it("検索入力欄のプレースホルダーが英語で表示されること", async () => {
+      // Arrange & Act
+      await render(<SearchScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("Search articles...")).toBeDefined();
+      });
+    });
+
+    it("検索ヒントテキストが英語で表示されること", async () => {
+      // Arrange & Act
+      await render(<SearchScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText("Search articles by keyword")).toBeDefined();
+      });
+    });
+
+    it("クリアボタンのアクセシビリティラベルが英語で表示されること", async () => {
+      // Arrange
+      await render(<SearchScreen />);
+      const input = screen.getByPlaceholderText("Search articles...");
+
+      // Act
+      await fireEvent.changeText(input, "react");
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByLabelText("Clear search")).toBeDefined();
+      });
+    });
+
+    it("日本語ハードコードの「記事を検索...」が表示されないこと", async () => {
+      // Arrange & Act
+      await render(<SearchScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText("記事を検索...")).toBeNull();
+      });
+    });
+  });
+});

--- a/tests/mobile/screens/search.test.tsx
+++ b/tests/mobile/screens/search.test.tsx
@@ -177,6 +177,31 @@ describe("SearchScreen", () => {
     });
   });
 
+  describe("検索結果なし状態（i18n）", () => {
+    it("クエリに一致する記事がない場合にnoMatchテキストがクエリ補間されて表示されること", async () => {
+      // Arrange
+      (useSearchArticles as jest.Mock).mockReturnValue({
+        ...DEFAULT_SEARCH_MOCK,
+        isError: false,
+        data: { pages: [{ items: [] }] },
+      });
+
+      await render(<SearchScreen />);
+      const input = screen.getByPlaceholderText("記事を検索...");
+
+      // Act
+      await fireEvent.changeText(input, "react");
+
+      // Assert
+      await waitFor(
+        () => {
+          expect(screen.getByText("「react」に一致する記事がありません")).toBeDefined();
+        },
+        { timeout: 1500 },
+      );
+    });
+  });
+
   describe("英語ロケール（i18n）", () => {
     beforeEach(() => {
       setMockLocale("en");


### PR DESCRIPTION
## 概要

mobile アプリの search 画面・share-intent 画面・ArticleCard コンポーネントに残っていた日本語ハードコード文言を i18n キーに置換し、多言語対応を完成させる。

## 変更ファイル

- `apps/mobile/app/(tabs)/search.tsx`: プレースホルダ・検索ヒント・空状態・再試行・検索中表示を i18n 化
- `apps/mobile/app/share-intent.tsx`: 読み込み中・エラー・URL未検出・閉じるボタンを i18n 化
- `apps/mobile/src/components/ArticleCard.tsx`: お気に入りトグルの accessibilityLabel を i18n 化

## 対応内容

- `useTranslation()` を追加
- 既存ロケールファイル（ja/en/ko/zh-CN/zh-TW）のキーを使用
- `search.hint`, `search.hintSub`, `search.placeholder`, `search.clearLabel`, `search.searching`, `search.error`, `article.noMatch`, `article.addToFavorites`, `article.removeFromFavorites`, `common.retry`, `shareIntent.loading`, `shareIntent.error`, `shareIntent.notFound`, `shareIntent.close`
- `useCallback` の依存配列に `t` を追加

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（884件全てパス）

Closes #924

Reviewed-by: ui-reviewer agent