### PR TITLE
ci/test: Turboキャッシュに依存しないuncached検証経路を追加する #898

### DIFF
--- a/.github/workflows/verify-uncached.yml
+++ b/.github/workflows/verify-uncached.yml
@@ -1,0 +1,23 @@
+name: Verify (uncached)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 毎日 18:00 UTC (JST 03:00) に uncached 検証を実行
+    - cron: '0 18 * * *'
+
+permissions: read-all
+
+concurrency:
+  group: verify-uncached-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify-uncached:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.2.2
+      - uses: ./.github/actions/nix-setup
+      - name: Uncached typecheck + test
+        run: nix develop .#ci --command pnpm verify:uncached

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -157,6 +157,34 @@ chore(deps): pnpm を 10.x に更新する
 
 ---
 
+## テスト / 検証
+
+### Turbo cache と uncached 検証
+
+通常の `pnpm typecheck` / `pnpm test` は Turbo キャッシュを使うため、
+過去の実行結果が replay されて「FULL TURBO」になることがある。
+開発サイクル中はこれで問題ないが、次のケースでは cache replay に依存しない
+uncached 検証を使うこと。
+
+- リリース前の最終確認
+- セキュリティ監査・インシデント調査
+- 原因切り分け中に「この作業木で本当に通るか」を裏付けたいとき
+- 複数 worktree を並行運用していて cache 整合が疑わしいとき
+
+コマンド:
+
+| 目的 | 高速経路 (cache あり) | uncached 経路 |
+|---|---|---|
+| typecheck + test | `pnpm typecheck && pnpm test` | `pnpm verify:uncached` |
+| typecheck のみ | `pnpm typecheck` | `pnpm typecheck:uncached` |
+| test のみ | `pnpm test` | `pnpm test:uncached` |
+
+CI では通常 PR の `checks` ジョブは引き続きキャッシュ経路で動作する。
+`.github/workflows/verify-uncached.yml` が nightly と手動トリガーで
+uncached 検証を担保する。
+
+---
+
 ## PR 作成のルール
 
 - タイトルはコミットメッセージと同じ形式にする

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "lint:fix": "./scripts/run-biome-check.sh --write",
     "deploy:staging": "turbo run deploy:staging --filter=@tech-clip/api",
     "deploy:production": "turbo run deploy:production --filter=@tech-clip/api",
+    "verify:uncached": "./scripts/verify-uncached.sh",
+    "typecheck:uncached": "./scripts/verify-uncached.sh typecheck",
+    "test:uncached": "./scripts/verify-uncached.sh test",
     "prepare": "husky"
   },
   "pnpm": {

--- a/scripts/verify-uncached.sh
+++ b/scripts/verify-uncached.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/verify-uncached.sh
+#
+# 現 worktree で Turbo cache replay に頼らず typecheck/test を再実行する。
+# 使い方:
+#   scripts/verify-uncached.sh               # typecheck → test を uncached 実行
+#   scripts/verify-uncached.sh typecheck     # typecheck のみ
+#   scripts/verify-uncached.sh test          # test のみ
+
+set -euo pipefail
+
+TASKS=("$@")
+if [ ${#TASKS[@]} -eq 0 ]; then
+  TASKS=(typecheck test)
+fi
+
+for task in "${TASKS[@]}"; do
+  echo "==> uncached: turbo run ${task} --force --no-cache"
+  pnpm turbo run "${task}" --force --no-cache
+done

--- a/scripts/verify-uncached.sh
+++ b/scripts/verify-uncached.sh
@@ -14,7 +14,13 @@ if [ ${#TASKS[@]} -eq 0 ]; then
   TASKS=(typecheck test)
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 for task in "${TASKS[@]}"; do
   echo "==> uncached: turbo run ${task} --force --no-cache"
-  pnpm turbo run "${task}" --force --no-cache
+  if [ "${task}" = "test" ]; then
+    "${SCRIPT_DIR}/run-and-fail-on-stderr.sh" pnpm turbo run "${task}" --force --no-cache
+  else
+    pnpm turbo run "${task}" --force --no-cache
+  fi
 done

--- a/scripts/verify-uncached.sh
+++ b/scripts/verify-uncached.sh
@@ -9,6 +9,9 @@
 
 set -euo pipefail
 
+# 任意の turbo タスクを uncached で実行できる汎用スクリプト。
+# package.json の *:uncached スクリプトから呼ばれるほか、手動実行にも使える。
+# タスク名バリデーションは意図的に省略しており、呼び出し元で制御する設計。
 TASKS=("$@")
 if [ ${#TASKS[@]} -eq 0 ]; then
   TASKS=(typecheck test)


### PR DESCRIPTION
## 概要

Turbo キャッシュ replay に依存しない uncached 検証経路を追加する。
`FULL TURBO` で過去ログが replay されるせいで「この worktree で実際にテストが通ったか」の裏付けが取りづらいため、force + no-cache で再実行する明示的な経路を用意した。

## 変更ファイル

- `scripts/verify-uncached.sh` 新規作成
  - `pnpm turbo run <task> --force --no-cache` を呼び出し cache bypass を強制
  - task が `test` のときは `run-and-fail-on-stderr.sh` 経由で実行し、メイン CI と同等の stderr ガードを通す
- `package.json` に `verify:uncached` / `typecheck:uncached` / `test:uncached` スクリプトを追加
- `.github/workflows/verify-uncached.yml` 新規作成
  - `workflow_dispatch` と nightly (`0 18 * * *` UTC / JST 03:00) で起動
  - `permissions: read-all`、`timeout-minutes: 40`、`concurrency` 設定済み
  - `actions/checkout` は SHA pin、nix-setup ローカルアクション経由で実行
- `docs/CONTRIBUTING.md` に uncached 検証の運用基準を追記

## 設計メモ

- 通常 PR の `checks` ジョブは従来通り cache 経路で高速に走る。uncached 経路は nightly / 手動トリガー / 疑わしい worktree の裏付け用途。
- `--force` で既存キャッシュを無視して再実行、`--no-cache` でキャッシュへの書き込みを抑止。両方付与することで「uncached 実行 + 結果はキャッシュ汚染しない」を満たす。
- test のみ `run-and-fail-on-stderr.sh` ラッパーを挟む。uncached 経路がメイン CI より弱い検証にならないようにするため。

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス
- [x] pnpm typecheck:uncached がローカルで `cache bypass, force executing` と表示して再実行されることを確認

Closes #898

🤖 Reviewed by infra-reviewer agent