### PR TITLE
feat(api): リフレッシュトークンの期限切れエントリを定期クリーンアップする

### DIFF
--- a/apps/api/src/cron/cleanupExpiredRefreshTokens.ts
+++ b/apps/api/src/cron/cleanupExpiredRefreshTokens.ts
@@ -1,0 +1,51 @@
+/** 期限切れリフレッシュトークンクリーンアップの依存注入インターフェース */
+export type RefreshTokenCleanupDeps = {
+  deleteExpiredRefreshTokens: (currentTimestamp: string) => Promise<number>;
+  getCurrentTimestamp: () => string;
+};
+
+/** 期限切れリフレッシュトークンクリーンアップの結果 */
+type RefreshTokenCleanupResult = {
+  success: boolean;
+  deletedCount: number;
+};
+
+/**
+ * 期限切れリフレッシュトークンを削除する
+ *
+ * @param deps - 依存注入（DB操作・現在時刻取得）
+ * @returns クリーンアップ結果（成功フラグ・削除件数）
+ */
+export async function cleanupExpiredRefreshTokens(
+  deps: RefreshTokenCleanupDeps,
+): Promise<RefreshTokenCleanupResult> {
+  const currentTimestamp = deps.getCurrentTimestamp();
+  const deletedCount = await deps.deleteExpiredRefreshTokens(currentTimestamp);
+  return { success: true, deletedCount };
+}
+
+/**
+ * Drizzle ORM を使った deleteExpiredRefreshTokens の実装を生成する
+ *
+ * @param db - Drizzle データベースインスタンス
+ * @returns RefreshTokenCleanupDeps に適合した依存オブジェクト
+ */
+export function createRefreshTokenCleanupDeps(db: {
+  delete: (table: unknown) => unknown;
+}): RefreshTokenCleanupDeps {
+  return {
+    deleteExpiredRefreshTokens: async (currentTimestamp) => {
+      const { lt } = await import("drizzle-orm");
+      const { refreshTokens } = await import("../db/schema");
+      const result = await (
+        db.delete(refreshTokens) as ReturnType<typeof db.delete> & {
+          where: (condition: unknown) => { returning: () => Promise<unknown[]> };
+        }
+      )
+        .where(lt(refreshTokens.expiresAt, currentTimestamp))
+        .returning();
+      return (result as unknown[]).length;
+    },
+    getCurrentTimestamp: () => new Date().toISOString(),
+  };
+}

