### PR TITLE
fix(mobile/api): apiFetch の HTTP エラー処理と非JSON応答耐性を強化する #853

### DIFF
--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -91,9 +91,9 @@ export class SessionExpiredError extends ApiError {
 export class ApiHttpError extends ApiError {
   /** HTTPステータスコード */
   public readonly status: number;
-  /** 業務エラーJSONから取得した code。非業務エラー時は undefined */
+  /** 将来の拡張用フィールド。現行実装では常に undefined */
   public readonly code?: string;
-  /** 業務エラーJSONから取得した details。非業務エラー時は undefined */
+  /** 将来の拡張用フィールド。現行実装では常に undefined */
   public readonly details?: unknown;
   /** レスポンス本文の先頭（診断用、最大 BODY_TEXT_PREVIEW_MAX_LENGTH 文字） */
   public readonly bodyText?: string;

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -44,6 +44,25 @@ const HTTP_ERROR_MESSAGE = "サーバーエラーが発生しました";
 /** パースエラー時のデフォルトメッセージ */
 const PARSE_ERROR_MESSAGE = "レスポンスの解析に失敗しました";
 
+/** ステータスコード別デフォルトメッセージ（非業務エラー時のフォールバック） */
+const HTTP_ERROR_MESSAGES_BY_STATUS: Readonly<Record<number, string>> = {
+  400: "リクエストが正しくありません",
+  403: "この操作を実行する権限がありません",
+  404: "リソースが見つかりません",
+  408: "リクエストがタイムアウトしました",
+  409: "競合が発生しました",
+  413: "送信データが大きすぎます",
+  422: "入力内容を確認してください",
+  429: "リクエストが多すぎます。しばらく待ってから再度お試しください",
+  500: "サーバーエラーが発生しました",
+  502: "サーバーに接続できません",
+  503: "サービスが一時的に利用できません",
+  504: "サーバー応答がタイムアウトしました",
+};
+
+/** bodyText のプレビュー最大長（診断用に残すが機密抑制のため制限） */
+const BODY_TEXT_PREVIEW_MAX_LENGTH = 512;
+
 /**
  * APIエラーの基底クラス
  */
@@ -72,11 +91,24 @@ export class SessionExpiredError extends ApiError {
 export class ApiHttpError extends ApiError {
   /** HTTPステータスコード */
   public readonly status: number;
+  /** 業務エラーJSONから取得した code。非業務エラー時は undefined */
+  public readonly code?: string;
+  /** 業務エラーJSONから取得した details。非業務エラー時は undefined */
+  public readonly details?: unknown;
+  /** レスポンス本文の先頭（診断用、最大 BODY_TEXT_PREVIEW_MAX_LENGTH 文字） */
+  public readonly bodyText?: string;
 
-  constructor(status: number, message: string) {
-    super(message);
+  constructor(
+    status: number,
+    message: string,
+    options?: { code?: string; details?: unknown; bodyText?: string; cause?: unknown },
+  ) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
     this.name = "ApiHttpError";
     this.status = status;
+    this.code = options?.code;
+    this.details = options?.details;
+    this.bodyText = options?.bodyText;
   }
 }
 
@@ -262,37 +294,124 @@ async function parseSuccessBody<T>(response: Response): Promise<T> {
 }
 
 /**
+ * 業務エラーの形状を表す型
+ * API 規約に従い `error.code` と `error.message` を必須とする
+ */
+type BusinessErrorShape = {
+  success: false;
+  error: { code: string; message: string; details?: unknown };
+};
+
+/**
  * 業務エラー形式かどうかを判定する
- * `{ success: false, error: { ... } }` の形を許容する
+ * `{ success: false, error: { code: string; message: string } }` の形を要求する
  *
  * @param value - 判定対象
  * @returns 業務エラー形式なら true
  */
-function isBusinessErrorPayload(value: unknown): boolean {
+function isBusinessErrorPayload(value: unknown): value is BusinessErrorShape {
   if (value === null || typeof value !== "object") {
     return false;
   }
-  const maybe = value as { success?: unknown; error?: unknown };
-  return maybe.success === false && typeof maybe.error === "object" && maybe.error !== null;
+  const v = value as { success?: unknown; error?: unknown };
+  if (v.success !== false) {
+    return false;
+  }
+  if (v.error === null || typeof v.error !== "object" || Array.isArray(v.error)) {
+    return false;
+  }
+  const e = v.error as { code?: unknown; message?: unknown };
+  return typeof e.code === "string" && typeof e.message === "string";
+}
+
+/**
+ * ステータスコードに対応する日本語メッセージを返す
+ *
+ * @param status - HTTPステータスコード
+ * @returns 対応する日本語メッセージ
+ */
+function defaultHttpErrorMessage(status: number): string {
+  return HTTP_ERROR_MESSAGES_BY_STATUS[status] ?? HTTP_ERROR_MESSAGE;
+}
+
+/**
+ * レスポンス本文をテキストとして一度だけ読み込む
+ * 読み込みに失敗した場合は null を返す
+ *
+ * @param response - fetchレスポンス
+ * @returns 読み込んだテキスト。失敗時は null
+ */
+async function readBodyOnce(response: Response): Promise<{ text: string } | null> {
+  try {
+    return { text: await response.text() };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * テキストを JSON としてパースする
+ * パースに失敗した場合は PARSE_FAILED を返す
+ *
+ * @param text - パース対象の文字列
+ * @returns パース結果。失敗時は PARSE_FAILED
+ */
+function tryParseJsonText(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return PARSE_FAILED;
+  }
+}
+
+/**
+ * テキストが JSON オブジェクトまたは配列に見えるか判定する
+ *
+ * @param text - 判定対象の文字列
+ * @returns JSON らしければ true
+ */
+function looksLikeJson(text: string): boolean {
+  const trimmed = text.trimStart();
+  return trimmed.startsWith("{") || trimmed.startsWith("[");
+}
+
+/**
+ * テキストを BODY_TEXT_PREVIEW_MAX_LENGTH 文字以内に切り詰める
+ *
+ * @param text - 切り詰め対象の文字列
+ * @returns 切り詰め後の文字列
+ */
+function truncateBodyText(text: string): string {
+  return text.length > BODY_TEXT_PREVIEW_MAX_LENGTH
+    ? text.slice(0, BODY_TEXT_PREVIEW_MAX_LENGTH)
+    : text;
 }
 
 /**
  * 非2xxレスポンスの本文を扱う
  * 業務エラーJSONならそのまま返し、そうでなければ ApiHttpError をスローする
+ * body は text() で一度だけ読み込み、JSON パースは文字列ベースで行う
  *
  * @param response - fetchレスポンス
  * @returns 業務エラー本文
  * @throws ApiHttpError - 非JSONまたは業務エラー形式でない場合
  */
 async function handleErrorResponse<T>(response: Response): Promise<T> {
-  const parsed = await tryParseJson(response);
-  if (parsed === PARSE_FAILED) {
-    throw new ApiHttpError(response.status, HTTP_ERROR_MESSAGE);
+  const body = await readBodyOnce(response);
+  if (body === null) {
+    throw new ApiHttpError(response.status, defaultHttpErrorMessage(response.status));
   }
-  if (!isBusinessErrorPayload(parsed)) {
-    throw new ApiHttpError(response.status, HTTP_ERROR_MESSAGE);
+
+  if (shouldParseAsJson(response) || looksLikeJson(body.text)) {
+    const parsed = tryParseJsonText(body.text);
+    if (parsed !== PARSE_FAILED && isBusinessErrorPayload(parsed)) {
+      return parsed as unknown as T;
+    }
   }
-  return parsed as T;
+
+  throw new ApiHttpError(response.status, defaultHttpErrorMessage(response.status), {
+    bodyText: truncateBodyText(body.text),
+  });
 }
 
 /**

--- a/tests/mobile/lib/api.test.ts
+++ b/tests/mobile/lib/api.test.ts
@@ -546,6 +546,146 @@ describe("apiFetch", () => {
     });
   });
 
+  describe("isBusinessErrorPayloadの型ガード厳格化", () => {
+    it("{success: false, error: '文字列'} のときApiHttpErrorがスローされること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse({ success: false, error: "エラー文字列" }, { status: 400 }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
+    });
+
+    it("{success: false, error: {}} （code/message欠落）のときApiHttpErrorがスローされること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse({ success: false, error: {} }, { status: 400 }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
+    });
+  });
+
+  describe("ステータス別エラーメッセージとbodyText診断情報", () => {
+    it("404の非業務エラー応答でApiHttpError.messageが'リソースが見つかりません'になること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("Not Found", {
+          status: 404,
+          contentType: "text/plain",
+        }),
+      );
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles/999");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiHttpError);
+      expect((caughtError as ApiHttpError).message).toBe("リソースが見つかりません");
+    });
+
+    it("429の非業務エラー応答でApiHttpError.messageが'リクエストが多すぎます...'になること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("Too Many Requests", {
+          status: 429,
+          contentType: "text/plain",
+        }),
+      );
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiHttpError);
+      expect((caughtError as ApiHttpError).message).toBe(
+        "リクエストが多すぎます。しばらく待ってから再度お試しください",
+      );
+    });
+
+    it("500の非業務エラーJSONでApiHttpError.bodyTextに本文先頭が格納されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse({ unexpected: "structure", error: null }, { status: 500 }),
+      );
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiHttpError);
+      const err = caughtError as ApiHttpError;
+      expect(err.bodyText).toBeDefined();
+      expect(err.bodyText?.length).toBeLessThanOrEqual(512);
+    });
+
+    it("500のHTML応答でApiHttpError.bodyTextにHTML先頭が格納されること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse("<html><body>Internal Server Error</body></html>", {
+          status: 500,
+          contentType: "text/html; charset=utf-8",
+        }),
+      );
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiHttpError);
+      const err = caughtError as ApiHttpError;
+      expect(err.bodyText).toBeDefined();
+      expect(err.bodyText).toContain("<html>");
+    });
+
+    it("bodyTextがBODY_TEXT_PREVIEW_MAX_LENGTHを超える場合に512文字に切り詰められること", async () => {
+      // Arrange
+      const longBody = "x".repeat(1000);
+      mockFetch.mockResolvedValue(
+        createFetchResponse(longBody, {
+          status: 503,
+          contentType: "text/plain",
+        }),
+      );
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiHttpError);
+      const err = caughtError as ApiHttpError;
+      expect(err.bodyText).toBeDefined();
+      expect(err.bodyText?.length).toBe(512);
+    });
+  });
+
   describe("getBaseUrl", () => {
     it("extra.apiUrlが設定されている場合はその値をベースURLとして使用すること", async () => {
       // Arrange（モックは上部でhttp://test-api.example.comを返すよう設定済み）

--- a/tests/mobile/lib/api.test.ts
+++ b/tests/mobile/lib/api.test.ts
@@ -332,6 +332,46 @@ describe("apiFetch", () => {
     });
   });
 
+  describe("readBodyOnce の境界ケース", () => {
+    it("response.text() が例外をスローした場合はApiHttpErrorをスローすること", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse(null, {
+          status: 500,
+          contentType: "application/json",
+          textImpl: () => Promise.reject(new Error("ストリーム読み取りエラー")),
+        }),
+      );
+
+      // Act & Assert
+      await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
+    });
+  });
+
+  describe("looksLikeJson のパス", () => {
+    it("Content-Typeが非JSONでも本文が'{' で始まる場合は業務エラーとして返すこと", async () => {
+      // Arrange
+      mockFetch.mockResolvedValue(
+        createFetchResponse(
+          { success: false, error: { code: "NOT_FOUND", message: "見つかりません" } },
+          {
+            status: 404,
+            contentType: "text/plain",
+          },
+        ),
+      );
+
+      // Act
+      const result = await apiFetch("/articles/999");
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: { code: "NOT_FOUND", message: "見つかりません" },
+      });
+    });
+  });
+
   describe("非JSON応答の耐性", () => {
     it("2xxでJSONパースに失敗した場合はApiParseErrorをスローすること", async () => {
       // Arrange


### PR DESCRIPTION
## 概要

モバイルアプリの `apiFetch` ラッパーにおいて、401 以外の非2xx 応答や非JSON本文に対する耐性を強化する。

- `isBusinessErrorPayload` 型ガードを厳格化し、`{ success: false, error: { code: string; message: string } }` の形式のみを業務エラーとして扱う
- 新規 `ApiHttpError` クラス（status / code / details / bodyText）を追加し、非業務エラーの非2xx 応答を明示的に扱う
- `handleErrorResponse` をリライト: 本文を text() で一度だけ読み、Content-Type または `{`/`[` 始まりを見て JSON パースを試行。業務エラー形式なら返し、それ以外は `ApiHttpError` をスロー
- ステータス別デフォルト日本語メッセージを追加（400/403/404/408/409/413/422/429/500/502/503/504）
- `bodyText` は診断用に先頭 512 文字まで保持
- `ApiNetworkError` / `ApiParseError` / `SessionExpiredError` との責務分離を維持
- リフレッシュAPIの非JSON/ネットワーク失敗も `SessionExpiredError` にラップ

## 変更ファイル

- `apps/mobile/src/lib/api.ts` — 型ガード厳格化・`ApiHttpError` 拡張・`handleErrorResponse` リライト
- `tests/mobile/lib/api.test.ts` — HTTPエラー耐性・非JSON耐性・境界ケース・ステータス別メッセージ・bodyText・型ガード厳格化のテスト追加

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（mobile: 925 tests / api: 1472 tests）

Closes #853

🤖 Reviewed by reviewer agent