### PR TITLE
perf(api): 記事検索をLIKEからFTS5 MATCHに移行する #929

### DIFF
--- a/apps/api/drizzle/0005_add_articles_fts.sql
+++ b/apps/api/drizzle/0005_add_articles_fts.sql
@@ -1,0 +1,37 @@
+-- 外部コンテンツ FTS5 仮想テーブル
+-- articles テーブルの title / content / excerpt を全文検索するためのインデックス
+CREATE VIRTUAL TABLE `articles_fts` USING fts5(
+  title,
+  content,
+  excerpt,
+  content='articles',
+  content_rowid='rowid',
+  tokenize='unicode61 remove_diacritics 2'
+);
+--> statement-breakpoint
+
+-- 既存データを FTS に取り込む（初回ビルド）
+INSERT INTO `articles_fts`(`articles_fts`) VALUES('rebuild');
+--> statement-breakpoint
+
+-- INSERT 同期トリガー
+CREATE TRIGGER `articles_ai_fts` AFTER INSERT ON `articles` BEGIN
+  INSERT INTO `articles_fts`(rowid, title, content, excerpt)
+  VALUES (new.rowid, new.title, new.content, new.excerpt);
+END;
+--> statement-breakpoint
+
+-- DELETE 同期トリガー（FTS5 外部コンテンツ用の特別構文）
+CREATE TRIGGER `articles_ad_fts` AFTER DELETE ON `articles` BEGIN
+  INSERT INTO `articles_fts`(`articles_fts`, rowid, title, content, excerpt)
+  VALUES('delete', old.rowid, old.title, old.content, old.excerpt);
+END;
+--> statement-breakpoint
+
+-- UPDATE 同期トリガー（delete + insert の 2 段階）
+CREATE TRIGGER `articles_au_fts` AFTER UPDATE ON `articles` BEGIN
+  INSERT INTO `articles_fts`(`articles_fts`, rowid, title, content, excerpt)
+  VALUES('delete', old.rowid, old.title, old.content, old.excerpt);
+  INSERT INTO `articles_fts`(rowid, title, content, excerpt)
+  VALUES (new.rowid, new.title, new.content, new.excerpt);
+END;

