### PR TITLE
fix(auth): パスワードハッシュ方式を Better Auth に統一する #957

### DIFF
--- a/apps/api/src/app/auth-subapp.ts
+++ b/apps/api/src/app/auth-subapp.ts
@@ -81,6 +81,7 @@ export async function handleAuthCatchAll(
       db,
       appUrl: env.APP_URL ?? DEFAULT_APP_URL,
       emailEnv: { RESEND_API_KEY: env.RESEND_API_KEY, FROM_EMAIL: env.FROM_EMAIL },
+      auth,
     });
     const subApp = new Hono();
     subApp.route("/api/auth", passwordResetRoute);

--- a/apps/api/src/app/users-subapp.ts
+++ b/apps/api/src/app/users-subapp.ts
@@ -137,6 +137,7 @@ export async function handleUsers(
     db,
     r2Bucket: env.AVATARS_BUCKET,
     r2PublicUrl: env.R2_PUBLIC_URL,
+    auth,
   });
 
   const followsRoute = createFollowsRoute({

--- a/apps/api/src/routes/password-reset.ts
+++ b/apps/api/src/routes/password-reset.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import type { Auth } from "../auth";
 import type { Database } from "../db";
 import { accounts, users, verifications } from "../db/schema";
 import { VALIDATION_ERROR_CODE, VALIDATION_ERROR_MESSAGE } from "../lib/error-codes";
@@ -65,6 +66,7 @@ type PasswordResetRouteOptions = {
   db: Database;
   appUrl: string;
   emailEnv: EmailEnv;
+  auth: Auth;
 };
 
 /**
@@ -94,7 +96,7 @@ async function hashToken(token: string): Promise<string> {
  * @returns Hono ルーターインスタンス
  */
 export function createPasswordResetRoute(options: PasswordResetRouteOptions) {
-  const { db, appUrl, emailEnv } = options;
+  const { db, appUrl, emailEnv, auth } = options;
   const route = new Hono();
 
   route.post("/forgot-password", async (c) => {
@@ -244,7 +246,8 @@ export function createPasswordResetRoute(options: PasswordResetRouteOptions) {
       );
     }
 
-    const hashedPassword = await hashPassword(password);
+    const ctx = await auth.$context;
+    const hashedPassword = await ctx.password.hash(password);
 
     await db.update(accounts).set({ password: hashedPassword }).where(eq(accounts.userId, user.id));
 
@@ -260,47 +263,4 @@ export function createPasswordResetRoute(options: PasswordResetRouteOptions) {
   });
 
   return route;
-}
-
-/**
- * パスワードをハッシュ化する
- *
- * Web Crypto API を使用してPBKDF2でハッシュ化する。
- * Cloudflare Workers 環境でも動作する。
- *
- * @param password - ハッシュ化する平文パスワード
- * @returns ハッシュ化されたパスワード文字列
- */
-async function hashPassword(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(password),
-    "PBKDF2",
-    false,
-    ["deriveBits"],
-  );
-
-  const salt = crypto.getRandomValues(new Uint8Array(16));
-  const iterations = 100000;
-
-  const derivedBits = await crypto.subtle.deriveBits(
-    {
-      name: "PBKDF2",
-      salt,
-      iterations,
-      hash: "SHA-256",
-    },
-    keyMaterial,
-    256,
-  );
-
-  const saltHex = Array.from(salt)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  const hashHex = Array.from(new Uint8Array(derivedBits))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  return `pbkdf2:${iterations}:${saltHex}:${hashHex}`;
 }

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 
+import type { Auth } from "../auth";
 import type { Database } from "../db";
 import { accounts, users } from "../db/schema";
 import {
@@ -50,9 +51,6 @@ const PASSWORD_MIN_LENGTH = 8;
 
 /** パスワード最大文字数 */
 const PASSWORD_MAX_LENGTH = 128;
-
-/** PBKDF2 イテレーション回数 */
-const PBKDF2_ITERATIONS = 100000;
 
 /** パスワード変更成功メッセージ */
 const PASSWORD_CHANGE_SUCCESS_MESSAGE = "パスワードを変更しました。";
@@ -127,6 +125,7 @@ type UsersRouteOptions = {
   db: Database;
   r2Bucket?: R2Bucket;
   r2PublicUrl?: string;
+  auth: Auth;
 };
 
 /**
@@ -154,7 +153,7 @@ function omitSensitiveFields(user: Record<string, unknown>): Record<string, unkn
  * @returns Hono ルーターインスタンス
  */
 export function createUsersRoute(options: UsersRouteOptions) {
-  const { db, r2Bucket, r2PublicUrl } = options;
+  const { db, r2Bucket, r2PublicUrl, auth } = options;
   const route = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
 
   route.get("/me", async (c) => {
@@ -472,7 +471,11 @@ export function createUsersRoute(options: UsersRouteOptions) {
       );
     }
 
-    const isValid = await verifyPassword(currentPassword, account.password);
+    const ctx = await auth.$context;
+    const isValid = await ctx.password.verify({
+      hash: account.password,
+      password: currentPassword,
+    });
 
     if (!isValid) {
       return c.json(
@@ -487,7 +490,7 @@ export function createUsersRoute(options: UsersRouteOptions) {
       );
     }
 
-    const hashedNewPassword = await hashPasswordPbkdf2(newPassword);
+    const hashedNewPassword = await ctx.password.hash(newPassword);
 
     await db
       .update(accounts)
@@ -541,97 +544,4 @@ export function createUsersRoute(options: UsersRouteOptions) {
   });
 
   return route;
-}
-
-/**
- * パスワードをPBKDF2でハッシュ化する
- *
- * Web Crypto API を使用する。Cloudflare Workers 環境でも動作する。
- *
- * @param password - ハッシュ化する平文パスワード
- * @returns ハッシュ化されたパスワード文字列（pbkdf2:iterations:saltHex:hashHex 形式）
- */
-async function hashPasswordPbkdf2(password: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(password),
-    "PBKDF2",
-    false,
-    ["deriveBits"],
-  );
-
-  const salt = crypto.getRandomValues(new Uint8Array(16));
-
-  const derivedBits = await crypto.subtle.deriveBits(
-    {
-      name: "PBKDF2",
-      salt,
-      iterations: PBKDF2_ITERATIONS,
-      hash: "SHA-256",
-    },
-    keyMaterial,
-    256,
-  );
-
-  const saltHex = Array.from(salt)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-  const hashHex = Array.from(new Uint8Array(derivedBits))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  return `pbkdf2:${PBKDF2_ITERATIONS}:${saltHex}:${hashHex}`;
-}
-
-/**
- * 平文パスワードと保存済みハッシュを照合する
- *
- * @param plainPassword - 照合する平文パスワード
- * @param storedHash - 保存済みハッシュ（pbkdf2:iterations:saltHex:hashHex 形式）
- * @returns 照合成功の場合 true
- */
-async function verifyPassword(plainPassword: string, storedHash: string): Promise<boolean> {
-  const parts = storedHash.split(":");
-  if (parts.length !== 4 || parts[0] !== "pbkdf2") {
-    return false;
-  }
-
-  const iterations = Number(parts[1]);
-  const saltHex = parts[2];
-  const expectedHashHex = parts[3];
-
-  if (!Number.isInteger(iterations) || iterations <= 0 || !saltHex || !expectedHashHex) {
-    return false;
-  }
-
-  const salt = new Uint8Array(
-    saltHex.match(/.{2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? [],
-  );
-
-  const encoder = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(plainPassword),
-    "PBKDF2",
-    false,
-    ["deriveBits"],
-  );
-
-  const derivedBits = await crypto.subtle.deriveBits(
-    {
-      name: "PBKDF2",
-      salt,
-      iterations,
-      hash: "SHA-256",
-    },
-    keyMaterial,
-    256,
-  );
-
-  const hashHex = Array.from(new Uint8Array(derivedBits))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-
-  return hashHex === expectedHashHex;
 }

--- a/tests/api/integration/password-change-login.test.ts
+++ b/tests/api/integration/password-change-login.test.ts
@@ -1,0 +1,495 @@
+/**
+ * パスワード変更・リセット後のサインイン互換性統合テスト
+ *
+ * Better Auth がサインアップ時に使用する scrypt ハッシュ（better-auth/crypto の
+ * hashPassword/verifyPassword）と、カスタムルートが auth.$context.password.hash/verify
+ * 経由で生成するハッシュが完全に一致することを、実 SQLite DB を用いて検証する。
+ *
+ * 検証戦略:
+ * - hashPassword / verifyPassword は Better Auth sign-in が使う関数と同一
+ * - カスタムルートが auth.$context.password.hash を使うことで同じ scrypt 形式になることを確認する
+ *
+ * テスト対象フロー:
+ * 1. scrypt ハッシュを DB に保存（Better Auth sign-up と同等）→ パスワード変更 →
+ *    新ハッシュを verifyPassword で検証できること
+ * 2. 同様のフローをパスワードリセットルートで検証
+ */
+
+import { rmSync } from "node:fs";
+
+import { accounts, users, verifications } from "@api/db/schema/index";
+import { createPasswordResetRoute } from "@api/routes/password-reset";
+import { createUsersRoute } from "@api/routes/users";
+import { createClient } from "@libsql/client";
+import { hashPassword, verifyPassword } from "better-auth/crypto";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/libsql";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+/** テスト用のベース URL */
+const BASE_URL = "http://localhost:8081";
+
+/** テスト固定値 */
+const TEST_EMAIL = "integration@example.com";
+const TEST_USER_ID = "test-user-integration-01";
+const OLD_PASSWORD = "OldPassword123";
+const NEW_PASSWORD = "NewPassword456";
+const WRONG_PASSWORD = "WrongPassword789";
+
+/** パスワードリセットのidentifierプレフィックス */
+const RESET_TOKEN_IDENTIFIER_PREFIX = "password-reset:";
+
+/**
+ * パスワードリセットトークンをハッシュ化する（password-reset.ts と同一実装）
+ *
+ * @param token - ハッシュ化するトークン文字列
+ * @returns SHA-256 ハッシュの16進数文字列
+ */
+async function hashResetToken(token: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(token);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** テスト用の一時 SQLite DB を作成する */
+function createTestDb() {
+  const dbPath = `/tmp/password-compat-${crypto.randomUUID()}.db`;
+  const client = createClient({ url: `file:${dbPath}` });
+  const db = drizzle(client);
+  return { db, dbPath, client };
+}
+
+/** テスト用テーブルを作成する */
+async function createTables(db: ReturnType<typeof drizzle>) {
+  await db.run(
+    "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, email TEXT NOT NULL UNIQUE, name TEXT, image TEXT, email_verified INTEGER DEFAULT 0, username TEXT UNIQUE, bio TEXT, website_url TEXT, github_username TEXT, twitter_username TEXT, avatar_url TEXT, is_profile_public INTEGER DEFAULT 1, preferred_language TEXT DEFAULT 'ja', is_premium INTEGER DEFAULT 0, premium_expires_at TEXT, free_ai_uses_remaining INTEGER DEFAULT 5, free_ai_reset_at TEXT, push_token TEXT, push_enabled INTEGER DEFAULT 1, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')))",
+  );
+  await db.run(
+    "CREATE TABLE IF NOT EXISTS accounts (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, account_id TEXT NOT NULL, provider_id TEXT NOT NULL, access_token TEXT, refresh_token TEXT, access_token_expires_at TEXT, refresh_token_expires_at TEXT, scope TEXT, id_token TEXT, password TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')))",
+  );
+  await db.run(
+    "CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, token TEXT NOT NULL UNIQUE, expires_at TEXT NOT NULL, ip_address TEXT, user_agent TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')))",
+  );
+  await db.run(
+    "CREATE TABLE IF NOT EXISTS verifications (id TEXT PRIMARY KEY, identifier TEXT NOT NULL, value TEXT NOT NULL, expires_at TEXT NOT NULL, created_at TEXT DEFAULT (datetime('now')), updated_at TEXT DEFAULT (datetime('now')))",
+  );
+}
+
+/**
+ * Better Auth の scrypt 互換ハッシュでユーザーを DB に挿入する
+ *
+ * これは Better Auth が sign-up 時に行うのと同等の操作である。
+ * hashPassword は better-auth/crypto からエクスポートされており、
+ * Better Auth のサインアップ・サインインが内部で使用するものと同一の関数。
+ */
+async function insertUserWithScryptHash(
+  db: ReturnType<typeof drizzle>,
+  userId: string,
+  email: string,
+  password: string,
+) {
+  const scryptHash = await hashPassword(password);
+  await db.insert(users).values({ id: userId, email, name: "テストユーザー" });
+  await db.insert(accounts).values({
+    id: `account-${userId}`,
+    userId,
+    accountId: userId,
+    providerId: "credential",
+    password: scryptHash,
+  });
+  return scryptHash;
+}
+
+/**
+ * auth.$context.password を使う mockAuth を生成する
+ *
+ * DB アダプタのセットアップを省略し、$context.password の
+ * hash/verify のみを実際の better-auth/crypto 実装にバインドする。
+ * これにより、カスタムルートが auth.$context を経由して scrypt を使うことを検証できる。
+ */
+function createMockAuthWithRealCrypto() {
+  return {
+    $context: Promise.resolve({
+      password: {
+        hash: hashPassword,
+        verify: verifyPassword,
+      },
+    }),
+  };
+}
+
+/**
+ * ユーザールートのテスト用アプリを構築する
+ *
+ * user コンテキストを直接セットするシンプルなミドルウェアを使用する。
+ */
+function buildUsersApp(db: ReturnType<typeof drizzle>, userId: string) {
+  const mockAuth = createMockAuthWithRealCrypto();
+  const usersRoute = createUsersRoute({ db: db as never, auth: mockAuth as never });
+  const app = new Hono<{ Variables: { user?: Record<string, unknown> } }>();
+
+  app.use("*", async (c, next) => {
+    c.set("user", { id: userId });
+    await next();
+  });
+
+  app.route("/api/users", usersRoute);
+  return app;
+}
+
+/**
+ * パスワードリセットルートのテスト用アプリを構築する
+ */
+function buildPasswordResetApp(db: ReturnType<typeof drizzle>) {
+  const mockAuth = createMockAuthWithRealCrypto();
+  const resetRoute = createPasswordResetRoute({
+    db: db as never,
+    appUrl: BASE_URL,
+    emailEnv: { RESEND_API_KEY: "test-key", FROM_EMAIL: "noreply@test.com" },
+    auth: mockAuth as never,
+  });
+  const app = new Hono();
+  app.route("/api/auth", resetRoute);
+  return app;
+}
+
+describe("パスワード変更ルートの scrypt 互換性統合テスト", () => {
+  let testDb: ReturnType<typeof createTestDb>;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    await createTables(testDb.db);
+    await insertUserWithScryptHash(testDb.db, TEST_USER_ID, TEST_EMAIL, OLD_PASSWORD);
+  });
+
+  afterEach(() => {
+    testDb.client.close();
+    rmSync(testDb.dbPath, { force: true });
+  });
+
+  describe("PATCH /me/password: パスワード変更フロー", () => {
+    it("パスワード変更後のハッシュを verifyPassword で検証できること", async () => {
+      // Arrange: scrypt ハッシュで保存済みの DB + 実ルート
+      const app = buildUsersApp(testDb.db, TEST_USER_ID);
+
+      // Act: パスワード変更（auth.$context.password.hash/verify を使用）
+      const changeRes = await app.request("/api/users/me/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: OLD_PASSWORD,
+          newPassword: NEW_PASSWORD,
+        }),
+      });
+
+      // Assert: パスワード変更成功
+      expect(changeRes.status).toBe(200);
+      const changeBody = (await changeRes.json()) as { success: boolean };
+      expect(changeBody.success).toBe(true);
+
+      // Assert: DB の新パスワードハッシュを Better Auth sign-in 互換の verifyPassword で検証できること
+      const [account] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const storedHash1 = account?.password ?? "";
+      expect(storedHash1).toBeTruthy();
+      const isNewPasswordValid = await verifyPassword({
+        hash: storedHash1,
+        password: NEW_PASSWORD,
+      });
+      expect(isNewPasswordValid).toBe(true);
+    });
+
+    it("パスワード変更後に旧パスワードは検証できないこと（ハッシュ互換性確認）", async () => {
+      // Arrange
+      const app = buildUsersApp(testDb.db, TEST_USER_ID);
+
+      // Act: パスワード変更
+      await app.request("/api/users/me/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: OLD_PASSWORD,
+          newPassword: NEW_PASSWORD,
+        }),
+      });
+
+      // Assert: 旧パスワードは verifyPassword で検証できないこと
+      const [account] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const storedHash2 = account?.password ?? "";
+      const isOldPasswordValid = await verifyPassword({
+        hash: storedHash2,
+        password: OLD_PASSWORD,
+      });
+      expect(isOldPasswordValid).toBe(false);
+    });
+
+    it("誤ったパスワードで変更しようとすると401が返ること", async () => {
+      // Arrange
+      const app = buildUsersApp(testDb.db, TEST_USER_ID);
+
+      // Act: 誤ったcurrentPasswordでパスワード変更試行
+      const changeRes = await app.request("/api/users/me/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: WRONG_PASSWORD,
+          newPassword: NEW_PASSWORD,
+        }),
+      });
+
+      // Assert: 認証エラー
+      expect(changeRes.status).toBe(401);
+    });
+
+    it("パスワード変更後のハッシュが scrypt 形式（salt:hash）であること", async () => {
+      // Arrange
+      const app = buildUsersApp(testDb.db, TEST_USER_ID);
+
+      // Act: パスワード変更
+      await app.request("/api/users/me/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: OLD_PASSWORD,
+          newPassword: NEW_PASSWORD,
+        }),
+      });
+
+      // Assert: ハッシュが scrypt 形式（"saltHex:hashHex"）であること
+      const [account] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const storedHash3 = account?.password ?? "";
+      expect(storedHash3).toBeTruthy();
+      const hashParts = storedHash3.split(":");
+
+      // scrypt 形式: saltHex:hashHex（2パーツ）
+      // PBKDF2 形式: pbkdf2:iterations:saltHex:hashHex（4パーツ）
+      expect(hashParts).toHaveLength(2);
+      expect(hashParts[0]).not.toBe("pbkdf2");
+    });
+  });
+
+  describe("POST /reset-password: パスワードリセットフロー", () => {
+    it("パスワードリセット後のハッシュを verifyPassword で検証できること", async () => {
+      // Arrange: リセットトークンを DB に直接挿入（メール送信をスキップ）
+      const rawToken = crypto.randomUUID();
+      const hashedToken = await hashResetToken(rawToken);
+      const expiresAt = new Date(Date.now() + 3_600_000).toISOString();
+
+      await testDb.db.insert(verifications).values({
+        id: crypto.randomUUID(),
+        identifier: `${RESET_TOKEN_IDENTIFIER_PREFIX}${TEST_EMAIL}`,
+        value: hashedToken,
+        expiresAt,
+      });
+
+      const app = buildPasswordResetApp(testDb.db);
+
+      // Act: パスワードリセット（auth.$context.password.hash を使用）
+      const resetRes = await app.request("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: rawToken, password: NEW_PASSWORD }),
+      });
+
+      // Assert: リセット成功
+      expect(resetRes.status).toBe(200);
+      const resetBody = (await resetRes.json()) as { success: boolean };
+      expect(resetBody.success).toBe(true);
+
+      // Assert: DB の新パスワードハッシュを Better Auth sign-in 互換の verifyPassword で検証できること
+      const [account] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const storedHash4 = account?.password ?? "";
+      expect(storedHash4).toBeTruthy();
+      const isNewPasswordValid = await verifyPassword({
+        hash: storedHash4,
+        password: NEW_PASSWORD,
+      });
+      expect(isNewPasswordValid).toBe(true);
+    });
+
+    it("パスワードリセット後のハッシュが scrypt 形式（salt:hash）であること", async () => {
+      // Arrange
+      const rawToken = crypto.randomUUID();
+      const hashedToken = await hashResetToken(rawToken);
+      const expiresAt = new Date(Date.now() + 3_600_000).toISOString();
+
+      await testDb.db.insert(verifications).values({
+        id: crypto.randomUUID(),
+        identifier: `${RESET_TOKEN_IDENTIFIER_PREFIX}${TEST_EMAIL}`,
+        value: hashedToken,
+        expiresAt,
+      });
+
+      const app = buildPasswordResetApp(testDb.db);
+
+      // Act: パスワードリセット
+      await app.request("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: rawToken, password: NEW_PASSWORD }),
+      });
+
+      // Assert: ハッシュが scrypt 形式（"saltHex:hashHex"）であること（PBKDF2 ではないこと）
+      const [account] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const storedHash5 = account?.password ?? "";
+      expect(storedHash5).toBeTruthy();
+      const hashParts = storedHash5.split(":");
+      expect(hashParts).toHaveLength(2);
+      expect(hashParts[0]).not.toBe("pbkdf2");
+    });
+
+    it("パスワードリセット後に旧パスワードは検証できないこと", async () => {
+      // Arrange
+      const rawToken = crypto.randomUUID();
+      const hashedToken = await hashResetToken(rawToken);
+      const expiresAt = new Date(Date.now() + 3_600_000).toISOString();
+
+      await testDb.db.insert(verifications).values({
+        id: crypto.randomUUID(),
+        identifier: `${RESET_TOKEN_IDENTIFIER_PREFIX}${TEST_EMAIL}`,
+        value: hashedToken,
+        expiresAt,
+      });
+
+      const app = buildPasswordResetApp(testDb.db);
+
+      // Act: パスワードリセット
+      await app.request("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: rawToken, password: NEW_PASSWORD }),
+      });
+
+      // Assert: 旧パスワードは検証できないこと
+      const [account] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const storedHash6 = account?.password ?? "";
+      const isOldPasswordValid = await verifyPassword({
+        hash: storedHash6,
+        password: OLD_PASSWORD,
+      });
+      expect(isOldPasswordValid).toBe(false);
+    });
+  });
+
+  describe("scrypt 形式互換性: hashPassword と auth.$context.password.hash の一致確認", () => {
+    it("hashPassword で生成したハッシュを verifyPassword で検証できること（Better Auth 内部一貫性）", async () => {
+      // Arrange: hashPassword が生成するハッシュ形式を確認
+      const hash = await hashPassword(OLD_PASSWORD);
+
+      // Assert: scrypt 形式（salt:hash）
+      const parts = hash.split(":");
+      expect(parts).toHaveLength(2);
+
+      // Assert: verifyPassword（Better Auth sign-in が使用）で検証できること
+      const isValid = await verifyPassword({ hash, password: OLD_PASSWORD });
+      expect(isValid).toBe(true);
+    });
+
+    it("初期ハッシュ（scrypt）がパスワード変更後も同形式で保存されること", async () => {
+      // Arrange: DB に保存された初期ハッシュを確認
+      const [initialAccount] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const initialHash = initialAccount?.password ?? "";
+      const initialHashParts = initialHash.split(":");
+      expect(initialHashParts).toHaveLength(2);
+
+      // Act: パスワード変更
+      const app = buildUsersApp(testDb.db, TEST_USER_ID);
+      await app.request("/api/users/me/password", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          currentPassword: OLD_PASSWORD,
+          newPassword: NEW_PASSWORD,
+        }),
+      });
+
+      // Assert: 変更後も scrypt 形式（salt:hash）が維持されること
+      const [updatedAccount] = await testDb.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.userId, TEST_USER_ID));
+
+      const updatedHash = updatedAccount?.password ?? "";
+      const updatedHashParts = updatedHash.split(":");
+      expect(updatedHashParts).toHaveLength(2);
+      expect(updatedHashParts[0]).not.toBe("pbkdf2");
+    });
+  });
+});
+
+describe("パスワード変更ルートの認証チェック（統合テスト）", () => {
+  let testDb: ReturnType<typeof createTestDb>;
+
+  beforeEach(async () => {
+    testDb = createTestDb();
+    await createTables(testDb.db);
+    await insertUserWithScryptHash(testDb.db, TEST_USER_ID, TEST_EMAIL, OLD_PASSWORD);
+  });
+
+  afterEach(() => {
+    testDb.client.close();
+    rmSync(testDb.dbPath, { force: true });
+  });
+
+  it("credential アカウントがない場合にパスワード変更すると401が返ること", async () => {
+    // Arrange: credential アカウントなしのユーザーを別途作成
+    const noCredUserId = "no-cred-user-01";
+    await testDb.db.insert(users).values({
+      id: noCredUserId,
+      email: "no-cred@example.com",
+      name: "ノークレデンシャル",
+    });
+    await testDb.db.insert(accounts).values({
+      id: `oauth-${noCredUserId}`,
+      userId: noCredUserId,
+      accountId: noCredUserId,
+      providerId: "google", // OAuth のみ
+      password: null,
+    });
+
+    const app = buildUsersApp(testDb.db, noCredUserId);
+
+    // Act: パスワード変更試行
+    const res = await app.request("/api/users/me/password", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        currentPassword: OLD_PASSWORD,
+        newPassword: NEW_PASSWORD,
+      }),
+    });
+
+    // Assert: 認証エラー（credential なし）
+    expect(res.status).toBe(401);
+  });
+});

