### PR TITLE
fix(api): R2_PUBLIC_URLを環境変数化して非本番環境でも動作させる #928

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -95,3 +95,13 @@ REVENUECAT_WEBHOOK_SECRET=your-revenuecat-webhook-secret
 
 RESEND_API_KEY=your-resend-api-key
 FROM_EMAIL=no-reply@example.com
+
+# -----------------------------------------------------------------------------
+# R2 (アバター画像ストレージ)
+# -----------------------------------------------------------------------------
+# アバター画像の公開 URL（末尾スラッシュなし）。
+# wrangler.toml の [vars] / [env.production.vars] で環境ごとに既定値を設定済み。
+# ローカルで別の URL を使いたい場合のみ .dev.vars で上書きする。
+#   - development 既定値: http://localhost:8787/avatars
+#   - production  既定値: https://avatars.techclip.io
+# R2_PUBLIC_URL=http://localhost:8787/avatars

--- a/apps/api/src/app/users-subapp.ts
+++ b/apps/api/src/app/users-subapp.ts
@@ -11,9 +11,6 @@ import { createPublicProfileRoute } from "../routes/public-profile";
 import { createUsersRoute } from "../routes/users";
 import type { Bindings } from "../types";
 
-/** 本番環境のアバター公開 URL */
-const PRODUCTION_AVATAR_URL = "https://avatars.techclip.io";
-
 /**
  * フォロー関係のリストをDBから取得する共通クエリビルダー
  *
@@ -139,7 +136,7 @@ export async function handleUsers(
   const usersRoute = createUsersRoute({
     db,
     r2Bucket: env.AVATARS_BUCKET,
-    r2PublicUrl: env.ENVIRONMENT === "production" ? PRODUCTION_AVATAR_URL : undefined,
+    r2PublicUrl: env.R2_PUBLIC_URL,
   });
 
   const followsRoute = createFollowsRoute({

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -126,7 +126,7 @@ const UpdateProfileSchema = z.object({
 type UsersRouteOptions = {
   db: Database;
   r2Bucket?: R2Bucket;
-  r2PublicUrl: string;
+  r2PublicUrl?: string;
 };
 
 /**
@@ -356,7 +356,7 @@ export function createUsersRoute(options: UsersRouteOptions) {
       );
     }
 
-    if (!r2Bucket || !r2PublicUrl) {
+    if (!r2Bucket || !r2PublicUrl || r2PublicUrl.length === 0) {
       return c.json(
         {
           success: false,

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -126,7 +126,7 @@ const UpdateProfileSchema = z.object({
 type UsersRouteOptions = {
   db: Database;
   r2Bucket?: R2Bucket;
-  r2PublicUrl?: string;
+  r2PublicUrl: string;
 };
 
 /**

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -356,7 +356,7 @@ export function createUsersRoute(options: UsersRouteOptions) {
       );
     }
 
-    if (!r2Bucket || !r2PublicUrl || r2PublicUrl.length === 0) {
+    if (!r2Bucket || !r2PublicUrl) {
       return c.json(
         {
           success: false,

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -23,6 +23,8 @@ export type Bindings = {
   CACHE: KVNamespace;
   /** アバター画像保存用 R2 バケット */
   AVATARS_BUCKET: R2Bucket;
+  /** アバター画像の公開 URL（末尾スラッシュなし） */
+  R2_PUBLIC_URL: string;
   /** アプリのベースURL（パスワードリセットリンク生成用） */
   APP_URL?: string;
   /** カンマ区切りの追加 trustedOrigins（例: "https://staging.example.com,https://dev.example.com"） */

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -57,3 +57,26 @@ binding = "AI"
 [[env.production.routes]]
 pattern = "api.techclip.app"
 custom_domain = true
+
+# --- ステージング環境 ---
+[env.staging]
+name = "tech-clip-api-staging"
+[env.staging.vars]
+ENVIRONMENT = "staging"
+APP_URL = "REPLACE_WITH_STAGING_APP_URL"
+R2_PUBLIC_URL = "REPLACE_WITH_STAGING_R2_PUBLIC_URL"
+
+[[env.staging.kv_namespaces]]
+binding = "RATE_LIMIT"
+id = "REPLACE_WITH_STAGING_RATE_LIMIT_KV_ID"
+
+[[env.staging.kv_namespaces]]
+binding = "CACHE"
+id = "REPLACE_WITH_STAGING_CACHE_KV_ID"
+
+[[env.staging.r2_buckets]]
+binding = "AVATARS_BUCKET"
+bucket_name = "tech-clip-avatars-staging"
+
+[env.staging.ai]
+binding = "AI"

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -5,6 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 ENVIRONMENT = "development"
+R2_PUBLIC_URL = "http://localhost:8787/avatars"
 
 [[kv_namespaces]]
 binding = "RATE_LIMIT"
@@ -36,6 +37,7 @@ name = "tech-clip-api-production"
 [env.production.vars]
 ENVIRONMENT = "production"
 APP_URL = "https://techclip.app"
+R2_PUBLIC_URL = "https://avatars.techclip.io"
 
 [[env.production.kv_namespaces]]
 binding = "RATE_LIMIT"


### PR DESCRIPTION
## 概要

アバター upload API の `r2PublicUrl` が production 環境以外で `undefined` になり、ローカル・ステージングでアップロードが 500 INTERNAL_ERROR を返す問題を修正する。`R2_PUBLIC_URL` を Cloudflare Workers の環境変数として管理するように変更し、全環境で動作可能にする。

Closes #928

## 変更内容

- `apps/api/src/types.ts`: `Bindings` 型に `R2_PUBLIC_URL: string` を必須項目として追加
- `apps/api/src/app/users-subapp.ts`: `PRODUCTION_AVATAR_URL` ハードコードを削除し、`env.R2_PUBLIC_URL` をそのまま渡すように変更
- `apps/api/wrangler.toml`: `[vars]`（development）・`[env.production.vars]`・`[env.staging.vars]` の全3環境に `R2_PUBLIC_URL` を設定（staging セクション自体も新規追加）
- `apps/api/.dev.vars.example`: `R2_PUBLIC_URL` の説明・既定値・上書き方法をコメント付きで追加

## 動機

- ローカル開発・ステージング環境でアバター upload の動作確認ができるようになる
- TypeScript 側にハードコードされていた本番ドメインを設定ファイル側に移動し、環境変数化のパターンに統一

## テスト

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（API 1440 tests / Mobile 884 tests）
- [x] 既存のアバター関連テスト（`tests/api/routes/users.test.ts`, `tests/api/services/imageUpload.test.ts`）が壊れないことを確認

🤖 Reviewed by reviewer agent