--- a/apps/api/drizzle/0005_add_articles_fts.sql
+++ b/apps/api/drizzle/0005_add_articles_fts.sql
@@ -11,6 +11,8 @@ CREATE VIRTUAL TABLE `articles_fts` USING fts5(
 --> statement-breakpoint
 
 -- 既存データを FTS に取り込む（初回ビルド）
+-- NOTE: rebuild はテーブル全件スキャンを伴うため処理が重い。
+-- 大量データが存在する場合はメンテナンスウィンドウ内での実行を検討すること。
 INSERT INTO `articles_fts`(`articles_fts`) VALUES('rebuild');
 --> statement-breakpoint
 

--- a/apps/api/drizzle/meta/0005_snapshot.json
+++ b/apps/api/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1418 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c8266127-9aa9-4015-8b0c-f018d40b6510",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_jobs": {
+      "name": "ai_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_job_id": {
+          "name": "provider_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ai_jobs_article": {
+          "name": "idx_ai_jobs_article",
+          "columns": [
+            "article_id"
+          ],
+          "isUnique": false
+        },
+        "idx_ai_jobs_request_key": {
+          "name": "idx_ai_jobs_request_key",
+          "columns": [
+            "request_key"
+          ],
+          "isUnique": false
+        },
+        "idx_ai_jobs_status": {
+          "name": "idx_ai_jobs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_jobs_article_id_articles_id_fk": {
+          "name": "ai_jobs_article_id_articles_id_fk",
+          "tableFrom": "ai_jobs",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "analytics_events": {
+      "name": "analytics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "properties": {
+          "name": "properties",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_analytics_events_user_id": {
+          "name": "idx_analytics_events_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_events_event": {
+          "name": "idx_analytics_events_event",
+          "columns": [
+            "event"
+          ],
+          "isUnique": false
+        },
+        "idx_analytics_events_created_at": {
+          "name": "idx_analytics_events_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "analytics_events_user_id_users_id_fk": {
+          "name": "analytics_events_user_id_users_id_fk",
+          "tableFrom": "analytics_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reading_time_minutes": {
+          "name": "reading_time_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_articles_user_id": {
+          "name": "idx_articles_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_articles_source": {
+          "name": "idx_articles_source",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "idx_articles_created_at": {
+          "name": "idx_articles_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_articles_published_at": {
+          "name": "idx_articles_published_at",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        },
+        "unq_articles_user_url": {
+          "name": "unq_articles_user_url",
+          "columns": [
+            "user_id",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "articles_user_id_users_id_fk": {
+          "name": "articles_user_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "follows": {
+      "name": "follows",
+      "columns": {
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_follows_follower": {
+          "name": "idx_follows_follower",
+          "columns": [
+            "follower_id"
+          ],
+          "isUnique": false
+        },
+        "idx_follows_following": {
+          "name": "idx_follows_following",
+          "columns": [
+            "following_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "follows_follower_id_users_id_fk": {
+          "name": "follows_follower_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_following_id_users_id_fk": {
+          "name": "follows_following_id_users_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_follower_id_following_id_pk": {
+          "columns": [
+            "follower_id",
+            "following_id"
+          ],
+          "name": "follows_follower_id_following_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "article_tags": {
+      "name": "article_tags",
+      "columns": {
+        "article_id": {
+          "name": "article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "article_tags_article_id_articles_id_fk": {
+          "name": "article_tags_article_id_articles_id_fk",
+          "tableFrom": "article_tags",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "article_tags_tag_id_tags_id_fk": {
+          "name": "article_tags_tag_id_tags_id_fk",
+          "tableFrom": "article_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "article_tags_article_id_tag_id_pk": {
+          "columns": [
+            "article_id",
+            "tag_id"
+          ],
+          "name": "article_tags_article_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_settings": {
+      "name": "notification_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_article": {
+          "name": "new_article",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "ai_complete": {
+          "name": "ai_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "follow": {
+          "name": "follow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "system": {
+          "name": "system",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "notification_settings_user_id_unique": {
+          "name": "notification_settings_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_settings_user_id_users_id_fk": {
+          "name": "notification_settings_user_id_users_id_fk",
+          "tableFrom": "notification_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user": {
+          "name": "idx_notifications_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            "user_id",
+            "is_read"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "summaries": {
+      "name": "summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_summaries_article": {
+          "name": "idx_summaries_article",
+          "columns": [
+            "article_id"
+          ],
+          "isUnique": false
+        },
+        "unq_summaries_article_language": {
+          "name": "unq_summaries_article_language",
+          "columns": [
+            "article_id",
+            "language"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "summaries_article_id_articles_id_fk": {
+          "name": "summaries_article_id_articles_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tags_user_id": {
+          "name": "idx_tags_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "unq_tags_user_name": {
+          "name": "unq_tags_user_name",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translations": {
+      "name": "translations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "translated_title": {
+          "name": "translated_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "translated_content": {
+          "name": "translated_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_translations_article": {
+          "name": "idx_translations_article",
+          "columns": [
+            "article_id"
+          ],
+          "isUnique": false
+        },
+        "unq_translations_article_language": {
+          "name": "unq_translations_article_language",
+          "columns": [
+            "article_id",
+            "target_language"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "translations_article_id_articles_id_fk": {
+          "name": "translations_article_id_articles_id_fk",
+          "tableFrom": "translations",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitter_username": {
+          "name": "twitter_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_profile_public": {
+          "name": "is_profile_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "preferred_language": {
+          "name": "preferred_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'ja'"
+        },
+        "is_premium": {
+          "name": "is_premium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "premium_expires_at": {
+          "name": "premium_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "free_ai_uses_remaining": {
+          "name": "free_ai_uses_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "free_ai_reset_at": {
+          "name": "free_ai_reset_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "push_enabled": {
+          "name": "push_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/0005_snapshot.json
+++ b/apps/api/drizzle/meta/0005_snapshot.json
@@ -2,7 +2,7 @@
   "version": "6",
   "dialect": "sqlite",
   "id": "c8266127-9aa9-4015-8b0c-f018d40b6510",
-  "prevId": "00000000-0000-0000-0000-000000000000",
+  "prevId": "3a58953f-6329-4f40-a297-0135ce88732f",
   "tables": {
     "accounts": {
       "name": "accounts",

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -26,20 +26,6 @@
     {
       "idx": 3,
       "version": "6",
-      "when": 1775100000000,
-      "tag": "0003_add_refresh_tokens_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "6",
-      "when": 1775200000000,
-      "tag": "0004_add_refresh_token_reuse_detection",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "6",
       "when": 1775300000000,
       "tag": "0005_add_articles_fts",
       "breakpoints": true

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -22,6 +22,27 @@
       "when": 1775035728229,
       "tag": "0002_amusing_jamie_braddock",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775100000000,
+      "tag": "0003_add_refresh_tokens_table",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1775200000000,
+      "tag": "0004_add_refresh_token_reuse_detection",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1775300000000,
+      "tag": "0005_add_articles_fts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/articles-subapp.ts
+++ b/apps/api/src/app/articles-subapp.ts
@@ -122,6 +122,9 @@ export async function handleArticles(
   const searchRoute = createSearchRoute({
     searchQueryFn: async (params) => {
       const matchExpr = buildFtsMatchExpression(params.query);
+      if (matchExpr === null) {
+        return [];
+      }
       const conditions = [
         eq(articles.userId, params.userId),
         sql`articles.rowid IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ${matchExpr})`,

--- a/apps/api/src/app/articles-subapp.ts
+++ b/apps/api/src/app/articles-subapp.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, like, lt, or } from "drizzle-orm";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
 import { Hono } from "hono";
 
 import type { Auth } from "../auth";
@@ -16,7 +16,7 @@ import { createAiRoute } from "../routes/ai";
 import { createArticlesRoute } from "../routes/articles";
 import { createFavoriteRoute } from "../routes/favorite";
 import { createPublicArticlesRoute } from "../routes/public-articles";
-import { createSearchRoute, escapeLikeWildcards } from "../routes/search";
+import { buildFtsMatchExpression, createSearchRoute } from "../routes/search";
 import { createSummaryRoute } from "../routes/summary";
 import { parseArticle } from "../services/article-parser";
 import { summarizeArticle } from "../services/summary";
@@ -121,14 +121,10 @@ export async function handleArticles(
 
   const searchRoute = createSearchRoute({
     searchQueryFn: async (params) => {
-      const keyword = `%${escapeLikeWildcards(params.query)}%`;
+      const matchExpr = buildFtsMatchExpression(params.query);
       const conditions = [
         eq(articles.userId, params.userId),
-        or(
-          like(articles.title, keyword),
-          like(articles.content, keyword),
-          like(articles.excerpt, keyword),
-        ),
+        sql`articles.rowid IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ${matchExpr})`,
       ];
       if (params.cursor) {
         conditions.push(lt(articles.id, params.cursor));

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -18,6 +18,9 @@ import { omitContent } from "../lib/response-utils";
  *
  * @param query - 検索キーワード（スペース区切り複数語可）
  * @returns FTS5 MATCH 式文字列。トークンが空の場合はnull
+ * @note FTS5 の unicode61 tokenizer はスペース・句読点を区切りとするため、
+ *       スペースなしの日本語テキスト（例: 「Reactフレームワーク」）は
+ *       単一トークンとして扱われ、部分一致検索が効かない場合がある。
  */
 export function buildFtsMatchExpression(query: string): string | null {
   const tokens = query

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -9,26 +9,24 @@ import {
 import { HTTP_UNAUTHORIZED, HTTP_UNPROCESSABLE_ENTITY } from "../lib/http-status";
 import { omitContent } from "../lib/response-utils";
 
-/** マッチしない特殊トークン（防御的フォールバック用） */
-const FTS_NO_MATCH_TOKEN = '"___no_match___"*';
-
 /**
  * 検索クエリをFTS5のMATCH式に変換する
  *
  * 各トークンをダブルクォートで囲み前方一致（*）を付加し、ANDで連結する。
  * ダブルクォートはダブルクォート2連でエスケープする。
+ * トークンが存在しない場合はnullを返す（呼び出し元で0件として処理する）。
  *
  * @param query - 検索キーワード（スペース区切り複数語可）
- * @returns FTS5 MATCH 式文字列
+ * @returns FTS5 MATCH 式文字列。トークンが空の場合はnull
  */
-export function buildFtsMatchExpression(query: string): string {
+export function buildFtsMatchExpression(query: string): string | null {
   const tokens = query
     .trim()
     .split(/\s+/)
     .filter((t) => t.length > 0);
 
   if (tokens.length === 0) {
-    return FTS_NO_MATCH_TOKEN;
+    return null;
   }
 
   return tokens.map((token) => `"${token.replace(/"/g, '""')}"*`).join(" AND ");
@@ -65,7 +63,7 @@ type SearchRouteOptions = {
 /**
  * 全文検索ルートを生成する
  *
- * GET /search: title/content/excerptをLIKE検索（認証必須、カーソルベースページネーション）
+ * GET /search: title/content/excerptをFTS5 MATCHで全文検索（認証必須、カーソルベースページネーション）
  *
  * @param options - 検索クエリ関数
  * @returns Hono ルーターインスタンス

--- a/apps/api/src/routes/search.ts
+++ b/apps/api/src/routes/search.ts
@@ -9,14 +9,29 @@ import {
 import { HTTP_UNAUTHORIZED, HTTP_UNPROCESSABLE_ENTITY } from "../lib/http-status";
 import { omitContent } from "../lib/response-utils";
 
+/** マッチしない特殊トークン（防御的フォールバック用） */
+const FTS_NO_MATCH_TOKEN = '"___no_match___"*';
+
 /**
- * LIKE検索のワイルドカード文字をエスケープする
+ * 検索クエリをFTS5のMATCH式に変換する
  *
- * @param input - エスケープ対象の文字列
- * @returns エスケープ済み文字列
+ * 各トークンをダブルクォートで囲み前方一致（*）を付加し、ANDで連結する。
+ * ダブルクォートはダブルクォート2連でエスケープする。
+ *
+ * @param query - 検索キーワード（スペース区切り複数語可）
+ * @returns FTS5 MATCH 式文字列
  */
-export function escapeLikeWildcards(input: string): string {
-  return input.replace(/[%_\\]/g, (char) => `\\${char}`);
+export function buildFtsMatchExpression(query: string): string {
+  const tokens = query
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+
+  if (tokens.length === 0) {
+    return FTS_NO_MATCH_TOKEN;
+  }
+
+  return tokens.map((token) => `"${token.replace(/"/g, '""')}"*`).join(" AND ");
 }
 
 /** デフォルトのページサイズ */

--- a/tests/api/integration/search-fts.test.ts
+++ b/tests/api/integration/search-fts.test.ts
@@ -1,5 +1,14 @@
 import path from "node:path";
 
+/**
+ * Drizzle マイグレーションファイルのフォルダパスを返す
+ *
+ * @returns apps/api/drizzle ディレクトリの絶対パス
+ */
+function getDrizzleMigrationsFolder(): string {
+  return path.resolve(import.meta.dirname, "../../../apps/api/drizzle");
+}
+
 import { articles } from "@api/db/schema/articles";
 import { users } from "@api/db/schema/users";
 import { buildFtsMatchExpression } from "@api/routes/search";
@@ -49,14 +58,17 @@ const ARTICLE_BASE = {
  *
  * @param db - Drizzle DBインスタンス
  * @param userId - 検索対象ユーザーID
- * @param matchExpr - FTS5 MATCH 式
+ * @param matchExpr - FTS5 MATCH 式。nullの場合は空配列を返す
  * @returns 記事一覧
  */
 async function searchArticlesByFts(
   db: ReturnType<typeof drizzle>,
   userId: string,
-  matchExpr: string,
+  matchExpr: string | null,
 ) {
+  if (matchExpr === null) {
+    return [];
+  }
   return await db
     .select()
     .from(articles)
@@ -78,7 +90,7 @@ describe("FTS5 全文検索 統合テスト", () => {
     db = drizzle(client);
 
     await migrate(db, {
-      migrationsFolder: path.resolve(import.meta.dirname, "../../../apps/api/drizzle"),
+      migrationsFolder: getDrizzleMigrationsFolder(),
     });
 
     await db.insert(users).values([TEST_USER_1, TEST_USER_2]);
@@ -268,14 +280,11 @@ describe("FTS5 全文検索 統合テスト", () => {
     });
   });
 
-  describe("rebuild動作", () => {
-    it("マイグレーション時点で既存データがFTSに取り込まれていること", async () => {
+  describe("INSERTトリガーによるFTS同期確認", () => {
+    it("INSERTトリガーにより挿入した記事がFTSで検索できること", async () => {
       // Arrange: すでに beforeAll で migrate が実行されており、
-      // migrate 後に insert した記事は rebuild の対象外だが、
-      // この検証は INSERT トリガーが正しく動いていることを確認する
-
       // テスト開始時にINSERTした article_fts_insert_01 が検索できることで
-      // トリガーが機能していることを確認
+      // INSERT トリガーが機能していることを確認する
       const matchExpr = buildFtsMatchExpression("React");
       const results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
 

--- a/tests/api/integration/search-fts.test.ts
+++ b/tests/api/integration/search-fts.test.ts
@@ -1,14 +1,5 @@
 import path from "node:path";
 
-/**
- * Drizzle マイグレーションファイルのフォルダパスを返す
- *
- * @returns apps/api/drizzle ディレクトリの絶対パス
- */
-function getDrizzleMigrationsFolder(): string {
-  return path.resolve(import.meta.dirname, "../../../apps/api/drizzle");
-}
-
 import { articles } from "@api/db/schema/articles";
 import { users } from "@api/db/schema/users";
 import { buildFtsMatchExpression } from "@api/routes/search";
@@ -17,6 +8,15 @@ import { and, desc, eq, lt, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate } from "drizzle-orm/libsql/migrator";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Drizzle マイグレーションファイルのフォルダパスを返す
+ *
+ * @returns apps/api/drizzle ディレクトリの絶対パス
+ */
+function getDrizzleMigrationsFolder(): string {
+  return path.resolve(import.meta.dirname, "../../../apps/api/drizzle");
+}
 
 /** テスト用ユーザー1 */
 const TEST_USER_1 = {
@@ -282,14 +282,25 @@ describe("FTS5 全文検索 統合テスト", () => {
 
   describe("INSERTトリガーによるFTS同期確認", () => {
     it("INSERTトリガーにより挿入した記事がFTSで検索できること", async () => {
-      // Arrange: すでに beforeAll で migrate が実行されており、
-      // テスト開始時にINSERTした article_fts_insert_01 が検索できることで
-      // INSERT トリガーが機能していることを確認する
-      const matchExpr = buildFtsMatchExpression("React");
+      // Arrange
+      const articleId = "article_fts_trigger_insert_01";
+      const uniqueKeyword = "TriggerSyncKeyword";
+      await db.insert(articles).values({
+        ...ARTICLE_BASE,
+        id: articleId,
+        userId: TEST_USER_1.id,
+        url: "https://example.com/trigger-sync-test",
+        title: `${uniqueKeyword} INSERTトリガー確認`,
+        content: "INSERTトリガーによるFTS同期確認用本文",
+        excerpt: "INSERTトリガー確認",
+      });
+
+      // Act
+      const matchExpr = buildFtsMatchExpression(uniqueKeyword);
       const results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
 
       // Assert
-      expect(results.length).toBeGreaterThan(0);
+      expect(results.some((r) => r.id === articleId)).toBe(true);
     });
   });
 

--- a/tests/api/integration/search-fts.test.ts
+++ b/tests/api/integration/search-fts.test.ts
@@ -1,0 +1,340 @@
+import path from "node:path";
+
+import { articles } from "@api/db/schema/articles";
+import { users } from "@api/db/schema/users";
+import { buildFtsMatchExpression } from "@api/routes/search";
+import { createClient } from "@libsql/client";
+import { and, desc, eq, lt, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/** テスト用ユーザー1 */
+const TEST_USER_1 = {
+  id: "user_fts_01",
+  name: "FTSテストユーザー1",
+  email: "fts1@example.com",
+  emailVerified: false,
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+/** テスト用ユーザー2 */
+const TEST_USER_2 = {
+  id: "user_fts_02",
+  name: "FTSテストユーザー2",
+  email: "fts2@example.com",
+  emailVerified: false,
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+/** テスト用記事の基本データ */
+const ARTICLE_BASE = {
+  url: "https://example.com/article",
+  source: "zenn",
+  author: "著者",
+  thumbnailUrl: null,
+  readingTimeMinutes: 5,
+  isRead: false,
+  isFavorite: false,
+  isPublic: false,
+  publishedAt: new Date("2024-01-01"),
+  createdAt: new Date("2024-01-01"),
+  updatedAt: new Date("2024-01-01"),
+};
+
+/**
+ * FTS MATCH クエリを実行し、ユーザースコープで絞り込む
+ *
+ * @param db - Drizzle DBインスタンス
+ * @param userId - 検索対象ユーザーID
+ * @param matchExpr - FTS5 MATCH 式
+ * @returns 記事一覧
+ */
+async function searchArticlesByFts(
+  db: ReturnType<typeof drizzle>,
+  userId: string,
+  matchExpr: string,
+) {
+  return await db
+    .select()
+    .from(articles)
+    .where(
+      and(
+        eq(articles.userId, userId),
+        sql`articles.rowid IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ${matchExpr})`,
+      ),
+    )
+    .orderBy(desc(articles.createdAt));
+}
+
+describe("FTS5 全文検索 統合テスト", () => {
+  let db: ReturnType<typeof drizzle>;
+  let client: ReturnType<typeof createClient>;
+
+  beforeAll(async () => {
+    client = createClient({ url: ":memory:" });
+    db = drizzle(client);
+
+    await migrate(db, {
+      migrationsFolder: path.resolve(import.meta.dirname, "../../../apps/api/drizzle"),
+    });
+
+    await db.insert(users).values([TEST_USER_1, TEST_USER_2]);
+  });
+
+  afterAll(async () => {
+    client.close();
+  });
+
+  describe("INSERT後のFTS同期", () => {
+    it("記事をINSERTした直後にMATCHクエリでヒットすること", async () => {
+      // Arrange
+      const articleId = "article_fts_insert_01";
+      await db.insert(articles).values({
+        ...ARTICLE_BASE,
+        id: articleId,
+        userId: TEST_USER_1.id,
+        url: "https://example.com/react-hooks",
+        title: "React hooks完全ガイド",
+        content: "useStateとuseEffectの使い方",
+        excerpt: "React hooksの基本",
+      });
+
+      // Act
+      const matchExpr = buildFtsMatchExpression("React");
+      const results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+
+      // Assert
+      expect(results.some((r) => r.id === articleId)).toBe(true);
+    });
+
+    it("複数語AND検索で全トークンを含む記事のみヒットすること", async () => {
+      // Arrange
+      const article1Id = "article_fts_multi_01";
+      const article2Id = "article_fts_multi_02";
+      await db.insert(articles).values([
+        {
+          ...ARTICLE_BASE,
+          id: article1Id,
+          userId: TEST_USER_1.id,
+          url: "https://example.com/ts-advanced",
+          title: "TypeScript advanced patterns",
+          content: "TypeScriptの高度なパターン",
+          excerpt: "TypeScript advanced",
+        },
+        {
+          ...ARTICLE_BASE,
+          id: article2Id,
+          userId: TEST_USER_1.id,
+          url: "https://example.com/ts-basic",
+          title: "TypeScript基礎",
+          content: "TypeScriptの基礎知識",
+          excerpt: "TypeScript入門",
+        },
+      ]);
+
+      // Act: "TypeScript" AND "advanced" の両方を含む記事のみヒット
+      const matchExpr = buildFtsMatchExpression("TypeScript advanced");
+      const results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+
+      // Assert: article1はヒット、article2はヒットしない
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain(article1Id);
+      expect(ids).not.toContain(article2Id);
+    });
+  });
+
+  describe("UPDATE後のFTS同期", () => {
+    it("記事をUPDATEした後、古いタイトルではヒットせず新しいタイトルでヒットすること", async () => {
+      // Arrange
+      const articleId = "article_fts_update_01";
+      await db.insert(articles).values({
+        ...ARTICLE_BASE,
+        id: articleId,
+        userId: TEST_USER_1.id,
+        url: "https://example.com/update-test",
+        title: "OldTitle検索テスト",
+        content: "更新テスト用記事本文",
+        excerpt: "更新テスト",
+      });
+
+      // Act: タイトルを更新
+      await db
+        .update(articles)
+        .set({ title: "NewTitle更新後テスト", updatedAt: new Date() })
+        .where(eq(articles.id, articleId));
+
+      // Assert: 古いタイトルではヒットしない
+      const oldMatchExpr = buildFtsMatchExpression("OldTitle");
+      const oldResults = await searchArticlesByFts(db, TEST_USER_1.id, oldMatchExpr);
+      expect(oldResults.some((r) => r.id === articleId)).toBe(false);
+
+      // Assert: 新しいタイトルでヒットする
+      const newMatchExpr = buildFtsMatchExpression("NewTitle");
+      const newResults = await searchArticlesByFts(db, TEST_USER_1.id, newMatchExpr);
+      expect(newResults.some((r) => r.id === articleId)).toBe(true);
+    });
+  });
+
+  describe("DELETE後のFTS同期", () => {
+    it("記事をDELETEした後にMATCHクエリでヒットしないこと", async () => {
+      // Arrange
+      const articleId = "article_fts_delete_01";
+      await db.insert(articles).values({
+        ...ARTICLE_BASE,
+        id: articleId,
+        userId: TEST_USER_1.id,
+        url: "https://example.com/delete-test",
+        title: "DeleteTarget削除テスト記事",
+        content: "削除テスト用本文",
+        excerpt: "削除テスト",
+      });
+
+      // 削除前はヒットすることを確認
+      const matchExpr = buildFtsMatchExpression("DeleteTarget");
+      const beforeResults = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+      expect(beforeResults.some((r) => r.id === articleId)).toBe(true);
+
+      // Act
+      await db.delete(articles).where(eq(articles.id, articleId));
+
+      // Assert
+      const afterResults = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+      expect(afterResults.some((r) => r.id === articleId)).toBe(false);
+    });
+  });
+
+  describe("ユーザースコープ絞り込み", () => {
+    it("別ユーザーの記事はヒットしないこと", async () => {
+      // Arrange
+      const user1ArticleId = "article_fts_scope_01";
+      const user2ArticleId = "article_fts_scope_02";
+      const uniqueKeyword = "UniqueKeywordForScope";
+
+      await db.insert(articles).values([
+        {
+          ...ARTICLE_BASE,
+          id: user1ArticleId,
+          userId: TEST_USER_1.id,
+          url: "https://example.com/scope-user1",
+          title: `${uniqueKeyword} ユーザー1の記事`,
+          content: "ユーザー1の本文",
+          excerpt: "ユーザー1の概要",
+        },
+        {
+          ...ARTICLE_BASE,
+          id: user2ArticleId,
+          userId: TEST_USER_2.id,
+          url: "https://example.com/scope-user2",
+          title: `${uniqueKeyword} ユーザー2の記事`,
+          content: "ユーザー2の本文",
+          excerpt: "ユーザー2の概要",
+        },
+      ]);
+
+      // Act: ユーザー1のスコープで検索
+      const matchExpr = buildFtsMatchExpression(uniqueKeyword);
+      const user1Results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+
+      // Assert: ユーザー1の記事のみヒット
+      const ids = user1Results.map((r) => r.id);
+      expect(ids).toContain(user1ArticleId);
+      expect(ids).not.toContain(user2ArticleId);
+    });
+  });
+
+  describe("部分文字列検索の動作", () => {
+    it("LIKE検索でヒットしていた部分文字列（単語境界なし）がFTSではヒットしないこと", async () => {
+      // Arrange
+      const articleId = "article_fts_boundary_01";
+      await db.insert(articles).values({
+        ...ARTICLE_BASE,
+        id: articleId,
+        userId: TEST_USER_1.id,
+        url: "https://example.com/boundary-test",
+        title: "React Framework",
+        content: "Reactの仕組みを解説",
+        excerpt: "React解説",
+      });
+
+      // Act: "eac" は "React" の部分文字列だが単語ではない
+      const matchExpr = buildFtsMatchExpression("eac");
+      const results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+
+      // Assert: FTSでは単語境界でトークン化されるため "eac" はヒットしない
+      expect(results.some((r) => r.id === articleId)).toBe(false);
+    });
+  });
+
+  describe("rebuild動作", () => {
+    it("マイグレーション時点で既存データがFTSに取り込まれていること", async () => {
+      // Arrange: すでに beforeAll で migrate が実行されており、
+      // migrate 後に insert した記事は rebuild の対象外だが、
+      // この検証は INSERT トリガーが正しく動いていることを確認する
+
+      // テスト開始時にINSERTした article_fts_insert_01 が検索できることで
+      // トリガーが機能していることを確認
+      const matchExpr = buildFtsMatchExpression("React");
+      const results = await searchArticlesByFts(db, TEST_USER_1.id, matchExpr);
+
+      // Assert
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("カーソルページネーション", () => {
+    it("cursorを指定してFTS検索でページネーションできること", async () => {
+      // Arrange: 複数の記事をINSERT
+      const baseTime = new Date("2024-06-01");
+      const articleIds = ["article_page_01", "article_page_02", "article_page_03"];
+      for (let i = 0; i < articleIds.length; i++) {
+        await db.insert(articles).values({
+          ...ARTICLE_BASE,
+          id: articleIds[i],
+          userId: TEST_USER_1.id,
+          url: `https://example.com/page-${i}`,
+          title: `PaginationKeyword記事 ${i + 1}`,
+          content: `ページネーションテスト本文 ${i + 1}`,
+          excerpt: `ページネーション ${i + 1}`,
+          createdAt: new Date(baseTime.getTime() - i * 1000),
+          updatedAt: new Date(baseTime.getTime() - i * 1000),
+        });
+      }
+
+      // Act: cursor付きで検索
+      const matchExpr = buildFtsMatchExpression("PaginationKeyword");
+      const allResults = await db
+        .select()
+        .from(articles)
+        .where(
+          and(
+            eq(articles.userId, TEST_USER_1.id),
+            sql`articles.rowid IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ${matchExpr})`,
+          ),
+        )
+        .orderBy(desc(articles.createdAt))
+        .limit(2);
+
+      expect(allResults.length).toBe(2);
+
+      // cursor以降を取得
+      const cursor = allResults[allResults.length - 1].id;
+      const nextResults = await db
+        .select()
+        .from(articles)
+        .where(
+          and(
+            eq(articles.userId, TEST_USER_1.id),
+            sql`articles.rowid IN (SELECT rowid FROM articles_fts WHERE articles_fts MATCH ${matchExpr})`,
+            lt(articles.id, cursor),
+          ),
+        )
+        .orderBy(desc(articles.createdAt));
+
+      // Assert: cursor以降の記事が取得できる
+      expect(nextResults.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/tests/api/routes/search.test.ts
+++ b/tests/api/routes/search.test.ts
@@ -192,7 +192,7 @@ describe("buildFtsMatchExpression", () => {
     expect(result).toBe('"TypeScript"*');
   });
 
-  it("空文字列の場合マッチしない特殊トークンを返すこと", () => {
+  it("空文字列の場合nullを返すこと", () => {
     // Arrange
     const query = "";
 
@@ -200,10 +200,10 @@ describe("buildFtsMatchExpression", () => {
     const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe('"___no_match___"*');
+    expect(result).toBeNull();
   });
 
-  it("全スペースの場合マッチしない特殊トークンを返すこと", () => {
+  it("全スペースの場合nullを返すこと", () => {
     // Arrange
     const query = "   ";
 
@@ -211,7 +211,7 @@ describe("buildFtsMatchExpression", () => {
     const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe('"___no_match___"*');
+    expect(result).toBeNull();
   });
 });
 

--- a/tests/api/routes/search.test.ts
+++ b/tests/api/routes/search.test.ts
@@ -1,6 +1,6 @@
 import { HTTP_UNAUTHORIZED, HTTP_UNPROCESSABLE_ENTITY } from "@api/lib/http-status";
 import type { SearchQueryFn } from "@api/routes/search";
-import { createSearchRoute, escapeLikeWildcards } from "@api/routes/search";
+import { buildFtsMatchExpression, createSearchRoute } from "@api/routes/search";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -103,71 +103,115 @@ function createTestAppWithoutAuth(mockSearchQueryFn: MockSearchQueryFn) {
   return app;
 }
 
-describe("escapeLikeWildcards", () => {
-  it("通常の文字列はそのまま返すこと", () => {
+describe("buildFtsMatchExpression", () => {
+  it("通常の単語をFTS5 MATCH式に変換できること", () => {
     // Arrange
-    const input = "React hooks";
+    const query = "React";
 
     // Act
-    const result = escapeLikeWildcards(input);
+    const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe("React hooks");
+    expect(result).toBe('"React"*');
   });
 
-  it("%を含む場合エスケープされること", () => {
+  it("複数語をANDで連結したFTS5 MATCH式に変換できること", () => {
     // Arrange
-    const input = "100%完了";
+    const query = "React hooks";
 
     // Act
-    const result = escapeLikeWildcards(input);
+    const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe("100\\%完了");
+    expect(result).toBe('"React"* AND "hooks"*');
   });
 
-  it("_を含む場合エスケープされること", () => {
+  it("ダブルクォートを含む場合二重クォートでエスケープされること", () => {
     // Arrange
-    const input = "foo_bar";
+    const query = 'foo"bar';
 
     // Act
-    const result = escapeLikeWildcards(input);
+    const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe("foo\\_bar");
+    expect(result).toBe('"foo""bar"*');
   });
 
-  it("バックスラッシュを含む場合エスケープされること", () => {
+  it("FTS5記号（ハイフン）を含む場合ダブルクォートで無効化されること", () => {
     // Arrange
-    const input = "C:\\path";
+    const query = "foo-bar";
 
     // Act
-    const result = escapeLikeWildcards(input);
+    const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe("C:\\\\path");
+    expect(result).toBe('"foo-bar"*');
   });
 
-  it("%と_が混在する場合すべてエスケープされること", () => {
+  it("FTS5記号（コロン）を含む場合ダブルクォートで無効化されること", () => {
     // Arrange
-    const input = "50%_off";
+    const query = "foo:bar";
 
     // Act
-    const result = escapeLikeWildcards(input);
+    const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe("50\\%\\_off");
+    expect(result).toBe('"foo:bar"*');
   });
 
-  it("空文字列は空文字列を返すこと", () => {
+  it("FTS5記号（アスタリスク）を含む場合ダブルクォートで無効化されること", () => {
     // Arrange
-    const input = "";
+    const query = "foo*bar";
 
     // Act
-    const result = escapeLikeWildcards(input);
+    const result = buildFtsMatchExpression(query);
 
     // Assert
-    expect(result).toBe("");
+    expect(result).toBe('"foo*bar"*');
+  });
+
+  it("連続空白はトークンとして無視されること", () => {
+    // Arrange
+    const query = "React   hooks";
+
+    // Act
+    const result = buildFtsMatchExpression(query);
+
+    // Assert
+    expect(result).toBe('"React"* AND "hooks"*');
+  });
+
+  it("前後の空白はトリムされること", () => {
+    // Arrange
+    const query = "  TypeScript  ";
+
+    // Act
+    const result = buildFtsMatchExpression(query);
+
+    // Assert
+    expect(result).toBe('"TypeScript"*');
+  });
+
+  it("空文字列の場合マッチしない特殊トークンを返すこと", () => {
+    // Arrange
+    const query = "";
+
+    // Act
+    const result = buildFtsMatchExpression(query);
+
+    // Assert
+    expect(result).toBe('"___no_match___"*');
+  });
+
+  it("全スペースの場合マッチしない特殊トークンを返すこと", () => {
+    // Arrange
+    const query = "   ";
+
+    // Act
+    const result = buildFtsMatchExpression(query);
+
+    // Assert
+    expect(result).toBe('"___no_match___"*');
   });
 });
 


### PR DESCRIPTION
## 概要

- 記事全文検索を LIKE ベースから SQLite FTS5 MATCH ベースに移行する
- `articles_fts` 外部コンテンツ FTS5 仮想テーブルと INSERT/UPDATE/DELETE 同期トリガーを追加する
- 検索クエリを `buildFtsMatchExpression` により FTS5 MATCH 式に変換（前方一致 + AND、ダブルクォートエスケープ）する

## 変更ファイル

- apps/api/drizzle/0005_add_articles_fts.sql（新規マイグレーション）
- apps/api/drizzle/meta/_journal.json, 0005_snapshot.json
- apps/api/src/routes/search.ts
- apps/api/src/app/articles-subapp.ts
- tests/api/integration/search-fts.test.ts
- tests/api/routes/search.test.ts

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（API 1452 / Mobile 884）

Closes #929

🤖 Reviewed by reviewer agent