--- a/tests/api/integration/password-change-login.test.ts
+++ b/tests/api/integration/password-change-login.test.ts
@@ -62,7 +62,12 @@ function createTestDb() {
   return { db, dbPath, client };
 }
 
-/** テスト用テーブルを作成する */
+/**
+ * テスト用テーブルを作成する
+ *
+ * このSQLは @api/db/schema/index のスキーマと同期が必要。
+ * スキーマ変更時は手動で更新すること。
+ */
 async function createTables(db: ReturnType<typeof drizzle>) {
   await db.run(
     "CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, email TEXT NOT NULL UNIQUE, name TEXT, image TEXT, email_verified INTEGER DEFAULT 0, username TEXT UNIQUE, bio TEXT, website_url TEXT, github_username TEXT, twitter_username TEXT, avatar_url TEXT, is_profile_public INTEGER DEFAULT 1, preferred_language TEXT DEFAULT 'ja', is_premium INTEGER DEFAULT 0, premium_expires_at TEXT, free_ai_uses_remaining INTEGER DEFAULT 5, free_ai_reset_at TEXT, push_token TEXT, push_enabled INTEGER DEFAULT 1, created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')))",
@@ -196,10 +201,10 @@ describe("パスワード変更ルートの scrypt 互換性統合テスト", ()
         .from(accounts)
         .where(eq(accounts.userId, TEST_USER_ID));
 
-      const storedHash1 = account?.password ?? "";
-      expect(storedHash1).toBeTruthy();
+      const storedHash = account?.password ?? "";
+      expect(storedHash).toBeTruthy();
       const isNewPasswordValid = await verifyPassword({
-        hash: storedHash1,
+        hash: storedHash,
         password: NEW_PASSWORD,
       });
       expect(isNewPasswordValid).toBe(true);
@@ -225,9 +230,9 @@ describe("パスワード変更ルートの scrypt 互換性統合テスト", ()
         .from(accounts)
         .where(eq(accounts.userId, TEST_USER_ID));
 
-      const storedHash2 = account?.password ?? "";
+      const storedHash = account?.password ?? "";
       const isOldPasswordValid = await verifyPassword({
-        hash: storedHash2,
+        hash: storedHash,
         password: OLD_PASSWORD,
       });
       expect(isOldPasswordValid).toBe(false);
@@ -271,9 +276,9 @@ describe("パスワード変更ルートの scrypt 互換性統合テスト", ()
         .from(accounts)
         .where(eq(accounts.userId, TEST_USER_ID));
 
-      const storedHash3 = account?.password ?? "";
-      expect(storedHash3).toBeTruthy();
-      const hashParts = storedHash3.split(":");
+      const storedHash = account?.password ?? "";
+      expect(storedHash).toBeTruthy();
+      const hashParts = storedHash.split(":");
 
       // scrypt 形式: saltHex:hashHex（2パーツ）
       // PBKDF2 形式: pbkdf2:iterations:saltHex:hashHex（4パーツ）
@@ -316,10 +321,10 @@ describe("パスワード変更ルートの scrypt 互換性統合テスト", ()
         .from(accounts)
         .where(eq(accounts.userId, TEST_USER_ID));
 
-      const storedHash4 = account?.password ?? "";
-      expect(storedHash4).toBeTruthy();
+      const storedHash = account?.password ?? "";
+      expect(storedHash).toBeTruthy();
       const isNewPasswordValid = await verifyPassword({
-        hash: storedHash4,
+        hash: storedHash,
         password: NEW_PASSWORD,
       });
       expect(isNewPasswordValid).toBe(true);
@@ -353,9 +358,9 @@ describe("パスワード変更ルートの scrypt 互換性統合テスト", ()
         .from(accounts)
         .where(eq(accounts.userId, TEST_USER_ID));
 
-      const storedHash5 = account?.password ?? "";
-      expect(storedHash5).toBeTruthy();
-      const hashParts = storedHash5.split(":");
+      const storedHash = account?.password ?? "";
+      expect(storedHash).toBeTruthy();
+      const hashParts = storedHash.split(":");
       expect(hashParts).toHaveLength(2);
       expect(hashParts[0]).not.toBe("pbkdf2");
     });
@@ -388,9 +393,9 @@ describe("パスワード変更ルートの scrypt 互換性統合テスト", ()
         .from(accounts)
         .where(eq(accounts.userId, TEST_USER_ID));
 
-      const storedHash6 = account?.password ?? "";
+      const storedHash = account?.password ?? "";
       const isOldPasswordValid = await verifyPassword({
-        hash: storedHash6,
+        hash: storedHash,
         password: OLD_PASSWORD,
       });
       expect(isOldPasswordValid).toBe(false);

--- a/tests/api/routes/password-reset.test.ts
+++ b/tests/api/routes/password-reset.test.ts
@@ -1,6 +1,7 @@
 import { HTTP_BAD_REQUEST, HTTP_OK, HTTP_UNPROCESSABLE_ENTITY } from "@api/lib/http-status";
 import { createPasswordResetRoute } from "@api/routes/password-reset";
 import { sendPasswordReset } from "@api/services/emailService";
+import { hashPassword, verifyPassword } from "better-auth/crypto";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -67,6 +68,16 @@ const mockDb = {
   delete: mockDelete,
 };
 
+/** Better Auth の password.hash/verify をそのまま返すモック auth */
+const mockAuth = {
+  $context: Promise.resolve({
+    password: {
+      hash: hashPassword,
+      verify: verifyPassword,
+    },
+  }),
+};
+
 /**
  * テスト用Honoアプリを作成する
  *
@@ -78,6 +89,7 @@ function createTestApp() {
     db: mockDb as never,
     appUrl: "https://app.example.com",
     emailEnv: { RESEND_API_KEY: "test-key", FROM_EMAIL: "test@example.com" },
+    auth: mockAuth as never,
   });
   app.route("/api/auth", passwordResetRoute);
   return app;

--- a/tests/api/routes/users.test.ts
+++ b/tests/api/routes/users.test.ts
@@ -1,5 +1,6 @@
 import { createUsersRoute } from "@api/routes/users";
 import { processAvatarImage, uploadAvatarToR2, validateImageFile } from "@api/services/imageUpload";
+import { hashPassword, verifyPassword } from "better-auth/crypto";
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -90,6 +91,16 @@ const mockDb = {
   update: mockUpdate,
 };
 
+/** Better Auth の password.hash/verify をそのまま返すモック auth */
+const mockAuth = {
+  $context: Promise.resolve({
+    password: {
+      hash: hashPassword,
+      verify: verifyPassword,
+    },
+  }),
+};
+
 /**
  * GET テスト用Honoアプリを作成する（認証済み）
  *
@@ -108,7 +119,7 @@ function createGetTestApp() {
     return next();
   });
 
-  const usersRoute = createUsersRoute({ db: mockDb as never });
+  const usersRoute = createUsersRoute({ db: mockDb as never, auth: mockAuth as never });
   app.route("/api/users", usersRoute);
 
   return app;
@@ -122,7 +133,7 @@ function createGetTestApp() {
 function createGetTestAppWithoutAuth() {
   const app = new Hono();
 
-  const usersRoute = createUsersRoute({ db: mockDb as never });
+  const usersRoute = createUsersRoute({ db: mockDb as never, auth: mockAuth as never });
   app.route("/api/users", usersRoute);
 
   return app;
@@ -649,13 +660,13 @@ describe("PATCH /api/users/me", () => {
 /** HTTP 200 OK ステータスコード */
 const HTTP_OK_PASSWORD = 200;
 
-/** モックのアカウントデータ */
+/** モックのアカウントデータ（passwordはダミー値; verifyに通らないことが前提のテストで使用） */
 const MOCK_ACCOUNT = {
   id: "account_01HXYZ",
   userId: "user_01HXYZ",
   accountId: "user_01HXYZ",
   providerId: "credential",
-  password: "pbkdf2:100000:aabbccdd:eeff1122",
+  password: "dummy-hash-does-not-verify",
   accessToken: null,
   refreshToken: null,
   accessTokenExpiresAt: null,
@@ -828,11 +839,12 @@ describe("PATCH /api/users/me/password", () => {
     });
 
     it("現在のパスワードが正しくない場合401が返ること", async () => {
-      // Arrange
+      // Arrange: Better Auth の hash で "CorrectPass123" のハッシュを生成し、
+      //          "WrongPassword123" で照合すると false になることを確認する
+      const correctHash = await hashPassword("CorrectPass123");
       const accountWithHash = {
         ...MOCK_ACCOUNT,
-        password:
-          "pbkdf2:100000:000102030405060708090a0b0c0d0e0f:0000000000000000000000000000000000000000000000000000000000000000",
+        password: correctHash,
       };
       mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
       mockSelectWhere.mockResolvedValue([accountWithHash]);
@@ -854,29 +866,9 @@ describe("PATCH /api/users/me/password", () => {
 
   describe("正常系", () => {
     it("正しい現在のパスワードでパスワードを変更できること", async () => {
-      // Arrange
+      // Arrange: Better Auth の hashPassword で現在パスワードのハッシュを生成する
       const plainPassword = "OldPass123";
-      const encoder = new TextEncoder();
-      const keyMaterial = await crypto.subtle.importKey(
-        "raw",
-        encoder.encode(plainPassword),
-        "PBKDF2",
-        false,
-        ["deriveBits"],
-      );
-      const salt = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-      const derivedBits = await crypto.subtle.deriveBits(
-        { name: "PBKDF2", salt, iterations: 100000, hash: "SHA-256" },
-        keyMaterial,
-        256,
-      );
-      const saltHex = Array.from(salt)
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-      const hashHex = Array.from(new Uint8Array(derivedBits))
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("");
-      const storedHash = `pbkdf2:100000:${saltHex}:${hashHex}`;
+      const storedHash = await hashPassword(plainPassword);
 
       mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
       mockSelectWhere.mockResolvedValue([{ ...MOCK_ACCOUNT, password: storedHash }]);
@@ -933,6 +925,7 @@ function createAvatarTestApp() {
     db: mockDb as never,
     r2Bucket: MOCK_R2_BUCKET,
     r2PublicUrl: "https://cdn.example.com",
+    auth: mockAuth as never,
   });
   app.route("/api/users", usersRoute);
 
@@ -968,6 +961,7 @@ describe("POST /api/users/me/avatar", () => {
         db: mockDb as never,
         r2Bucket: MOCK_R2_BUCKET,
         r2PublicUrl: "https://cdn.example.com",
+        auth: mockAuth as never,
       });
       app.route("/api/users", usersRoute);
       const file = new File([new Uint8Array([0xff, 0xd8, 0xff])], "avatar.jpg", {

--- a/tests/api/routes/users.test.ts
+++ b/tests/api/routes/users.test.ts
@@ -1,3 +1,5 @@
+import type { Auth } from "@api/auth";
+import type { Database } from "@api/db";
 import { createUsersRoute } from "@api/routes/users";
 import { processAvatarImage, uploadAvatarToR2, validateImageFile } from "@api/services/imageUpload";
 import { hashPassword, verifyPassword } from "better-auth/crypto";
@@ -119,7 +121,10 @@ function createGetTestApp() {
     return next();
   });
 
-  const usersRoute = createUsersRoute({ db: mockDb as never, auth: mockAuth as never });
+  const usersRoute = createUsersRoute({
+    db: mockDb as unknown as Database,
+    auth: mockAuth as unknown as Auth,
+  });
   app.route("/api/users", usersRoute);
 
   return app;
@@ -133,7 +138,10 @@ function createGetTestApp() {
 function createGetTestAppWithoutAuth() {
   const app = new Hono();
 
-  const usersRoute = createUsersRoute({ db: mockDb as never, auth: mockAuth as never });
+  const usersRoute = createUsersRoute({
+    db: mockDb as unknown as Database,
+    auth: mockAuth as unknown as Auth,
+  });
   app.route("/api/users", usersRoute);
 
   return app;
@@ -922,10 +930,10 @@ function createAvatarTestApp() {
   });
 
   const usersRoute = createUsersRoute({
-    db: mockDb as never,
+    db: mockDb as unknown as Database,
     r2Bucket: MOCK_R2_BUCKET,
     r2PublicUrl: "https://cdn.example.com",
-    auth: mockAuth as never,
+    auth: mockAuth as unknown as Auth,
   });
   app.route("/api/users", usersRoute);
 
@@ -958,10 +966,10 @@ describe("POST /api/users/me/avatar", () => {
       // Arrange
       const app = createGetTestAppWithoutAuth();
       const usersRoute = createUsersRoute({
-        db: mockDb as never,
+        db: mockDb as unknown as Database,
         r2Bucket: MOCK_R2_BUCKET,
         r2PublicUrl: "https://cdn.example.com",
-        auth: mockAuth as never,
+        auth: mockAuth as unknown as Auth,
       });
       app.route("/api/users", usersRoute);
       const file = new File([new Uint8Array([0xff, 0xd8, 0xff])], "avatar.jpg", {
@@ -969,7 +977,7 @@ describe("POST /api/users/me/avatar", () => {
       });
 
       // Act
-      const res = await postAvatar(app as never, file);
+      const res = await postAvatar(app as unknown as { request: Hono["request"] }, file);
 
       // Assert
       expect(res.status).toBe(HTTP_UNAUTHORIZED);


### PR DESCRIPTION
## 概要

パスワード変更（PATCH /api/users/me/password）とパスワードリセット（POST /api/auth/reset-password）が独自の PBKDF2 ハッシュを保存していたため、Better Auth の sign-in 検証（scrypt 形式）と互換性がなく、変更・リセット後にログインできない不具合を修正する。

両エンドポイントを `auth.\$context.password.hash/verify()` 経由で Better Auth の scrypt ハッシュに統一した。

Closes #957

## 変更ファイル

- \`apps/api/src/routes/users.ts\` — PATCH /me/password を \`auth.\$context.password.hash/verify\` に置き換え
- \`apps/api/src/routes/password-reset.ts\` — POST /reset-password を \`auth.\$context.password.hash\` に置き換え
- \`apps/api/src/app/auth-subapp.ts\` — \`auth\` を \`createPasswordResetRoute\` に伝播
- \`apps/api/src/app/users-subapp.ts\` — \`auth\` を \`createUsersRoute\` に伝播
- \`tests/api/integration/password-change-login.test.ts\` — 新規統合テスト（scrypt 形式互換性・変更後サインイン検証・リセット後サインイン検証）
- \`tests/api/routes/password-reset.test.ts\` — \`auth\` モック追加
- \`tests/api/routes/users.test.ts\` — PBKDF2 固定値を \`better-auth/crypto\` の \`hashPassword\` に置換

## レビュー観点の確認

- Better Auth の hash 方式と変更・リセット側が完全統一されていること（両者とも \`auth.\$context.password.hash\` を使用）
- セキュリティ: current password 検証、リソース所有者チェック、リセットトークン有効期限チェックを保持
- テスト: サインアップ（scrypt）→ 変更/リセット → \`verifyPassword\` 互換性の統合フローをカバー
- コーディング規約準拠: 早期リターン / JSDoc / 日本語エラーメッセージ / Drizzle ORM パラメータ化クエリ

## テスト結果

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（1482 passed）

🤖 Reviewed by reviewer agent