### PR TITLE
fix(mobile/offline): バックグラウンド同期で記事本文までオフライン保存する

### DIFF
--- a/apps/mobile/app/article/[id].tsx
+++ b/apps/mobile/app/article/[id].tsx
@@ -18,7 +18,12 @@ import { useColors } from "@/hooks/use-colors";
 import { useNetworkStatus } from "@/hooks/use-network-status";
 import { formatArticleDate } from "@/lib/date-format";
 import { UI_TO_API_LANGUAGE } from "@/lib/language-code";
-import { getOfflineArticleById } from "@/lib/localDb";
+import {
+  getOfflineArticleById,
+  upsertArticle,
+  upsertSummary,
+  upsertTranslation,
+} from "@/lib/localDb";
 import { useSettingsStore } from "@/stores/settings-store";
 import type { ArticleDetail } from "@/types/article";
 
@@ -174,6 +179,19 @@ export default function ArticleDetailScreen() {
         setIsOfflineLoading(false);
       });
   }, [isOffline, id]);
+
+  useEffect(() => {
+    if (isOffline || !onlineArticle) {
+      return;
+    }
+    void upsertArticle(onlineArticle);
+    if (onlineArticle.summary) {
+      void upsertSummary(onlineArticle.id, onlineArticle.summary);
+    }
+    if (onlineArticle.translation) {
+      void upsertTranslation(onlineArticle.id, onlineArticle.translation);
+    }
+  }, [isOffline, onlineArticle]);
 
   const article = isOffline ? offlineArticle : onlineArticle;
   const isLoading = isOffline ? isOfflineLoading : isOnlineLoading;