--- a/apps/api/src/cron/cleanupExpiredRefreshTokens.ts
+++ b/apps/api/src/cron/cleanupExpiredRefreshTokens.ts
@@ -1,3 +1,7 @@
+import { lt } from "drizzle-orm";
+
+import { refreshTokens } from "../db/schema";
+
 /** 期限切れリフレッシュトークンクリーンアップの依存注入インターフェース */
 export type RefreshTokenCleanupDeps = {
   deleteExpiredRefreshTokens: (currentTimestamp: string) => Promise<number>;
@@ -6,6 +10,7 @@ export type RefreshTokenCleanupDeps = {
 
 /** 期限切れリフレッシュトークンクリーンアップの結果 */
 type RefreshTokenCleanupResult = {
+  /** 常に true を返す（エラー時は例外をスロー）。他の cron ジョブとの一貫性のため success フィールドを保持 */
   success: boolean;
   deletedCount: number;
 };
@@ -27,7 +32,8 @@ export async function cleanupExpiredRefreshTokens(
 /**
  * Drizzle ORM を使った deleteExpiredRefreshTokens の実装を生成する
  *
- * @param db - Drizzle データベースインスタンス
+ * @param db - Drizzle データベースインスタンス。既存の cron ジョブパターンとの一貫性を保つため
+ *   loose な型 `{ delete: (table: unknown) => unknown }` を使用している
  * @returns RefreshTokenCleanupDeps に適合した依存オブジェクト
  */
 export function createRefreshTokenCleanupDeps(db: {
@@ -35,8 +41,6 @@ export function createRefreshTokenCleanupDeps(db: {
 }): RefreshTokenCleanupDeps {
   return {
     deleteExpiredRefreshTokens: async (currentTimestamp) => {
-      const { lt } = await import("drizzle-orm");
-      const { refreshTokens } = await import("../db/schema");
       const result = await (
         db.delete(refreshTokens) as ReturnType<typeof db.delete> & {
           where: (condition: unknown) => { returning: () => Promise<unknown[]> };

--- a/apps/api/src/db/schema/refresh-tokens.ts
+++ b/apps/api/src/db/schema/refresh-tokens.ts
@@ -8,9 +8,8 @@ import { users } from "./users";
  * refresh_tokensテーブル
  * モバイルクライアント向けのリフレッシュトークンを管理する
  *
- * @todo 期限切れトークンの定期クリーンアップ - 将来的にCronジョブで実装する
- *   例: `DELETE FROM refresh_tokens WHERE expires_at < datetime('now')`
- *   を定期的に実行して、DBの肥大化を防ぐ
+ * 期限切れエントリは `cron/cleanupExpiredRefreshTokens` によって
+ * 月次 Cron トリガー (`[triggers] crons` in wrangler.toml) で削除される
  */
 export const refreshTokens = sqliteTable(
   "refresh_tokens",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,14 @@ import { handleSubscription } from "./app/subscription-subapp";
 import { handleTags } from "./app/tags-subapp";
 import { handlePublicProfile, handleUsers } from "./app/users-subapp";
 import { createAuth } from "./auth";
+import {
+  cleanupExpiredRefreshTokens,
+  createRefreshTokenCleanupDeps,
+} from "./cron/cleanupExpiredRefreshTokens";
+import { createMonthlyResetDeps, resetFreeAiUsesMonthly } from "./cron/monthlyReset";
+import { createSubscriptionCheckDeps, disableExpiredSubscriptions } from "./cron/subscriptionCheck";
 import { createDatabase } from "./db";
+import { createLogger } from "./lib/logger";
 import { corsMiddleware } from "./middleware/cors";
 import { createDbInitMiddleware } from "./middleware/db-init";
 import {
@@ -20,7 +27,7 @@ import {
 import { securityHeadersMiddleware } from "./middleware/security-headers";
 import { createSentryMiddleware } from "./middleware/sentry";
 import { openApiSpec } from "./openapi";
-import type { AppEnv } from "./types";
+import type { AppEnv, Bindings } from "./types";
 
 const app = new Hono<AppEnv>();
 
@@ -121,4 +128,50 @@ app.on(["POST"], "/api/analytics/**", async (c) => {
   return handleAnalytics(c.get("db"), c.get("auth")(), c.req.raw);
 });
 
-export default app;
+/** Cloudflare Workers scheduled イベントハンドラー */
+const scheduled: ExportedHandlerScheduledHandler<Bindings> = async (_event, env, ctx) => {
+  const db = createDatabase(env);
+  const dbForCron = db as unknown as { update: (table: unknown) => unknown } & {
+    delete: (table: unknown) => unknown;
+  };
+  const logger = createLogger();
+  ctx.waitUntil(
+    (async () => {
+      try {
+        const result = await resetFreeAiUsesMonthly(createMonthlyResetDeps(dbForCron));
+        logger.info("cron monthlyReset 完了", { job: "monthlyReset", result });
+      } catch (error) {
+        logger.error("cron monthlyReset 失敗", {
+          job: "monthlyReset",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      try {
+        const result = await disableExpiredSubscriptions(createSubscriptionCheckDeps(dbForCron));
+        logger.info("cron subscriptionCheck 完了", { job: "subscriptionCheck", result });
+      } catch (error) {
+        logger.error("cron subscriptionCheck 失敗", {
+          job: "subscriptionCheck",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      try {
+        const result = await cleanupExpiredRefreshTokens(createRefreshTokenCleanupDeps(dbForCron));
+        logger.info("cron refreshTokenCleanup 完了", {
+          job: "refreshTokenCleanup",
+          result,
+        });
+      } catch (error) {
+        logger.error("cron refreshTokenCleanup 失敗", {
+          job: "refreshTokenCleanup",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })(),
+  );
+};
+
+export default {
+  fetch: app.fetch,
+  scheduled,
+} satisfies ExportedHandler<Bindings>;

--- a/tests/api/cron/cleanupExpiredRefreshTokens.test.ts
+++ b/tests/api/cron/cleanupExpiredRefreshTokens.test.ts
@@ -1,0 +1,160 @@
+import {
+  cleanupExpiredRefreshTokens,
+  createRefreshTokenCleanupDeps,
+  type RefreshTokenCleanupDeps,
+} from "@api/cron/cleanupExpiredRefreshTokens";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("drizzle-orm", () => ({
+  lt: vi.fn((col: unknown, val: unknown) => ({ col, val, op: "lt" })),
+}));
+
+vi.mock("@api/db/schema", () => ({
+  refreshTokens: { expiresAt: "expiresAt" },
+}));
+
+/** 期限切れリフレッシュトークンクリーンアップのテスト用モック */
+function createMockDeps(overrides?: Partial<RefreshTokenCleanupDeps>): RefreshTokenCleanupDeps {
+  return {
+    deleteExpiredRefreshTokens: vi.fn().mockResolvedValue(3),
+    getCurrentTimestamp: vi.fn().mockReturnValue("2024-02-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("cleanupExpiredRefreshTokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("期限切れのトークンを削除できること", async () => {
+      // Arrange
+      const deps = createMockDeps();
+
+      // Act
+      const result = await cleanupExpiredRefreshTokens(deps);
+
+      // Assert
+      expect(deps.deleteExpiredRefreshTokens).toHaveBeenCalledWith("2024-02-01T00:00:00.000Z");
+      expect(result.deletedCount).toBe(3);
+    });
+
+    it("削除成功時にsuccessがtrueであること", async () => {
+      // Arrange
+      const deps = createMockDeps();
+
+      // Act
+      const result = await cleanupExpiredRefreshTokens(deps);
+
+      // Assert
+      expect(result.success).toBe(true);
+    });
+
+    it("対象トークンが0件の場合も正常終了すること", async () => {
+      // Arrange
+      const deps = createMockDeps({
+        deleteExpiredRefreshTokens: vi.fn().mockResolvedValue(0),
+      });
+
+      // Act
+      const result = await cleanupExpiredRefreshTokens(deps);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.deletedCount).toBe(0);
+    });
+
+    it("getCurrentTimestampの結果がdeleteExpiredRefreshTokensに渡ること", async () => {
+      // Arrange
+      const fixedTimestamp = "2024-03-01T00:00:00.000Z";
+      const deps = createMockDeps({
+        getCurrentTimestamp: vi.fn().mockReturnValue(fixedTimestamp),
+      });
+
+      // Act
+      await cleanupExpiredRefreshTokens(deps);
+
+      // Assert
+      expect(deps.deleteExpiredRefreshTokens).toHaveBeenCalledWith(fixedTimestamp);
+    });
+  });
+
+  describe("異常系", () => {
+    it("DB操作が失敗した場合はエラーをスローすること", async () => {
+      // Arrange
+      const deps = createMockDeps({
+        deleteExpiredRefreshTokens: vi.fn().mockRejectedValue(new Error("DBエラーが発生しました")),
+      });
+
+      // Act & Assert
+      await expect(cleanupExpiredRefreshTokens(deps)).rejects.toThrow("DBエラーが発生しました");
+    });
+  });
+});
+
+describe("createRefreshTokenCleanupDeps", () => {
+  it("RefreshTokenCleanupDepsインターフェースに適合したオブジェクトを返すこと", () => {
+    // Arrange
+    const mockReturning = vi.fn().mockResolvedValue([{}, {}]);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+    const mockDelete = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockDb = { delete: mockDelete };
+
+    // Act
+    const deps = createRefreshTokenCleanupDeps(mockDb);
+
+    // Assert
+    expect(deps).toHaveProperty("deleteExpiredRefreshTokens");
+    expect(deps).toHaveProperty("getCurrentTimestamp");
+    expect(typeof deps.deleteExpiredRefreshTokens).toBe("function");
+    expect(typeof deps.getCurrentTimestamp).toBe("function");
+  });
+
+  it("getCurrentTimestampがISO8601形式の文字列を返すこと", () => {
+    // Arrange
+    const mockDb = { delete: vi.fn() };
+
+    // Act
+    const deps = createRefreshTokenCleanupDeps(mockDb);
+    const timestamp = deps.getCurrentTimestamp();
+
+    // Assert
+    expect(typeof timestamp).toBe("string");
+    expect(new Date(timestamp).toISOString()).toBe(timestamp);
+  });
+
+  it("deleteExpiredRefreshTokensがDBのdeleteを呼び出して削除件数を返すこと", async () => {
+    // Arrange
+    const deletedRows = [{}, {}, {}];
+    const mockReturning = vi.fn().mockResolvedValue(deletedRows);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+    const mockDelete = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockDb = { delete: mockDelete };
+    const deps = createRefreshTokenCleanupDeps(mockDb);
+
+    // Act
+    const count = await deps.deleteExpiredRefreshTokens("2024-02-01T00:00:00.000Z");
+
+    // Assert
+    expect(count).toBe(3);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("expiresAt < currentTimestamp 条件でwhereが呼ばれること", async () => {
+    // Arrange
+    const mockReturning = vi.fn().mockResolvedValue([]);
+    const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
+    const mockDelete = vi.fn().mockReturnValue({ where: mockWhere });
+    const mockDb = { delete: mockDelete };
+    const deps = createRefreshTokenCleanupDeps(mockDb);
+    const currentTimestamp = "2024-02-01T00:00:00.000Z";
+
+    // Act
+    await deps.deleteExpiredRefreshTokens(currentTimestamp);
+
+    // Assert（whereが呼ばれたことを確認する）
+    expect(mockWhere).toHaveBeenCalledTimes(1);
+    expect(mockWhere).toHaveBeenCalledWith(expect.anything());
+  });
+});


### PR DESCRIPTION
## 概要

期限切れリフレッシュトークンを月次 Cron で削除する処理を追加する。DB 肥大化を防止するのが目的。

## 変更内容

- `apps/api/src/cron/cleanupExpiredRefreshTokens.ts` 新規追加
  - 期限切れ (`expires_at < currentTimestamp`) の refresh_tokens を Drizzle ORM で DELETE
  - 依存注入 (RefreshTokenCleanupDeps) でテスタブルに実装
- `apps/api/src/index.ts` scheduled ハンドラー追加
  - 月次 Cron (wrangler.toml の \`[triggers] crons = [\"0 0 1 * *\"]\`) で以下を実行
    - monthlyReset
    - subscriptionCheck
    - refreshTokenCleanup (新規)
  - ログ出力は \`createLogger()\` による構造化ログ（console.log 禁止規約遵守）
- \`apps/api/src/db/schema/refresh-tokens.ts\` JSDoc コメントを更新
  - TODO を削除し、クリーンアップ実装の参照先を追記

## テスト

- \`tests/api/cron/cleanupExpiredRefreshTokens.test.ts\` 新規追加（9 テスト）
  - 正常系: 期限切れトークンの削除・0件時の正常終了・タイムスタンプ伝搬
  - 異常系: DB 操作失敗時のエラー伝播
  - \`createRefreshTokenCleanupDeps\` の構造検証

## 確認

- [x] pnpm lint 通過
- [x] pnpm typecheck 通過
- [x] pnpm test 通過（1449 tests）
- [x] console.log / any 型なし
- [x] 日本語エラーメッセージ / JSDoc

Closes #927