### PR TITLE
fix(config): wrangler.toml の [env.staging] 二重定義を修正する

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -45,6 +45,7 @@ name = "tech-clip-api-staging"
 [env.staging.vars]
 ENVIRONMENT = "staging"
 APP_URL = "REPLACE_WITH_STAGING_APP_URL"
+R2_PUBLIC_URL = "REPLACE_WITH_STAGING_R2_PUBLIC_URL"
 
 [[env.staging.kv_namespaces]]
 binding = "RATE_LIMIT"
@@ -87,26 +88,3 @@ binding = "AI"
 [[env.production.routes]]
 pattern = "api.techclip.app"
 custom_domain = true
-
-# --- ステージング環境 ---
-[env.staging]
-name = "tech-clip-api-staging"
-[env.staging.vars]
-ENVIRONMENT = "staging"
-APP_URL = "REPLACE_WITH_STAGING_APP_URL"
-R2_PUBLIC_URL = "REPLACE_WITH_STAGING_R2_PUBLIC_URL"
-
-[[env.staging.kv_namespaces]]
-binding = "RATE_LIMIT"
-id = "REPLACE_WITH_STAGING_RATE_LIMIT_KV_ID"
-
-[[env.staging.kv_namespaces]]
-binding = "CACHE"
-id = "REPLACE_WITH_STAGING_CACHE_KV_ID"
-
-[[env.staging.r2_buckets]]
-binding = "AVATARS_BUCKET"
-bucket_name = "tech-clip-avatars-staging"
-
-[env.staging.ai]
-binding = "AI"


### PR DESCRIPTION
## Summary
- [env.staging] セクションの重複定義（2つ目を削除）を修正
- 1つ目のセクションに欠けていた R2_PUBLIC_URL 変数を追加

## Background
PR#943 のマージにより wrangler.toml に [env.staging] が2つ存在する状態になり、TOML パーサーが "Cannot declare ('env', 'staging') twice" エラーを報告。これにより wrangler dev が起動できず CI の ZAP スキャンが失敗していた。

## Test plan
- [ ] python3 tomllib で VALID 確認済み
- [ ] [env.staging] セクションが1つのみ存在
- [ ] [env.production] セクションに影響なし
- [ ] R2_PUBLIC_URL がステージング vars に含まれる

Fixes #953

🤖 Generated with [Claude Code](https://claude.ai/code)