@@ -507,6 +525,12 @@ export default function ArticleDetailScreen() {
         <View className="px-4 pt-4">
           {article.content ? (
             <Markdown style={markdownStyles}>{article.content}</Markdown>
+          ) : isOffline ? (
+            <View className="items-center py-8">
+              <Text className="text-text-muted text-center">
+                {t("article.offlineContentUnavailable")}
+              </Text>
+            </View>
           ) : (
             <View className="items-center py-8">
               <Text className="text-text-muted text-center">{t("article.noContent")}</Text>

--- a/apps/mobile/src/lib/backgroundSync.ts
+++ b/apps/mobile/src/lib/backgroundSync.ts
@@ -3,7 +3,7 @@ import * as TaskManager from "expo-task-manager";
 import type { AppStateStatus, NativeEventSubscription } from "react-native";
 import { AppState } from "react-native";
 
-import { syncArticles } from "./syncManager";
+import { syncAllForOffline } from "./syncManager";
 
 /**
  * バックグラウンド同期の最小間隔（ミリ秒）
@@ -41,11 +41,11 @@ export const DEFAULT_BACKGROUND_SYNC_CONFIG: BackgroundSyncConfig = {
  */
 TaskManager.defineTask(DEFAULT_BACKGROUND_SYNC_CONFIG.taskName, async () => {
   try {
-    const result = await syncArticles();
+    const result = await syncAllForOffline();
     if (result.errors.length > 0) {
       return BackgroundFetch.BackgroundFetchResult.Failed;
     }
-    if (result.synced === 0) {
+    if (result.contentsPrefetched + result.listSynced === 0) {
       return BackgroundFetch.BackgroundFetchResult.NoData;
     }
     return BackgroundFetch.BackgroundFetchResult.NewData;
@@ -111,7 +111,7 @@ export function createAppStateHandler(config: BackgroundSyncConfig): AppStateCha
       return;
     }
     state.lastSyncedAt = Date.now();
-    syncArticles().catch(() => {
+    syncAllForOffline().catch(() => {
       /* バックグラウンド同期エラーは無視（次回復帰時に再試行） */
     });
   };

--- a/apps/mobile/src/lib/backgroundSync.ts
+++ b/apps/mobile/src/lib/backgroundSync.ts
@@ -42,10 +42,12 @@ export const DEFAULT_BACKGROUND_SYNC_CONFIG: BackgroundSyncConfig = {
 TaskManager.defineTask(DEFAULT_BACKGROUND_SYNC_CONFIG.taskName, async () => {
   try {
     const result = await syncAllForOffline();
-    if (result.errors.length > 0) {
+    const hasNewData = result.contentsPrefetched + result.listSynced > 0;
+    const allFailed = !hasNewData && result.errors.length > 0;
+    if (allFailed) {
       return BackgroundFetch.BackgroundFetchResult.Failed;
     }
-    if (result.contentsPrefetched + result.listSynced === 0) {
+    if (!hasNewData) {
       return BackgroundFetch.BackgroundFetchResult.NoData;
     }
     return BackgroundFetch.BackgroundFetchResult.NewData;

--- a/apps/mobile/src/lib/localDb.ts
+++ b/apps/mobile/src/lib/localDb.ts
@@ -202,6 +202,35 @@ export async function upsertTranslation(articleId: string, translation: string):
 }
 
 /**
+ * 本文をオフライン保存すべき記事 ID を取得する
+ * - synced_at DESC の先頭 limit 件
+ * - + is_favorite = 1 の全記事（重複除外）
+ *
+ * @param limit - 最新記事の取得件数
+ * @returns 対象記事 ID の配列（重複なし）
+ */
+export async function getOfflineTargetArticleIds(limit: number): Promise<string[]> {
+  const database = await getDb();
+
+  const rows = await database.getAllAsync<{ id: string }>(
+    `SELECT id FROM articles
+     WHERE id IN (SELECT id FROM articles ORDER BY synced_at DESC LIMIT ?)
+     OR is_favorite = 1`,
+    [limit],
+  );
+
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const row of rows) {
+    if (!seen.has(row.id)) {
+      seen.add(row.id);
+      ids.push(row.id);
+    }
+  }
+  return ids;
+}
+
+/**
  * 全オフラインデータを削除する
  * 外部キー制約の順序に従い translations → summaries → articles の順で削除する
  */

--- a/apps/mobile/src/lib/syncManager.ts
+++ b/apps/mobile/src/lib/syncManager.ts
@@ -1,7 +1,15 @@
 import type { ArticleDetailResponse, ArticlesListResponse } from "@/types/article";
 
 import { apiFetch } from "./api";
-import { upsertArticle, upsertSummary, upsertTranslation } from "./localDb";
+import {
+  getOfflineTargetArticleIds,
+  upsertArticle,
+  upsertSummary,
+  upsertTranslation,
+} from "./localDb";
+
+/** 最新記事を本文までオフライン保存する件数 */
+const OFFLINE_FULL_CONTENT_LIMIT = 20;
 
 /** 同期結果 */
 export type SyncResult = {
@@ -11,6 +19,19 @@ export type SyncResult = {
 
 /** 記事詳細同期結果 */
 export type SyncDetailResult = { success: true } | { success: false; error: string };
+
+/** プレフェッチ結果 */
+export type PrefetchResult = {
+  prefetched: number;
+  errors: string[];
+};
+
+/** オフライン同期全体の結果 */
+export type SyncAllResult = {
+  listSynced: number;
+  contentsPrefetched: number;
+  errors: string[];
+};
 
 /**
  * サーバーから記事一覧を取得してローカルDBに同期する（全ページ取得）
@@ -92,4 +113,75 @@ export async function syncArticleDetail(articleId: string): Promise<SyncDetailRe
       error instanceof Error ? error.message : "記事詳細の同期中にエラーが発生しました";
     return { success: false, error: message };
   }
+}
+
+/**
+ * オフライン対象記事の本文を順次取得して保存する
+ * - 直列実行（サーバー負荷とバックグラウンドフェッチ時間制限のため）
+ * - 個別記事の失敗は errors に記録するが処理は継続する
+ *
+ * @param limit - 最新記事の取得件数
+ * @returns プレフェッチ結果
+ */
+export async function prefetchOfflineArticleContents(
+  limit = OFFLINE_FULL_CONTENT_LIMIT,
+): Promise<PrefetchResult> {
+  const ids = await getOfflineTargetArticleIds(limit);
+
+  if (ids.length === 0) {
+    return { prefetched: 0, errors: [] };
+  }
+
+  let prefetched = 0;
+  const errors: string[] = [];
+
+  for (const id of ids) {
+    try {
+      const result = await syncArticleDetail(id);
+      if (result.success) {
+        prefetched++;
+      } else {
+        errors.push(`${id}: ${result.error}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "不明なエラーが発生しました";
+      errors.push(`${id}: ${message}`);
+    }
+  }
+
+  return { prefetched, errors };
+}
+
+/**
+ * バックグラウンド同期エントリポイント
+ * 1. 一覧同期
+ * 2. 本文プレフェッチ（最新 N 件 + お気に入り）
+ *
+ * @returns オフライン同期全体の結果
+ */
+export async function syncAllForOffline(): Promise<SyncAllResult> {
+  const allErrors: string[] = [];
+  let listSynced = 0;
+
+  try {
+    const listResult = await syncArticles();
+    listSynced = listResult.synced;
+    for (const error of listResult.errors) {
+      allErrors.push(error);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "一覧同期中にエラーが発生しました";
+    allErrors.push(message);
+  }
+
+  const prefetchResult = await prefetchOfflineArticleContents();
+  for (const error of prefetchResult.errors) {
+    allErrors.push(error);
+  }
+
+  return {
+    listSynced,
+    contentsPrefetched: prefetchResult.prefetched,
+    errors: allErrors,
+  };
 }

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -144,6 +144,7 @@
     "addToFavorites": "Add to favorites",
     "removeFromFavorites": "Remove from favorites",
     "noContent": "Article content is unavailable",
+    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
     "viewOriginal": "View original article",
     "fetchError": "Failed to fetch article",
     "loadingArticle": "Loading...",

--- a/apps/mobile/src/locales/ja.json
+++ b/apps/mobile/src/locales/ja.json
@@ -144,6 +144,7 @@
     "addToFavorites": "お気に入り追加",
     "removeFromFavorites": "お気に入り解除",
     "noContent": "記事本文が利用できません",
+    "offlineContentUnavailable": "この記事はオフライン保存されていません。オンライン時に開くと本文が保存されます。",
     "viewOriginal": "元の記事を見る",
     "fetchError": "記事の取得に失敗しました",
     "loadingArticle": "読み込み中...",

--- a/apps/mobile/src/locales/ko.json
+++ b/apps/mobile/src/locales/ko.json
@@ -143,7 +143,7 @@
     "addToFavorites": "즐겨찾기 추가",
     "removeFromFavorites": "즐겨찾기 해제",
     "noContent": "기사 내용을 이용할 수 없습니다",
-    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
+    "offlineContentUnavailable": "이 기사는 오프라인에 저장되지 않았습니다. 온라인 상태에서 열면 본문이 저장됩니다.",
     "viewOriginal": "원문 보기",
     "fetchError": "기사를 불러오는데 실패했습니다",
     "loadingArticle": "불러오는 중...",

--- a/apps/mobile/src/locales/ko.json
+++ b/apps/mobile/src/locales/ko.json
@@ -143,6 +143,7 @@
     "addToFavorites": "즐겨찾기 추가",
     "removeFromFavorites": "즐겨찾기 해제",
     "noContent": "기사 내용을 이용할 수 없습니다",
+    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
     "viewOriginal": "원문 보기",
     "fetchError": "기사를 불러오는데 실패했습니다",
     "loadingArticle": "불러오는 중...",

--- a/apps/mobile/src/locales/zh-CN.json
+++ b/apps/mobile/src/locales/zh-CN.json
@@ -143,6 +143,7 @@
     "addToFavorites": "添加到收藏",
     "removeFromFavorites": "取消收藏",
     "noContent": "文章内容不可用",
+    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
     "viewOriginal": "查看原文",
     "fetchError": "获取文章失败",
     "loadingArticle": "加载中...",

--- a/apps/mobile/src/locales/zh-CN.json
+++ b/apps/mobile/src/locales/zh-CN.json
@@ -143,7 +143,7 @@
     "addToFavorites": "添加到收藏",
     "removeFromFavorites": "取消收藏",
     "noContent": "文章内容不可用",
-    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
+    "offlineContentUnavailable": "此文章未保存为离线内容。在线时打开即可保存正文。",
     "viewOriginal": "查看原文",
     "fetchError": "获取文章失败",
     "loadingArticle": "加载中...",

--- a/apps/mobile/src/locales/zh-TW.json
+++ b/apps/mobile/src/locales/zh-TW.json
@@ -143,6 +143,7 @@
     "addToFavorites": "加入收藏",
     "removeFromFavorites": "取消收藏",
     "noContent": "文章內容不可用",
+    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
     "viewOriginal": "查看原文",
     "fetchError": "取得文章失敗",
     "loadingArticle": "載入中...",

--- a/apps/mobile/src/locales/zh-TW.json
+++ b/apps/mobile/src/locales/zh-TW.json
@@ -143,7 +143,7 @@
     "addToFavorites": "加入收藏",
     "removeFromFavorites": "取消收藏",
     "noContent": "文章內容不可用",
-    "offlineContentUnavailable": "This article has not been saved for offline use. Open it while online to save the content.",
+    "offlineContentUnavailable": "此文章未儲存為離線內容。在線時開啟即可儲存內文。",
     "viewOriginal": "查看原文",
     "fetchError": "取得文章失敗",
     "loadingArticle": "載入中...",

--- a/tests/mobile/lib/backgroundSync.test.ts
+++ b/tests/mobile/lib/backgroundSync.test.ts
@@ -1,5 +1,6 @@
 jest.mock("@mobile/lib/syncManager", () => ({
   syncArticles: jest.fn(),
+  syncAllForOffline: jest.fn(),
 }));
 
 jest.mock("expo-task-manager", () => ({
@@ -27,7 +28,7 @@ import {
   startBackgroundSync,
   unregisterNativeBackgroundFetch,
 } from "@mobile/lib/backgroundSync";
-import { syncArticles } from "@mobile/lib/syncManager";
+import { syncAllForOffline, syncArticles } from "@mobile/lib/syncManager";
 import * as BackgroundFetch from "expo-background-fetch";
 import { AppState } from "react-native";
 
@@ -129,9 +130,13 @@ describe("backgroundSync", () => {
   });
 
   describe("createAppStateHandler", () => {
-    it("activeになった場合にsyncArticlesを呼び出すこと", async () => {
+    it("activeになった場合にsyncAllForOfflineを呼び出すこと", async () => {
       // Arrange
-      (syncArticles as jest.Mock).mockResolvedValue({ synced: 5, errors: [] });
+      (syncAllForOffline as jest.Mock).mockResolvedValue({
+        listSynced: 5,
+        contentsPrefetched: 3,
+        errors: [],
+      });
       const handler = createAppStateHandler(DEFAULT_BACKGROUND_SYNC_CONFIG);
 
       // Act
@@ -139,10 +144,10 @@ describe("backgroundSync", () => {
       await Promise.resolve();
 
       // Assert
-      expect(syncArticles).toHaveBeenCalledTimes(1);
+      expect(syncAllForOffline).toHaveBeenCalledTimes(1);
     });
 
-    it("backgroundになった場合はsyncArticlesを呼び出さないこと", async () => {
+    it("backgroundになった場合はsyncAllForOfflineを呼び出さないこと", async () => {
       // Arrange
       const handler = createAppStateHandler(DEFAULT_BACKGROUND_SYNC_CONFIG);
 
@@ -150,10 +155,10 @@ describe("backgroundSync", () => {
       handler("background");
 
       // Assert
-      expect(syncArticles).not.toHaveBeenCalled();
+      expect(syncAllForOffline).not.toHaveBeenCalled();
     });
 
-    it("inactiveになった場合はsyncArticlesを呼び出さないこと", async () => {
+    it("inactiveになった場合はsyncAllForOfflineを呼び出さないこと", async () => {
       // Arrange
       const handler = createAppStateHandler(DEFAULT_BACKGROUND_SYNC_CONFIG);
 
@@ -161,32 +166,36 @@ describe("backgroundSync", () => {
       handler("inactive");
 
       // Assert
-      expect(syncArticles).not.toHaveBeenCalled();
+      expect(syncAllForOffline).not.toHaveBeenCalled();
     });
 
-    it("同期間隔が経過していない場合はsyncArticlesを呼び出さないこと", async () => {
+    it("同期間隔が経過していない場合はsyncAllForOfflineを呼び出さないこと", async () => {
       // Arrange
-      (syncArticles as jest.Mock).mockResolvedValue({ synced: 0, errors: [] });
+      (syncAllForOffline as jest.Mock).mockResolvedValue({
+        listSynced: 0,
+        contentsPrefetched: 0,
+        errors: [],
+      });
       const config = { ...DEFAULT_BACKGROUND_SYNC_CONFIG, intervalMs: 15 * 60 * 1000 };
       const handler = createAppStateHandler(config);
 
       handler("active");
       await Promise.resolve();
-      expect(syncArticles).toHaveBeenCalledTimes(1);
+      expect(syncAllForOffline).toHaveBeenCalledTimes(1);
 
-      (syncArticles as jest.Mock).mockClear();
+      (syncAllForOffline as jest.Mock).mockClear();
 
       // Act
       handler("active");
       await Promise.resolve();
 
       // Assert
-      expect(syncArticles).not.toHaveBeenCalled();
+      expect(syncAllForOffline).not.toHaveBeenCalled();
     });
 
-    it("syncArticlesがエラーを返してもハンドラーがクラッシュしないこと", async () => {
+    it("syncAllForOfflineがエラーを返してもハンドラーがクラッシュしないこと", async () => {
       // Arrange
-      (syncArticles as jest.Mock).mockRejectedValue(new Error("ネットワークエラー"));
+      (syncAllForOffline as jest.Mock).mockRejectedValue(new Error("ネットワークエラー"));
       const handler = createAppStateHandler(DEFAULT_BACKGROUND_SYNC_CONFIG);
 
       // Act & Assert

--- a/tests/mobile/lib/localDb.test.ts
+++ b/tests/mobile/lib/localDb.test.ts
@@ -6,6 +6,7 @@ import {
   clearAllOfflineData,
   getOfflineArticleById,
   getOfflineArticles,
+  getOfflineTargetArticleIds,
   initLocalDb,
   upsertArticle,
   upsertSummary,
@@ -254,6 +255,69 @@ describe("localDb", () => {
         expect.stringContaining("INSERT OR REPLACE INTO translations"),
         expect.arrayContaining([articleId, translation]),
       );
+    });
+  });
+
+  describe("getOfflineTargetArticleIds", () => {
+    it("synced_at DESC 順に limit 件を返すこと", async () => {
+      // Arrange
+      mockGetAllAsync.mockResolvedValue([{ id: "article-003" }, { id: "article-001" }]);
+
+      // Act
+      await initLocalDb();
+      const ids = await getOfflineTargetArticleIds(2);
+
+      // Assert
+      expect(mockGetAllAsync).toHaveBeenCalledWith(
+        expect.stringContaining("synced_at"),
+        expect.arrayContaining([2]),
+      );
+      expect(ids).toEqual(["article-003", "article-001"]);
+    });
+
+    it("limit を超える記事でも is_favorite=1 の記事を含めること", async () => {
+      // Arrange
+      mockGetAllAsync.mockResolvedValue([
+        { id: "article-001" },
+        { id: "article-002" },
+        { id: "favorite-article" },
+      ]);
+
+      // Act
+      await initLocalDb();
+      const ids = await getOfflineTargetArticleIds(2);
+
+      // Assert
+      expect(ids).toContain("favorite-article");
+    });
+
+    it("重複を排除すること", async () => {
+      // Arrange
+      mockGetAllAsync.mockResolvedValue([
+        { id: "article-001" },
+        { id: "article-001" },
+        { id: "article-002" },
+      ]);
+
+      // Act
+      await initLocalDb();
+      const ids = await getOfflineTargetArticleIds(20);
+
+      // Assert
+      const uniqueIds = [...new Set(ids)];
+      expect(ids).toHaveLength(uniqueIds.length);
+    });
+
+    it("記事が存在しない場合は空配列を返すこと", async () => {
+      // Arrange
+      mockGetAllAsync.mockResolvedValue([]);
+
+      // Act
+      await initLocalDb();
+      const ids = await getOfflineTargetArticleIds(20);
+
+      // Assert
+      expect(ids).toHaveLength(0);
     });
   });
 

--- a/tests/mobile/lib/syncManager.test.ts
+++ b/tests/mobile/lib/syncManager.test.ts
@@ -8,6 +8,7 @@ jest.mock("@mobile/lib/localDb", () => ({
   upsertSummary: jest.fn().mockResolvedValue(undefined),
   upsertTranslation: jest.fn().mockResolvedValue(undefined),
   getOfflineArticles: jest.fn().mockResolvedValue([]),
+  getOfflineTargetArticleIds: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@mobile/lib/api", () => ({
@@ -15,8 +16,19 @@ jest.mock("@mobile/lib/api", () => ({
 }));
 
 import { apiFetch } from "@mobile/lib/api";
-import { initLocalDb, upsertArticle, upsertSummary, upsertTranslation } from "@mobile/lib/localDb";
-import { syncArticleDetail, syncArticles } from "@mobile/lib/syncManager";
+import {
+  getOfflineTargetArticleIds,
+  initLocalDb,
+  upsertArticle,
+  upsertSummary,
+  upsertTranslation,
+} from "@mobile/lib/localDb";
+import {
+  prefetchOfflineArticleContents,
+  syncAllForOffline,
+  syncArticleDetail,
+  syncArticles,
+} from "@mobile/lib/syncManager";
 
 import type { ArticleDetail, ArticleListItem } from "@/types/article";
 
@@ -26,6 +38,7 @@ const mockInitLocalDb = jest.mocked(initLocalDb);
 const mockUpsertArticle = jest.mocked(upsertArticle);
 const mockUpsertSummary = jest.mocked(upsertSummary);
 const mockUpsertTranslation = jest.mocked(upsertTranslation);
+const mockGetOfflineTargetArticleIds = jest.mocked(getOfflineTargetArticleIds);
 
 /** apiFetch の戻り値を unknown 経由でキャストするヘルパー */
 function asApiFetchResult<T>(value: T): Awaited<ReturnType<typeof apiFetch>> {
@@ -89,6 +102,7 @@ describe("syncManager", () => {
     mockUpsertArticle.mockResolvedValue(undefined);
     mockUpsertSummary.mockResolvedValue(undefined);
     mockUpsertTranslation.mockResolvedValue(undefined);
+    mockGetOfflineTargetArticleIds.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -316,6 +330,128 @@ describe("syncManager", () => {
       if (!result.success) {
         expect(result.error).toBeDefined();
       }
+    });
+  });
+
+  describe("prefetchOfflineArticleContents", () => {
+    it("対象記事の詳細を順次取得してローカルDBに保存できること", async () => {
+      // Arrange
+      mockGetOfflineTargetArticleIds.mockResolvedValue(["article-001", "article-002"]);
+      mockApiFetch
+        .mockResolvedValueOnce(
+          asApiFetchResult({
+            success: true,
+            data: { ...mockArticleDetailData, id: "article-001" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          asApiFetchResult({
+            success: true,
+            data: { ...mockArticleDetailData, id: "article-002" },
+          }),
+        );
+
+      // Act
+      const result = await prefetchOfflineArticleContents(20);
+
+      // Assert
+      expect(mockUpsertArticle).toHaveBeenCalledTimes(2);
+      expect(result.prefetched).toBe(2);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("個別記事の取得失敗時は errors に記録して処理を継続すること", async () => {
+      // Arrange
+      mockGetOfflineTargetArticleIds.mockResolvedValue(["article-001", "article-002"]);
+      mockApiFetch
+        .mockResolvedValueOnce(
+          asApiFetchResult({
+            success: false,
+            error: { code: "NOT_FOUND", message: "記事が見つかりません" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          asApiFetchResult({
+            success: true,
+            data: { ...mockArticleDetailData, id: "article-002" },
+          }),
+        );
+
+      // Act
+      const result = await prefetchOfflineArticleContents(20);
+
+      // Assert
+      expect(result.errors).toHaveLength(1);
+      expect(result.prefetched).toBe(1);
+    });
+
+    it("対象 ID が空の場合はプレフェッチをスキップすること", async () => {
+      // Arrange
+      mockGetOfflineTargetArticleIds.mockResolvedValue([]);
+
+      // Act
+      const result = await prefetchOfflineArticleContents(20);
+
+      // Assert
+      expect(mockApiFetch).not.toHaveBeenCalled();
+      expect(result.prefetched).toBe(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("個別記事の取得で例外が発生した場合は errors に記録して処理を継続すること", async () => {
+      // Arrange
+      mockGetOfflineTargetArticleIds.mockResolvedValue(["article-001", "article-002"]);
+      mockApiFetch.mockRejectedValueOnce(new Error("ネットワークエラー")).mockResolvedValueOnce(
+        asApiFetchResult({
+          success: true,
+          data: { ...mockArticleDetailData, id: "article-002" },
+        }),
+      );
+
+      // Act
+      const result = await prefetchOfflineArticleContents(20);
+
+      // Assert
+      expect(result.errors).toHaveLength(1);
+      expect(result.prefetched).toBe(1);
+    });
+  });
+
+  describe("syncAllForOffline", () => {
+    it("一覧同期後に本文プレフェッチを呼び出すこと", async () => {
+      // Arrange
+      mockApiFetch
+        .mockResolvedValueOnce(asApiFetchResult(mockArticleListResponse))
+        .mockResolvedValueOnce(asApiFetchResult({ success: true, data: mockArticleDetailData }));
+      mockGetOfflineTargetArticleIds.mockResolvedValue(["article-001"]);
+
+      // Act
+      const result = await syncAllForOffline();
+
+      // Assert
+      expect(result.listSynced).toBe(2);
+      expect(result.contentsPrefetched).toBe(1);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("一覧同期失敗時でも本文プレフェッチを実行すること", async () => {
+      // Arrange
+      mockApiFetch
+        .mockResolvedValueOnce(
+          asApiFetchResult({
+            success: false,
+            error: { code: "INTERNAL_ERROR", message: "サーバーエラー" },
+          }),
+        )
+        .mockResolvedValueOnce(asApiFetchResult({ success: true, data: mockArticleDetailData }));
+      mockGetOfflineTargetArticleIds.mockResolvedValue(["article-001"]);
+
+      // Act
+      const result = await syncAllForOffline();
+
+      // Assert
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.contentsPrefetched).toBe(1);
     });
   });
 });

--- a/tests/mobile/screens/[id].test.tsx
+++ b/tests/mobile/screens/[id].test.tsx
@@ -53,6 +53,9 @@ jest.mock("@mobile/hooks/use-network-status", () => ({
 
 jest.mock("@mobile/lib/localDb", () => ({
   getOfflineArticleById: jest.fn(),
+  upsertArticle: jest.fn().mockResolvedValue(undefined),
+  upsertSummary: jest.fn().mockResolvedValue(undefined),
+  upsertTranslation: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("@mobile/hooks/use-articles", () => ({
@@ -355,6 +358,65 @@ describe("ArticleDetailScreen", () => {
       // Assert
       await waitFor(() => {
         expect(getByLabelText("お気に入り解除")).not.toBeNull();
+      });
+    });
+  });
+
+  describe("オフライン本文あり/なし分岐", () => {
+    it("オフラインでも本文がローカルDBにあれば表示されること", async () => {
+      // Arrange
+      const { useNetworkStatus } = require("@mobile/hooks/use-network-status");
+      (useNetworkStatus as jest.Mock).mockReturnValue({ isOnline: false, isOffline: true });
+      const { getOfflineArticleById } = require("@mobile/lib/localDb");
+      (getOfflineArticleById as jest.Mock).mockResolvedValue({
+        ...MOCK_ARTICLE,
+        content: "# オフライン本文\nローカルに保存済みのコンテンツ",
+      });
+
+      // Act
+      const { getByText } = await render(<ArticleDetailScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("テスト記事")).not.toBeNull();
+      });
+    });
+
+    it("オフライン + 本文なしの場合は offlineContentUnavailable メッセージを表示すること", async () => {
+      // Arrange
+      setMockLocale("ja");
+      const { useNetworkStatus } = require("@mobile/hooks/use-network-status");
+      (useNetworkStatus as jest.Mock).mockReturnValue({ isOnline: false, isOffline: true });
+      const { getOfflineArticleById } = require("@mobile/lib/localDb");
+      (getOfflineArticleById as jest.Mock).mockResolvedValue({
+        ...MOCK_ARTICLE,
+        content: null,
+      });
+
+      // Act
+      const { getByText } = await render(<ArticleDetailScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(
+          getByText(
+            "この記事はオフライン保存されていません。オンライン時に開くと本文が保存されます。",
+          ),
+        ).not.toBeNull();
+      });
+    });
+
+    it("オンラインで取得した記事はローカルDBにも保存されること（write-through）", async () => {
+      // Arrange
+      const { upsertArticle } = require("@mobile/lib/localDb");
+      mockArticleDetailState.data = MOCK_ARTICLE;
+
+      // Act
+      await render(<ArticleDetailScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(upsertArticle).toHaveBeenCalledWith(expect.objectContaining({ id: "article-1" }));
       });
     });
   });


### PR DESCRIPTION
## 概要

バックグラウンド同期が `/api/articles` の一覧レスポンスのみを upsert していたため、同期済み記事でも本文 `content` が `null` のまま残りオフライン閲覧が成立していなかった問題を修正する。最新 N 件 + お気に入り記事に限り記事詳細 API を追加フェッチし、本文・要約・翻訳をローカル DB に保存する。

Closes #959

## 変更内容

- `apps/mobile/src/lib/localDb.ts`
  - `getOfflineTargetArticleIds(limit)` を追加。`synced_at DESC` 先頭 N 件と `is_favorite=1` の記事 ID をマージ（重複除外）して返す
- `apps/mobile/src/lib/syncManager.ts`
  - `prefetchOfflineArticleContents(limit)`: 対象記事の詳細を直列で取得し本文/要約/翻訳を upsert。個別失敗は errors に記録して継続
  - `syncAllForOffline()`: 一覧同期 → 本文プリフェッチのエントリポイント。一覧同期が失敗しても本文プリフェッチは実行
  - デフォルト上限 `OFFLINE_FULL_CONTENT_LIMIT = 20`
- `apps/mobile/src/lib/backgroundSync.ts`
  - `TaskManager.defineTask` と `createAppStateHandler` で `syncArticles` → `syncAllForOffline` に差し替え
  - `BackgroundFetchResult` の判定は `listSynced + contentsPrefetched` で算出
- `apps/mobile/app/article/[id].tsx`
  - オンラインで取得した記事詳細を write-through でローカル DB にキャッシュ（`upsertArticle`/`upsertSummary`/`upsertTranslation`）
  - オフライン + 本文なしの場合に `article.offlineContentUnavailable` を表示
- `apps/mobile/src/locales/{en,ja,ko,zh-CN,zh-TW}.json`
  - `article.offlineContentUnavailable` を全 5 言語に追加

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（mobile 931 tests, api 1476 tests）

### 追加したテスト

- `tests/mobile/lib/localDb.test.ts`: `getOfflineTargetArticleIds` の正常系・お気に入り包含・重複排除・空配列
- `tests/mobile/lib/syncManager.test.ts`: `prefetchOfflineArticleContents` の正常系・個別失敗継続・空対象スキップ・例外継続 / `syncAllForOffline` の正常系・一覧失敗時も本文プレフェッチ
- `tests/mobile/lib/backgroundSync.test.ts`: AppState ハンドラーが `syncAllForOffline` を呼ぶように更新
- `tests/mobile/screens/[id].test.tsx`: オフライン本文あり/なし分岐・write-through キャッシュの 3 ケース

🤖 Reviewed by reviewer agent