### PR TITLE
fix(ci): wrangler.tomlのenv.staging重複定義を修正してZAPスキャンを通るようにする

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -45,6 +45,7 @@ name = "tech-clip-api-staging"
 [env.staging.vars]
 ENVIRONMENT = "staging"
 APP_URL = "REPLACE_WITH_STAGING_APP_URL"
+R2_PUBLIC_URL = "REPLACE_WITH_STAGING_R2_PUBLIC_URL"
 
 [[env.staging.kv_namespaces]]
 binding = "RATE_LIMIT"
@@ -88,25 +89,3 @@ binding = "AI"
 pattern = "api.techclip.app"
 custom_domain = true
 
-# --- ステージング環境 ---
-[env.staging]
-name = "tech-clip-api-staging"
-[env.staging.vars]
-ENVIRONMENT = "staging"
-APP_URL = "REPLACE_WITH_STAGING_APP_URL"
-R2_PUBLIC_URL = "REPLACE_WITH_STAGING_R2_PUBLIC_URL"
-
-[[env.staging.kv_namespaces]]
-binding = "RATE_LIMIT"
-id = "REPLACE_WITH_STAGING_RATE_LIMIT_KV_ID"
-
-[[env.staging.kv_namespaces]]
-binding = "CACHE"
-id = "REPLACE_WITH_STAGING_CACHE_KV_ID"
-
-[[env.staging.r2_buckets]]
-binding = "AVATARS_BUCKET"
-bucket_name = "tech-clip-avatars-staging"
-
-[env.staging.ai]
-binding = "AI"


### PR DESCRIPTION
## 概要

`apps/api/wrangler.toml` で `[env.staging]` が2回定義されており、wrangler が TOML エラーで起動できず ZAP セキュリティスキャンが失敗していた問題を修正する。

## 変更内容

- `[env.staging]` の重複定義を解消（後者を削除、必要な vars を前者にマージ）

## 確認方法

CI の ZAP ジョブが SUCCESS になることを確認する。

Closes #955

🤖 Generated with [Claude Code](https://claude.ai/code)