### PR TITLE
fix(agents): reviewerエージェントの承認判定を AI Review ラベルベースに修正

### DIFF
--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -189,7 +189,7 @@ fi
   4. 終了する
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
-  gh pr view {pr_number} --json comments --jq '.comments[-1].body'
+  gh pr view {pr_number} --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
   ```
   `SendMessage(to: "issue-{issue_number}-infra-engineer", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）

--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -165,21 +165,34 @@ PR は再作成しない。push のみ行う。
 
 ### フェーズ 6: GitHub レビューポーリング
 
+> **絶対に `gh pr view --json statusCheckRollup` の `claude-review: SUCCESS` を APPROVED の根拠にしないこと。**
+> `claude-review: SUCCESS` は CI ジョブが正常終了したという意味にすぎず、レビュー合否（PASS/NEEDS WORK）を表すものではない。
+> **絶対に `gh pr view --json reviews,state` の `state: APPROVED` だけに依存しないこと。**
+> claude-review は GitHub Review を作成せず、label のみでレビュー結果を通知する。
+
 ```bash
-gh pr view {pr_number} --json reviews,state --jq '...'
+LABELS=$(gh pr view {pr_number} --json labels --jq '.labels[].name')
+
+if echo "$LABELS" | grep -Fxq "AI Review: PASS"; then
+  # APPROVED 処理
+elif echo "$LABELS" | grep -Fxq "AI Review: NEEDS WORK"; then
+  # CHANGES_REQUESTED 処理
+else
+  # PENDING: 再ポーリング
+fi
 ```
 
-- **PENDING**: 再ポーリング（適度な間隔で待機）
-- **APPROVED**:
+- **`AI Review: PASS` ラベルが存在する（APPROVED）**:
   1. `SendMessage(to: "issue-{issue_number}-infra-engineer", "APPROVED")` → infra-engineer 終了
   2. worktree を削除する: `git -C <main-worktree-path> worktree remove {worktree} --force`
   3. `SendMessage(to: orchestrator, "APPROVED: issue-{issue_number}")` → orchestrator がカウント管理
   4. 終了する
-- **CHANGES_REQUESTED**: レビューコメントを取得する:
+- **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
-  gh pr view {pr_number} --json reviews --jq '.reviews[] | select(.state=="CHANGES_REQUESTED") | .body'
+  gh pr view {pr_number} --json comments --jq '.comments[-1].body'
   ```
   `SendMessage(to: "issue-{issue_number}-infra-engineer", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
+- **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）
 
 ## レビュー方針（厳守）
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -159,21 +159,34 @@ PR は再作成しない。push のみ行う。
 
 ### フェーズ 6: GitHub レビューポーリング
 
+> **絶対に `gh pr view --json statusCheckRollup` の `claude-review: SUCCESS` を APPROVED の根拠にしないこと。**
+> `claude-review: SUCCESS` は CI ジョブが正常終了したという意味にすぎず、レビュー合否（PASS/NEEDS WORK）を表すものではない。
+> **絶対に `gh pr view --json reviews,state` の `state: APPROVED` だけに依存しないこと。**
+> claude-review は GitHub Review を作成せず、label のみでレビュー結果を通知する。
+
 ```bash
-gh pr view {pr_number} --json reviews,state --jq '...'
+LABELS=$(gh pr view {pr_number} --json labels --jq '.labels[].name')
+
+if echo "$LABELS" | grep -Fxq "AI Review: PASS"; then
+  # APPROVED 処理
+elif echo "$LABELS" | grep -Fxq "AI Review: NEEDS WORK"; then
+  # CHANGES_REQUESTED 処理
+else
+  # PENDING: 再ポーリング
+fi
 ```
 
-- **PENDING**: 再ポーリング（適度な間隔で待機）
-- **APPROVED**:
+- **`AI Review: PASS` ラベルが存在する（APPROVED）**:
   1. `SendMessage(to: "issue-{issue_number}-coder", "APPROVED")` → coder 終了
   2. worktree を削除する: `git -C <main-worktree-path> worktree remove {worktree} --force`
   3. `SendMessage(to: orchestrator, "APPROVED: issue-{issue_number}")` → orchestrator がカウント管理
   4. 終了する
-- **CHANGES_REQUESTED**: レビューコメントを取得する:
+- **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
-  gh pr view {pr_number} --json reviews --jq '.reviews[] | select(.state=="CHANGES_REQUESTED") | .body'
+  gh pr view {pr_number} --json comments --jq '.comments[-1].body'
   ```
   `SendMessage(to: "issue-{issue_number}-coder", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
+- **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）
 
 ## レビュー方針（厳守）
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -183,7 +183,7 @@ fi
   4. 終了する
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
-  gh pr view {pr_number} --json comments --jq '.comments[-1].body'
+  gh pr view {pr_number} --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
   ```
   `SendMessage(to: "issue-{issue_number}-coder", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -162,12 +162,24 @@ EOF
 
 ### フェーズ 6: GitHub レビューポーリング
 
+> **絶対に `gh pr view --json statusCheckRollup` の `claude-review: SUCCESS` を APPROVED の根拠にしないこと。**
+> `claude-review: SUCCESS` は CI ジョブが正常終了したという意味にすぎず、レビュー合否（PASS/NEEDS WORK）を表すものではない。
+> **絶対に `gh pr view --json reviews,state` の `state: APPROVED` だけに依存しないこと。**
+> claude-review は GitHub Review を作成せず、label のみでレビュー結果を通知する。
+
 ```bash
-gh pr view <PR番号> --json reviews,state
+LABELS=$(gh pr view <PR番号> --json labels --jq '.labels[].name')
+
+if echo "$LABELS" | grep -Fxq "AI Review: PASS"; then
+  # APPROVED 処理
+elif echo "$LABELS" | grep -Fxq "AI Review: NEEDS WORK"; then
+  # CHANGES_REQUESTED 処理
+else
+  # PENDING: 再ポーリング
+fi
 ```
 
-- **PENDING**: 再ポーリングする（適度な間隔を空けて繰り返す）
-- **APPROVED**:
+- **`AI Review: PASS` ラベルが存在する（APPROVED）**:
   1. ui-designer に APPROVED を送信する
      ```text
      SendMessage(
@@ -177,7 +189,7 @@ gh pr view <PR番号> --json reviews,state
      ```
   2. worktree を削除する
      ```bash
-     git worktree remove {worktree} --force
+     git -C <main-worktree-path> worktree remove {worktree} --force
      ```
   3. orchestrator に完了を通知する
      ```text
@@ -187,10 +199,10 @@ gh pr view <PR番号> --json reviews,state
      )
      ```
   4. 終了する。
-- **CHANGES_REQUESTED**:
+- **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**:
   1. レビューコメントを取得する
      ```bash
-     gh pr view <PR番号> --json reviews --jq '.reviews[-1].body'
+     gh pr view <PR番号> --json comments --jq '.comments[-1].body'
      ```
   2. ui-designer に修正依頼を送信する
      ```text
@@ -200,6 +212,7 @@ gh pr view <PR番号> --json reviews,state
      )
      ```
   3. フェーズ 0 に戻り次の impl-ready を待機する。
+- **どちらのラベルも存在しない（PENDING）**: 再ポーリングする（適度な間隔を空けて繰り返す）
 
 ## レビュー方針（厳守）
 

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -202,7 +202,7 @@ fi
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**:
   1. レビューコメントを取得する
      ```bash
-     gh pr view <PR番号> --json comments --jq '.comments[-1].body'
+     gh pr view <PR番号> --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
      ```
   2. ui-designer に修正依頼を送信する
      ```text


### PR DESCRIPTION
## 概要

reviewer / infra-reviewer / ui-reviewer の各エージェント定義で、GitHub レビューポーリング時の承認判定ロジックを修正した。

従来は \`gh pr view --json reviews,state\` の state を見て APPROVED / CHANGES_REQUESTED / PENDING を判定していたが、claude-review は GitHub Review を作成せずラベル (\`AI Review: PASS\` / \`AI Review: NEEDS WORK\`) とコメントで結果を通知する。このため以下の問題があった:

- \`state: APPROVED\` が常に返らず PENDING 扱いになりポーリングが無限ループする
- \`claude-review: SUCCESS\` (CI ジョブ成功) を APPROVED と誤認するリスクがある

## 変更内容

- \`.claude/agents/reviewer.md\`
- \`.claude/agents/infra-reviewer.md\`
- \`.claude/agents/ui-reviewer.md\`

以下を各ファイルに適用:

1. フェーズ 6 冒頭に \`claude-review: SUCCESS\` を承認の根拠にしない警告、および \`state: APPROVED\` のみへの依存を禁じる警告を追加
2. ポーリング処理を \`gh pr view --json labels\` ベースに変更
   - \`AI Review: PASS\` ラベルあり → APPROVED 処理
   - \`AI Review: NEEDS WORK\` ラベルあり → CHANGES_REQUESTED 処理
   - どちらもない → PENDING 再ポーリング
3. CHANGES_REQUESTED 時のコメント取得を \`.reviews[-1].body\` から \`.comments[-1].body\` に変更(claude-review は GitHub Review でなくコメントとして結果本文を投稿するため)
4. ui-reviewer の worktree 削除コマンドも \`git -C <main-worktree-path> worktree remove\` 形式に統一

## テスト

ドキュメント(エージェント定義 Markdown)の変更のみでコード変更なし。

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス (1476 tests passed)

Closes #965

🤖 Reviewed by reviewer agent