### PR TITLE
fix(auth): send-verification に認証コンテキストを注入して 401 を解消する #960

### DIFF
--- a/apps/api/src/app/auth-subapp.ts
+++ b/apps/api/src/app/auth-subapp.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import type { Auth } from "../auth";
 import type { Database } from "../db";
+import { fetchWithAuth } from "../lib/route-helpers";
 import { createAuthRoute } from "../routes/auth";
 import { createEmailVerificationRoute } from "../routes/email-verification";
 import { createPasswordResetRoute } from "../routes/password-reset";
@@ -37,12 +38,14 @@ export async function handleAuthRoute(
  *
  * @param db - データベースインスタンス
  * @param env - Cloudflare Workers バインディング
+ * @param auth - Better Auth インスタンス
  * @param request - 元のリクエスト
  * @returns fetch レスポンス
  */
 export async function handleEmailVerification(
   db: Database,
   env: Bindings,
+  auth: Auth,
   request: Request,
 ): Promise<Response> {
   const appUrl = env.APP_URL ?? DEFAULT_APP_URL;
@@ -51,9 +54,14 @@ export async function handleEmailVerification(
     appUrl,
     emailEnv: { RESEND_API_KEY: env.RESEND_API_KEY, FROM_EMAIL: env.FROM_EMAIL },
   });
-  const subApp = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
-  subApp.route("/api/auth", route);
-  return subApp.fetch(request);
+
+  return fetchWithAuth(
+    auth.api.getSession.bind(auth.api),
+    (subApp) => {
+      subApp.route("/api/auth", route);
+    },
+    request,
+  );
 }
 
 /**

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -85,11 +85,11 @@ app.post("/api/auth/refresh", async (c) => {
 });
 
 app.post("/api/auth/send-verification", async (c) => {
-  return handleEmailVerification(c.get("db"), c.env, c.req.raw);
+  return handleEmailVerification(c.get("db"), c.env, c.get("auth")(), c.req.raw);
 });
 
 app.post("/api/auth/verify-email", async (c) => {
-  return handleEmailVerification(c.get("db"), c.env, c.req.raw);
+  return handleEmailVerification(c.get("db"), c.env, c.get("auth")(), c.req.raw);
 });
 
 app.on(["POST", "GET"], "/api/auth/**", async (c) => {

--- a/tests/api/app/auth-subapp.test.ts
+++ b/tests/api/app/auth-subapp.test.ts
@@ -1,0 +1,164 @@
+import { handleEmailVerification } from "@api/app/auth-subapp";
+import type { Auth } from "@api/auth";
+import type { Bindings } from "@api/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@api/services/emailService", () => ({
+  sendEmailVerification: vi.fn(),
+}));
+
+import { sendEmailVerification } from "@api/services/emailService";
+
+/** テスト用のモックユーザー */
+const MOCK_USER = {
+  id: "user_01HXYZ",
+  email: "test@example.com",
+  name: "テストユーザー",
+  emailVerified: false,
+};
+
+/** テスト用のモック検証レコード */
+const MOCK_VERIFICATION = {
+  id: "verif_01",
+  identifier: `email-verification:${MOCK_USER.id}`,
+  value: "hashed-token",
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+/** DBモック */
+const mockSelectWhere = vi.fn();
+const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+const mockSelect = vi.fn().mockReturnValue({ from: mockSelectFrom });
+
+const mockInsertValues = vi.fn().mockResolvedValue([]);
+const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
+
+const mockUpdateWhere = vi.fn().mockResolvedValue([]);
+const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
+const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
+
+const mockDeleteWhere = vi.fn().mockResolvedValue([]);
+const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere });
+
+const mockDb = {
+  select: mockSelect,
+  insert: mockInsert,
+  update: mockUpdate,
+  delete: mockDelete,
+} as unknown as Parameters<typeof handleEmailVerification>[0];
+
+const mockEnv = {
+  APP_URL: "https://app.example.com",
+  RESEND_API_KEY: "test-key",
+  FROM_EMAIL: "test@example.com",
+} as unknown as Bindings;
+
+/**
+ * テスト用のモック Auth インスタンスを生成する
+ *
+ * @param sessionUser - セッションに返すユーザー（null の場合は未認証）
+ * @returns モック Auth インスタンス
+ */
+function createMockAuth(sessionUser: Record<string, unknown> | null = null): Auth {
+  return {
+    api: {
+      getSession: vi.fn().mockResolvedValue(sessionUser ? { user: sessionUser } : null),
+    },
+  } as unknown as Auth;
+}
+
+describe("handleEmailVerification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+    mockInsertValues.mockResolvedValue([]);
+    mockUpdateWhere.mockResolvedValue([]);
+    mockDeleteWhere.mockResolvedValue([]);
+  });
+
+  describe("POST /api/auth/send-verification", () => {
+    it("セッション付きリクエストで認証メール送信が成功すること", async () => {
+      // Arrange
+      const auth = createMockAuth(MOCK_USER);
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      vi.mocked(sendEmailVerification).mockResolvedValue({ messageId: "msg_01" });
+
+      const request = new Request("https://app.example.com/api/auth/send-verification", {
+        method: "POST",
+        headers: { Cookie: "session=test-session-token" },
+      });
+
+      // Act
+      const response = await handleEmailVerification(mockDb, mockEnv, auth, request);
+      const body = await response.json();
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        data: { message: "認証メールを送信しました" },
+      });
+    });
+
+    it("getSession にリクエストヘッダーが渡されること", async () => {
+      // Arrange
+      const auth = createMockAuth(MOCK_USER);
+      mockSelectWhere.mockResolvedValue([MOCK_USER]);
+      vi.mocked(sendEmailVerification).mockResolvedValue({ messageId: "msg_01" });
+
+      const request = new Request("https://app.example.com/api/auth/send-verification", {
+        method: "POST",
+        headers: { Authorization: "Bearer test-token" },
+      });
+
+      // Act
+      await handleEmailVerification(mockDb, mockEnv, auth, request);
+
+      // Assert
+      expect(auth.api.getSession).toHaveBeenCalledOnce();
+    });
+
+    it("セッションなしリクエストで401を返すこと", async () => {
+      // Arrange
+      const auth = createMockAuth(null);
+
+      const request = new Request("https://app.example.com/api/auth/send-verification", {
+        method: "POST",
+      });
+
+      // Act
+      const response = await handleEmailVerification(mockDb, mockEnv, auth, request);
+      const body = await response.json();
+
+      // Assert
+      expect(response.status).toBe(401);
+      expect(body).toMatchObject({
+        success: false,
+        error: { code: "AUTH_REQUIRED" },
+      });
+    });
+  });
+
+  describe("POST /api/auth/verify-email", () => {
+    it("セッションなしでもトークン検証処理が進み認証エラーにならないこと", async () => {
+      // Arrange
+      const auth = createMockAuth(null);
+      mockSelectWhere.mockResolvedValue([MOCK_VERIFICATION]);
+
+      const request = new Request("https://app.example.com/api/auth/verify-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: "some-token" }),
+      });
+
+      // Act
+      const response = await handleEmailVerification(mockDb, mockEnv, auth, request);
+
+      // Assert
+      expect(response.status).not.toBe(401);
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/tests/api/app/auth-subapp.test.ts
+++ b/tests/api/app/auth-subapp.test.ts
@@ -118,6 +118,9 @@ describe("handleEmailVerification", () => {
 
       // Assert
       expect(auth.api.getSession).toHaveBeenCalledOnce();
+      expect(auth.api.getSession).toHaveBeenCalledWith(
+        expect.objectContaining({ headers: expect.any(Headers) }),
+      );
     });
 
     it("セッションなしリクエストで401を返すこと", async () => {


### PR DESCRIPTION
## 概要

`POST /api/auth/send-verification` が認証コンテキスト未注入により常に 401 を返していた不具合を修正する。

### 原因

`handleEmailVerification` は `Hono` サブアプリを生成するが、セッションミドルウェアを適用していなかったため `c.get("user")` が常に `undefined` となり、認証済みユーザーからのリクエストでも 401 を返していた。

### 修正内容

- `handleEmailVerification` のシグネチャに `auth: Auth` を追加
- `fetchWithAuth` ヘルパー経由でセッションミドルウェアを挿入し `user` を Hono コンテキストに注入
- `index.ts` の呼び出し 2 箇所（`/send-verification`, `/verify-email`）を `c.get(\"auth\")()` 経由で渡すよう更新

`/verify-email` は未認証のメールリンク経由でも呼ばれる前提のため、`fetchWithAuth` は session があれば user を set する non-enforcing 仕様とし、401 応答はルート側（`/send-verification`）で行う責務分担にした。

## 変更ファイル

- `apps/api/src/app/auth-subapp.ts` — `handleEmailVerification` の修正
- `apps/api/src/index.ts` — 呼び出し側 2 箇所の更新
- `tests/api/app/auth-subapp.test.ts` — 新規テスト（TDD）

## テスト

- [x] セッション付き `/send-verification` で 200 を返すこと
- [x] セッションなし `/send-verification` で 401 / `AUTH_REQUIRED` を返すこと
- [x] `getSession` にリクエストヘッダーが渡されること
- [x] セッションなしでも `/verify-email` はトークン検証処理に進むこと
- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（1476 tests）

Closes #960

🤖 Reviewed by reviewer agent