### PR TITLE
feat(mobile): ライトモード実装とDARK_COLORS直参照を解消する #923

### DIFF
--- a/apps/mobile/app/(auth)/forgot-password.tsx
+++ b/apps/mobile/app/(auth)/forgot-password.tsx
@@ -13,8 +13,8 @@ import {
 
 import { AuthAlert } from "@/components/auth/AuthAlert";
 import { AuthSubmitButton } from "@/components/auth/AuthSubmitButton";
+import { useColors } from "@/hooks/use-colors";
 import { fetchWithTimeout, getBaseUrl } from "@/lib/api";
-import { DARK_COLORS } from "@/lib/constants";
 import { EMAIL_SIMPLE_REGEX } from "@/lib/validation";
 
 function hasForgotPasswordMessageShape(value: unknown): value is { data: { message: string } } {
@@ -77,6 +77,7 @@ function ForgotPasswordFooter({ hasSuccess }: { hasSuccess: boolean }) {
 
 export default function ForgotPasswordScreen() {
   const { t } = useTranslation();
+  const colors = useColors();
 
   const [email, setEmail] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -160,7 +161,7 @@ export default function ForgotPasswordScreen() {
           <TextInput
             className="rounded-lg border border-border bg-card px-4 py-3 text-base text-text"
             placeholder={t("auth.emailPlaceholder")}
-            placeholderTextColor={DARK_COLORS.textDim}
+            placeholderTextColor={colors.textDim}
             value={email}
             onChangeText={setEmail}
             autoCapitalize="none"

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -15,8 +15,9 @@ import {
 
 import { AuthAlert } from "@/components/auth/AuthAlert";
 import { AuthSubmitButton } from "@/components/auth/AuthSubmitButton";
+import { useColors } from "@/hooks/use-colors";
 import { fetchWithTimeout, getBaseUrl } from "@/lib/api";
-import { APP_SCHEME, DARK_COLORS } from "@/lib/constants";
+import { APP_SCHEME } from "@/lib/constants";
 import { EMAIL_SIMPLE_REGEX, PASSWORD_MIN_LENGTH } from "@/lib/validation";
 import { useAuthStore } from "@/stores/auth-store";
 
@@ -50,6 +51,7 @@ const SOCIAL_PROVIDERS: ReadonlyArray<{ provider: SocialProvider; translationKey
  */
 export default function LoginScreen() {
   const { t } = useTranslation();
+  const colors = useColors();
   const signIn = useAuthStore((s) => s.signIn);
 
   const [email, setEmail] = useState("");
@@ -177,7 +179,7 @@ export default function LoginScreen() {
             <TextInput
               className="rounded-lg border border-border bg-card px-4 py-3 text-base text-text"
               placeholder={t("auth.emailPlaceholder")}
-              placeholderTextColor={DARK_COLORS.textDim}
+              placeholderTextColor={colors.textDim}
               value={email}
               onChangeText={setEmail}
               keyboardType="email-address"
@@ -197,7 +199,7 @@ export default function LoginScreen() {
               <TextInput
                 className="flex-1 px-4 py-3 text-base text-text"
                 placeholder={t("auth.passwordPlaceholder")}
-                placeholderTextColor={DARK_COLORS.textDim}
+                placeholderTextColor={colors.textDim}
                 value={password}
                 onChangeText={setPassword}
                 secureTextEntry={!isPasswordVisible}
@@ -242,7 +244,7 @@ export default function LoginScreen() {
             testID="login-submit-button"
             accessibilityHint={t("auth.loginHint")}
             label={t("auth.login")}
-            indicatorColor={DARK_COLORS.text}
+            indicatorColor={colors.text}
             textClassName="text-base font-semibold text-text"
           />
 
@@ -269,7 +271,7 @@ export default function LoginScreen() {
               >
                 {socialSigningInProvider === provider ? (
                   <ActivityIndicator
-                    color={DARK_COLORS.text}
+                    color={colors.text}
                     size="small"
                     testID={`social-signin-${provider}-loading`}
                   />

--- a/apps/mobile/app/(auth)/register.tsx
+++ b/apps/mobile/app/(auth)/register.tsx
@@ -13,12 +13,13 @@ import {
 
 import { AuthAlert } from "@/components/auth/AuthAlert";
 import { AuthSubmitButton } from "@/components/auth/AuthSubmitButton";
-import { DARK_COLORS } from "@/lib/constants";
+import { useColors } from "@/hooks/use-colors";
 import { EMAIL_SIMPLE_REGEX, PASSWORD_MIN_LENGTH } from "@/lib/validation";
 import { useAuthStore } from "@/stores/auth-store";
 
 export default function RegisterScreen() {
   const { t } = useTranslation();
+  const colors = useColors();
   const signUp = useAuthStore((s) => s.signUp);
 
   const [name, setName] = useState("");
@@ -92,7 +93,7 @@ export default function RegisterScreen() {
             <TextInput
               className="rounded-lg border border-border bg-surface px-4 py-3 text-base text-text"
               placeholder={t("auth.namePlaceholder")}
-              placeholderTextColor={DARK_COLORS.textDim}
+              placeholderTextColor={colors.textDim}
               value={name}
               onChangeText={setName}
               autoCapitalize="words"
@@ -109,7 +110,7 @@ export default function RegisterScreen() {
             <TextInput
               className="rounded-lg border border-border bg-surface px-4 py-3 text-base text-text"
               placeholder={t("auth.emailPlaceholder")}
-              placeholderTextColor={DARK_COLORS.textDim}
+              placeholderTextColor={colors.textDim}
               value={email}
               onChangeText={setEmail}
               autoCapitalize="none"
@@ -127,7 +128,7 @@ export default function RegisterScreen() {
             <TextInput
               className="rounded-lg border border-border bg-surface px-4 py-3 text-base text-text"
               placeholder={t("auth.passwordPlaceholder")}
-              placeholderTextColor={DARK_COLORS.textDim}
+              placeholderTextColor={colors.textDim}
               value={password}
               onChangeText={setPassword}
               secureTextEntry

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,42 +1,35 @@
 import { Tabs } from "expo-router";
 import { Bell, Home, Search, Settings, User } from "lucide-react-native";
 import { useTranslation } from "react-i18next";
-import { Text, useColorScheme, View } from "react-native";
+import { Text, View } from "react-native";
 
+import { useColors } from "@/hooks/use-colors";
 import { useUnreadNotificationCount } from "@/hooks/use-notifications";
-import { DARK_COLORS, LIGHT_COLORS } from "@/lib/constants";
 
 /** タブアイコンサイズ */
 const TAB_ICON_SIZE = 24;
-
-/** 未読バッジの背景色（テーマ連動） */
-function getBadgeBgColor(isDark: boolean): string {
-  return isDark ? DARK_COLORS.favorite : LIGHT_COLORS.favorite;
-}
 
 /** 未読バッジの最大表示数 */
 const BADGE_MAX_COUNT = 99;
 
 export default function TabLayout() {
   const { t } = useTranslation();
-  const colorScheme = useColorScheme();
-  // TODO: ライトモード対応時に `|| true` を除去
-  const isDark = colorScheme === "dark" || true;
+  const colors = useColors();
   const { data: unreadCount } = useUnreadNotificationCount();
 
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: isDark ? DARK_COLORS.primary : LIGHT_COLORS.primary,
-        tabBarInactiveTintColor: isDark ? DARK_COLORS.textDim : LIGHT_COLORS.textDim,
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textDim,
         tabBarStyle: {
-          backgroundColor: isDark ? DARK_COLORS.surface : LIGHT_COLORS.card,
-          borderTopColor: isDark ? DARK_COLORS.border : LIGHT_COLORS.border,
+          backgroundColor: colors.surface,
+          borderTopColor: colors.border,
         },
         headerStyle: {
-          backgroundColor: isDark ? DARK_COLORS.surface : LIGHT_COLORS.card,
+          backgroundColor: colors.surface,
         },
-        headerTintColor: isDark ? DARK_COLORS.text : LIGHT_COLORS.text,
+        headerTintColor: colors.text,
         headerShadowVisible: false,
         tabBarLabelStyle: {
           fontSize: 11,
@@ -67,7 +60,7 @@ export default function TabLayout() {
               {unreadCount != null && unreadCount > 0 && (
                 <View
                   testID="tab-badge"
-                  style={{ backgroundColor: getBadgeBgColor(isDark) }}
+                  style={{ backgroundColor: colors.favorite }}
                   className="absolute -top-1 -right-2 rounded-full min-w-[16px] h-4 items-center justify-center px-1"
                   accessibilityLabel={`未読通知${unreadCount > BADGE_MAX_COUNT ? `${BADGE_MAX_COUNT}件以上` : `${unreadCount}件`}`}
                 >

--- a/apps/mobile/src/components/ErrorBoundary.tsx
+++ b/apps/mobile/src/components/ErrorBoundary.tsx
@@ -5,7 +5,7 @@ import type { WithTranslation } from "react-i18next";
 import { withTranslation } from "react-i18next";
 import { Pressable, Text, View } from "react-native";
 
-import { DARK_COLORS } from "@/lib/constants";
+import { useColors } from "@/hooks/use-colors";
 
 type ErrorBoundaryOwnProps = {
   children: ReactNode;
@@ -22,11 +22,53 @@ type ErrorBoundaryState = {
 /** エラーアイコンサイズ（px） */
 const ERROR_ICON_SIZE = 48;
 
-/** エラーアイコン色 */
-const ERROR_ICON_COLOR = DARK_COLORS.error;
-
 /** リトライアイコンサイズ（px） */
 const RETRY_ICON_SIZE = 20;
+
+type ErrorFallbackProps = {
+  error: Error | null;
+  onRetry: () => void;
+  t: WithTranslation["t"];
+};
+
+/**
+ * `ErrorBoundary` のフォールバック UI
+ *
+ * クラスコンポーネントから切り出した関数コンポーネント。
+ * `useColors()` で OS テーマに応じたカラートークンを取得する。
+ *
+ * @param error - キャッチしたエラーオブジェクト
+ * @param onRetry - リトライボタン押下時のコールバック
+ * @param t - i18n の翻訳関数
+ */
+function ErrorFallback({ error, onRetry, t }: ErrorFallbackProps) {
+  const colors = useColors();
+
+  return (
+    <View
+      testID="error-boundary-fallback"
+      className="flex-1 items-center justify-center bg-background px-8"
+    >
+      <AlertTriangle testID="error-boundary-icon" size={ERROR_ICON_SIZE} color={colors.error} />
+      <Text className="text-lg font-semibold text-text mt-4 text-center">
+        {t("errorBoundary.unexpectedError")}
+      </Text>
+      <Text className="text-sm text-text-muted mt-2 text-center">
+        {error?.message ?? t("errorBoundary.appError")}
+      </Text>
+      <Pressable
+        testID="error-boundary-retry"
+        onPress={onRetry}
+        className="flex-row items-center gap-2 mt-6 rounded-lg bg-primary px-5 py-3"
+        accessibilityRole="button"
+        accessibilityLabel={t("errorBoundary.retry")}
+      >
+        <RefreshCw size={RETRY_ICON_SIZE} color={colors.white} />
+        <Text className="text-white font-semibold">{t("errorBoundary.retry")}</Text>
+      </Pressable>
+    </View>
+  );
+}
 
 /**
  * グローバルエラーバウンダリ
@@ -74,34 +116,7 @@ class ErrorBoundaryBase extends Component<ErrorBoundaryProps, ErrorBoundaryState
       return fallback;
     }
 
-    return (
-      <View
-        testID="error-boundary-fallback"
-        className="flex-1 items-center justify-center bg-background px-8"
-      >
-        <AlertTriangle
-          testID="error-boundary-icon"
-          size={ERROR_ICON_SIZE}
-          color={ERROR_ICON_COLOR}
-        />
-        <Text className="text-lg font-semibold text-text mt-4 text-center">
-          {t("errorBoundary.unexpectedError")}
-        </Text>
-        <Text className="text-sm text-text-muted mt-2 text-center">
-          {this.state.error?.message ?? t("errorBoundary.appError")}
-        </Text>
-        <Pressable
-          testID="error-boundary-retry"
-          onPress={this.handleRetry}
-          className="flex-row items-center gap-2 mt-6 rounded-lg bg-primary px-5 py-3"
-          accessibilityRole="button"
-          accessibilityLabel={t("errorBoundary.retry")}
-        >
-          <RefreshCw size={RETRY_ICON_SIZE} color={DARK_COLORS.white} />
-          <Text className="text-white font-semibold">{t("errorBoundary.retry")}</Text>
-        </Pressable>
-      </View>
-    );
+    return <ErrorFallback error={this.state.error} onRetry={this.handleRetry} t={t} />;
   }
 }
 

--- a/apps/mobile/src/components/OfflineBanner.tsx
+++ b/apps/mobile/src/components/OfflineBanner.tsx
@@ -2,14 +2,11 @@ import { WifiOff } from "lucide-react-native";
 import { useTranslation } from "react-i18next";
 import { Text, View } from "react-native";
 
+import { useColors } from "@/hooks/use-colors";
 import { useNetworkStatus } from "@/hooks/use-network-status";
-import { DARK_COLORS } from "@/lib/constants";
 
 /** オフラインアイコンのサイズ（px） */
 const OFFLINE_ICON_SIZE = 16;
-
-/** オフラインアイコンのカラー */
-const OFFLINE_ICON_COLOR = DARK_COLORS.white;
 
 /**
  * オフライン時に画面上部に表示するバナーコンポーネント
@@ -18,6 +15,7 @@ const OFFLINE_ICON_COLOR = DARK_COLORS.white;
  */
 export function OfflineBanner() {
   const { t } = useTranslation();
+  const colors = useColors();
   const { isOffline } = useNetworkStatus();
 
   if (!isOffline) {
@@ -31,7 +29,7 @@ export function OfflineBanner() {
       accessibilityRole="alert"
       accessibilityLabel={t("common.accessibility.offline")}
     >
-      <WifiOff size={OFFLINE_ICON_SIZE} color={OFFLINE_ICON_COLOR} />
+      <WifiOff size={OFFLINE_ICON_SIZE} color={colors.white} />
       <Text className="text-white text-sm font-medium">{t("common.offline")}</Text>
     </View>
   );

--- a/apps/mobile/src/components/TagPicker.tsx
+++ b/apps/mobile/src/components/TagPicker.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, Text, TextInput, View } from "react-native";
 
-import { DARK_COLORS } from "@/lib/constants";
+import { useColors } from "@/hooks/use-colors";
 
 type TagPickerProps = {
   tags: readonly string[];
@@ -16,12 +16,6 @@ type TagPickerProps = {
 /** タグの最大文字数 */
 const TAG_MAX_LENGTH = 30;
 
-/** 新規タグ入力欄のプレースホルダー色 */
-const PLACEHOLDER_COLOR = DARK_COLORS.textDim;
-
-/** アイコンカラー（ミュート） */
-const ICON_COLOR_MUTED = DARK_COLORS.textMuted;
-
 /** アイコンサイズ（px） */
 const ICON_SIZE = 14;
 
@@ -32,7 +26,7 @@ const DEFAULT_MAX_TAGS = 10;
  * タグ選択コンポーネント
  *
  * 既存タグの表示・選択と新規タグ追加機能を提供する。
- * NativeWindダークテーマ対応。
+ * テーマ連動カラー対応。
  *
  * @param tags - 選択可能なタグ一覧
  * @param selectedTags - 現在選択中のタグ一覧
@@ -48,6 +42,7 @@ export function TagPicker({
   maxTags = DEFAULT_MAX_TAGS,
 }: TagPickerProps) {
   const { t } = useTranslation();
+  const colors = useColors();
   const [newTagText, setNewTagText] = useState("");
   const isAtLimit = selectedTags.length >= maxTags;
 
@@ -101,7 +96,7 @@ export function TagPicker({
               <Text className={`text-sm font-medium ${isSelected ? "text-white" : "text-text"}`}>
                 {tag}
               </Text>
-              {isSelected && <X size={ICON_SIZE} color={DARK_COLORS.white} />}
+              {isSelected && <X size={ICON_SIZE} color={colors.white} />}
             </Pressable>
           );
         })}
@@ -113,7 +108,7 @@ export function TagPicker({
             testID="tag-input"
             className="flex-1 bg-surface border border-border rounded-lg px-3 py-2 text-text text-sm"
             placeholder={t("common.tagInputPlaceholder")}
-            placeholderTextColor={PLACEHOLDER_COLOR}
+            placeholderTextColor={colors.textDim}
             value={newTagText}
             onChangeText={setNewTagText}
             onSubmitEditing={handleAddTag}
@@ -135,7 +130,7 @@ export function TagPicker({
           >
             <Plus
               size={ICON_SIZE + 2}
-              color={newTagText.trim() ? DARK_COLORS.white : ICON_COLOR_MUTED}
+              color={newTagText.trim() ? colors.white : colors.textMuted}
             />
           </Pressable>
         </View>

--- a/apps/mobile/src/components/auth/AuthSubmitButton.tsx
+++ b/apps/mobile/src/components/auth/AuthSubmitButton.tsx
@@ -1,7 +1,7 @@
 import { ActivityIndicator, Pressable, Text } from "react-native";
 import { twMerge } from "tailwind-merge";
 
-import { DARK_COLORS } from "@/lib/constants";
+import { useColors } from "@/hooks/use-colors";
 
 type AuthSubmitButtonProps = {
   label: string;
@@ -25,7 +25,7 @@ const BASE_TEXT_CLASS_NAME = "text-base font-semibold text-white";
  * @param onPress - 押下時の処理
  * @param disabled - 無効状態
  * @param isLoading - ローディング状態
- * @param indicatorColor - ローディングインジケーターの色
+ * @param indicatorColor - ローディングインジケーターの色（未指定時はテーマの white を使用）
  * @param testID - テストID
  * @param accessibilityHint - 補足説明
  * @param textClassName - ラベルのテキストスタイル（サイズ・ウェイト・色）
@@ -36,12 +36,15 @@ export function AuthSubmitButton({
   onPress,
   disabled = false,
   isLoading = false,
-  indicatorColor = DARK_COLORS.white,
+  indicatorColor,
   testID,
   accessibilityHint,
   textClassName,
   className,
 }: AuthSubmitButtonProps) {
+  const colors = useColors();
+  const resolvedIndicatorColor = indicatorColor ?? colors.white;
+
   return (
     <Pressable
       className={twMerge(BASE_BUTTON_CLASS_NAME, className)}
@@ -57,7 +60,7 @@ export function AuthSubmitButton({
       accessibilityState={{ disabled }}
     >
       {isLoading ? (
-        <ActivityIndicator color={indicatorColor} />
+        <ActivityIndicator color={resolvedIndicatorColor} />
       ) : (
         <Text className={twMerge(BASE_TEXT_CLASS_NAME, textClassName)}>{label}</Text>
       )}

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -1,12 +1,15 @@
 import { ActivityIndicator, Pressable, Text } from "react-native";
 
-import { DARK_COLORS } from "@/lib/constants";
+import { useColors } from "@/hooks/use-colors";
 
 /** Buttonコンポーネントで使用可能なバリアント */
 type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "danger";
 
 /** Buttonコンポーネントで使用可能なサイズ */
 type ButtonSize = "sm" | "md" | "lg";
+
+/** useColors() の戻り値型 */
+type ThemeColors = ReturnType<typeof useColors>;
 
 type ButtonProps = {
   children: string;
@@ -50,14 +53,25 @@ const TEXT_SIZE_STYLES: Record<ButtonSize, string> = {
   lg: "text-lg",
 };
 
-/** loading時のActivityIndicatorカラー */
-const LOADING_INDICATOR_COLORS: Record<ButtonVariant, string> = {
-  primary: DARK_COLORS.white,
-  secondary: DARK_COLORS.text,
-  outline: DARK_COLORS.text,
-  ghost: DARK_COLORS.textMuted,
-  danger: DARK_COLORS.white,
-};
+/**
+ * バリアントに対応するローディングインジケーターの色を返す
+ *
+ * @param variant - ボタンバリアント
+ * @param colors - 現在のテーマカラートークン
+ * @returns ActivityIndicator に渡す色
+ */
+function getIndicatorColor(variant: ButtonVariant, colors: ThemeColors): string {
+  switch (variant) {
+    case "primary":
+    case "danger":
+      return colors.white;
+    case "secondary":
+    case "outline":
+      return colors.text;
+    case "ghost":
+      return colors.textMuted;
+  }
+}
 
 /**
  * 汎用ボタンコンポーネント
@@ -78,9 +92,11 @@ export function Button({
   onPress,
   testID = "button",
 }: ButtonProps) {
+  const colors = useColors();
   const isDisabled = disabled || loading;
   const containerStyle = `rounded-lg items-center justify-center ${SIZE_STYLES[size]} ${VARIANT_STYLES[variant]} ${isDisabled ? "opacity-50" : ""}`;
   const textStyle = `${TEXT_VARIANT_STYLES[variant]} ${TEXT_SIZE_STYLES[size]}`;
+  const indicatorColor = getIndicatorColor(variant, colors);
 
   return (
     <Pressable
@@ -92,7 +108,7 @@ export function Button({
       accessibilityState={{ disabled: isDisabled }}
     >
       {loading ? (
-        <ActivityIndicator color={LOADING_INDICATOR_COLORS[variant]} />
+        <ActivityIndicator color={indicatorColor} />
       ) : (
         <Text className={textStyle}>{children}</Text>
       )}

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -1,5 +1,6 @@
 import { ActivityIndicator, Pressable, Text } from "react-native";
 
+import type { ThemeColors } from "@/hooks/use-colors";
 import { useColors } from "@/hooks/use-colors";
 
 /** Buttonコンポーネントで使用可能なバリアント */
@@ -7,9 +8,6 @@ type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "danger";
 
 /** Buttonコンポーネントで使用可能なサイズ */
 type ButtonSize = "sm" | "md" | "lg";
-
-/** useColors() の戻り値型 */
-type ThemeColors = ReturnType<typeof useColors>;
 
 type ButtonProps = {
   children: string;
@@ -70,6 +68,10 @@ function getIndicatorColor(variant: ButtonVariant, colors: ThemeColors): string 
       return colors.text;
     case "ghost":
       return colors.textMuted;
+    default: {
+      const _exhaustive: never = variant;
+      return colors.text;
+    }
   }
 }
 

--- a/apps/mobile/src/components/ui/Input.tsx
+++ b/apps/mobile/src/components/ui/Input.tsx
@@ -1,10 +1,7 @@
 import type { TextInputProps } from "react-native";
 import { Text, TextInput, View } from "react-native";
 
-import { DARK_COLORS } from "@/lib/constants";
-
-/** プレースホルダーの色（テーマのtext-dimに対応） */
-const PLACEHOLDER_COLOR = DARK_COLORS.textDim;
+import { useColors } from "@/hooks/use-colors";
 
 type InputProps = {
   label?: string;
@@ -42,6 +39,7 @@ export function Input({
   autoCapitalize = "none",
   editable = true,
 }: InputProps) {
+  const colors = useColors();
   const borderStyle = error ? "border-error" : "border-border";
   const inputStyle = `bg-surface ${borderStyle} border rounded-lg px-4 py-3 text-text text-base`;
 
@@ -52,7 +50,7 @@ export function Input({
         testID="input-field"
         className={inputStyle}
         placeholder={placeholder}
-        placeholderTextColor={PLACEHOLDER_COLOR}
+        placeholderTextColor={colors.textDim}
         value={value}
         onChangeText={onChangeText}
         secureTextEntry={secureTextEntry}

--- a/apps/mobile/src/components/ui/Skeleton.tsx
+++ b/apps/mobile/src/components/ui/Skeleton.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Animated, type DimensionValue, View } from "react-native";
 
-import { DARK_COLORS } from "@/lib/constants";
+import { useColors } from "@/hooks/use-colors";
 
 type SkeletonProps = {
   width?: DimensionValue;
@@ -30,6 +30,7 @@ const MAX_OPACITY = 0.7;
  */
 export function Skeleton({ width, height, borderRadius = 8, className = "" }: SkeletonProps) {
   const { t } = useTranslation();
+  const colors = useColors();
   const opacity = useRef(new Animated.Value(MIN_OPACITY)).current;
 
   useEffect(() => {
@@ -68,8 +69,8 @@ export function Skeleton({ width, height, borderRadius = 8, className = "" }: Sk
           height,
           borderRadius,
           opacity,
-          /** Animated APIはNativeWindクラス（bg-card等）と直接統合できないため、テーマ定数を直接参照 */
-          backgroundColor: DARK_COLORS.card,
+          /** Animated APIはNativeWindクラス（bg-card等）と直接統合できないため、テーマ連動の値を直接指定 */
+          backgroundColor: colors.card,
         }}
       />
     </View>

--- a/apps/mobile/src/hooks/use-colors.ts
+++ b/apps/mobile/src/hooks/use-colors.ts
@@ -2,22 +2,15 @@ import { useColorScheme } from "react-native";
 
 import { DARK_COLORS, LIGHT_COLORS } from "@/lib/constants";
 
-/** ライトモード対応完了まで強制ダーク固定 */
-const FORCE_DARK_MODE = true;
-
 /**
- * 現在のテーマに対応したカラートークンを返すフック
+ * 現在の OS テーマに対応したカラートークンを返すフック
  *
- * useColorScheme でシステムテーマを取得し、ライト/ダーク対応のカラーセットを返す。
+ * `useColorScheme()` が `"dark"` を返したときのみ `DARK_COLORS` を返し、
+ * それ以外（`"light"` / `null` / `undefined`）はすべて `LIGHT_COLORS` を返す。
  *
- * TODO(#891): ライトモード対応完了後に `FORCE_DARK_MODE` 定数と強制ダーク分岐を除去する
- *
- * @returns テーマ連動のカラートークンオブジェクト
+ * @returns OS テーマ連動のカラートークンオブジェクト
  */
 export function useColors() {
   const colorScheme = useColorScheme();
-  if (FORCE_DARK_MODE) {
-    return DARK_COLORS;
-  }
   return colorScheme === "dark" ? DARK_COLORS : LIGHT_COLORS;
 }

--- a/apps/mobile/src/hooks/use-colors.ts
+++ b/apps/mobile/src/hooks/use-colors.ts
@@ -14,3 +14,6 @@ export function useColors() {
   const colorScheme = useColorScheme();
   return colorScheme === "dark" ? DARK_COLORS : LIGHT_COLORS;
 }
+
+/** useColors() の戻り値型 */
+export type ThemeColors = ReturnType<typeof useColors>;

--- a/tests/mobile/hooks/use-colors.test.ts
+++ b/tests/mobile/hooks/use-colors.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react-native";
 import * as ReactNative from "react-native";
 
 import { useColors } from "../../../apps/mobile/src/hooks/use-colors";
-import { DARK_COLORS } from "../../../apps/mobile/src/lib/constants";
+import { DARK_COLORS, LIGHT_COLORS } from "../../../apps/mobile/src/lib/constants";
 
 describe("useColors", () => {
   beforeEach(() => {
@@ -13,7 +13,7 @@ describe("useColors", () => {
     jest.restoreAllMocks();
   });
 
-  it("ダークモードのとき DARK_COLORS を返すこと", async () => {
+  it("colorScheme が 'dark' のとき DARK_COLORS を返すこと", async () => {
     // Arrange
     jest.spyOn(ReactNative, "useColorScheme").mockReturnValue("dark");
 
@@ -24,8 +24,7 @@ describe("useColors", () => {
     expect(result.current).toBe(DARK_COLORS);
   });
 
-  /** TODO(#891): FORCE_DARK_MODE を false に変更またはロジック除去時は LIGHT_COLORS を返す期待値に差し替える */
-  it("FORCE_DARK_MODE により常に DARK_COLORS を返すこと（ライトモード設定でも）", async () => {
+  it("colorScheme が 'light' のとき LIGHT_COLORS を返すこと", async () => {
     // Arrange
     jest.spyOn(ReactNative, "useColorScheme").mockReturnValue("light");
 
@@ -33,11 +32,10 @@ describe("useColors", () => {
     const { result } = await renderHook(() => useColors());
 
     // Assert
-    expect(result.current).toBe(DARK_COLORS);
+    expect(result.current).toBe(LIGHT_COLORS);
   });
 
-  /** TODO(#891): FORCE_DARK_MODE を false に変更またはロジック除去時は LIGHT_COLORS を返す期待値に差し替える */
-  it("colorScheme が null のとき DARK_COLORS を返すこと", async () => {
+  it("colorScheme が null のとき LIGHT_COLORS を返すこと", async () => {
     // Arrange
     jest.spyOn(ReactNative, "useColorScheme").mockReturnValue(null);
 
@@ -45,6 +43,6 @@ describe("useColors", () => {
     const { result } = await renderHook(() => useColors());
 
     // Assert
-    expect(result.current).toBe(DARK_COLORS);
+    expect(result.current).toBe(LIGHT_COLORS);
   });
 });


### PR DESCRIPTION
## 概要

Issue #923 の対応。OS テーマに完全追従するライトモードを有効化し、モバイルコンポーネント/画面から `DARK_COLORS` の直参照を撤去する。

## 主な変更

- `apps/mobile/src/hooks/use-colors.ts`
  - `FORCE_DARK_MODE` 定数を削除
  - `useColorScheme()` が `"dark"` のときのみ `DARK_COLORS`、それ以外（`"light"` / `null` / `undefined`）は `LIGHT_COLORS` を返すように変更
- `apps/mobile/app/(tabs)/_layout.tsx`
  - `const isDark = colorScheme === "dark" || true;` を削除し、`useColors()` に一本化
  - `getBadgeBgColor` ヘルパーを削除し `colors.favorite` を直接使用
- 以下のコンポーネント/画面で `DARK_COLORS` 直参照を `useColors()` 経由に置換
  - `apps/mobile/src/components/ui/Button.tsx`（`getIndicatorColor(variant, colors)` 関数に変更）
  - `apps/mobile/src/components/ui/Input.tsx`
  - `apps/mobile/src/components/ui/Skeleton.tsx`
  - `apps/mobile/src/components/auth/AuthSubmitButton.tsx`（`indicatorColor` デフォルト値を `useColors().white` に変更）
  - `apps/mobile/src/components/TagPicker.tsx`
  - `apps/mobile/src/components/OfflineBanner.tsx`
  - `apps/mobile/src/components/ErrorBoundary.tsx`（フォールバック UI を `ErrorFallback` 関数コンポーネントに切り出し）
  - `apps/mobile/app/(auth)/login.tsx`
  - `apps/mobile/app/(auth)/register.tsx`
  - `apps/mobile/app/(auth)/forgot-password.tsx`
- `tests/mobile/hooks/use-colors.test.ts` をライト/ダーク/null の 3 ケースに更新

## 既知の制約

`tailwind.config.js` の NativeWind クラス（`bg-surface`, `text-text`, `bg-card` 等）は現状ダーク固定値のまま。ライトモードでも NativeWind クラス部分は黒系で表示される。これは別 Issue #855（移行タスク #3）で対応予定。

## テスト

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（mobile: 884 tests、api: 1440 tests）

Closes #923

🤖 Reviewed by ui-reviewer agent