### PR TITLE
feat(mobile/i18n): ハードコード文言を i18n に置換 #958

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -62,7 +62,11 @@ export default function TabLayout() {
                   testID="tab-badge"
                   style={{ backgroundColor: colors.favorite }}
                   className="absolute -top-1 -right-2 rounded-full min-w-[16px] h-4 items-center justify-center px-1"
-                  accessibilityLabel={`未読通知${unreadCount > BADGE_MAX_COUNT ? `${BADGE_MAX_COUNT}件以上` : `${unreadCount}件`}`}
+                  accessibilityLabel={
+                    unreadCount > BADGE_MAX_COUNT
+                      ? t("notifications.unreadBadgeLabelOver", { max: BADGE_MAX_COUNT })
+                      : t("notifications.unreadBadgeLabel", { count: unreadCount })
+                  }
                 >
                   <Text className="text-white text-[10px] font-bold">
                     {unreadCount > BADGE_MAX_COUNT ? `${BADGE_MAX_COUNT}+` : String(unreadCount)}

--- a/apps/mobile/app/(tabs)/notifications.tsx
+++ b/apps/mobile/app/(tabs)/notifications.tsx
@@ -1,5 +1,6 @@
 import { BellOff, CheckCheck, RefreshCw } from "lucide-react-native";
 import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { ActivityIndicator, FlatList, Pressable, RefreshControl, Text, View } from "react-native";
 
 import { NotificationItem } from "@/components/NotificationItem";
@@ -21,6 +22,7 @@ const EMPTY_ICON_SIZE = 48;
  * 全既読、個別既読に対応。
  */
 export default function NotificationsScreen() {
+  const { t } = useTranslation();
   const colors = useColors();
   const {
     data,
@@ -78,17 +80,17 @@ export default function NotificationsScreen() {
     if (isError) {
       return (
         <View className="flex-1 items-center justify-center py-20">
-          <Text className="text-text-muted text-base">通知の取得に失敗しました</Text>
+          <Text className="text-text-muted text-base">{t("notifications.fetchError")}</Text>
           <Pressable
             testID="retry-button"
             onPress={() => refetch()}
             className="mt-4 flex-row items-center gap-2"
             accessibilityRole="button"
-            accessibilityLabel="再試行"
-            accessibilityHint="通知の取得を再試行します"
+            accessibilityLabel={t("common.retry")}
+            accessibilityHint={t("notifications.retryHint")}
           >
             <RefreshCw size={HEADER_ICON_SIZE} color={colors.primary} />
-            <Text className="text-primary">再試行</Text>
+            <Text className="text-primary">{t("common.retry")}</Text>
           </Pressable>
         </View>
       );
@@ -96,11 +98,11 @@ export default function NotificationsScreen() {
     return (
       <EmptyState
         icon={<BellOff size={EMPTY_ICON_SIZE} color={colors.textDim} />}
-        title="通知はありません"
-        description="新しい通知が届くとここに表示されます"
+        title={t("notifications.empty")}
+        description={t("notifications.emptyDescription")}
       />
     );
-  }, [isLoading, isError, refetch, colors.primary, colors.textDim]);
+  }, [isLoading, isError, refetch, colors.primary, colors.textDim, t]);
 
   return (
     <View className="flex-1 bg-background">
@@ -111,10 +113,10 @@ export default function NotificationsScreen() {
             onPress={handleMarkAllAsRead}
             className="flex-row items-center gap-1.5"
             accessibilityRole="button"
-            accessibilityLabel="すべて既読にする"
+            accessibilityLabel={t("notifications.markAllReadLabel")}
           >
             <CheckCheck size={HEADER_ICON_SIZE} color={colors.primary} />
-            <Text className="text-sm text-primary">すべて既読</Text>
+            <Text className="text-sm text-primary">{t("notifications.markAllRead")}</Text>
           </Pressable>
         </View>
       )}
@@ -122,7 +124,7 @@ export default function NotificationsScreen() {
       {isLoading ? (
         <View className="flex-1 items-center justify-center">
           <ActivityIndicator testID="loading-indicator" size="large" color={colors.primary} />
-          <Text className="text-text-muted mt-3">読み込み中...</Text>
+          <Text className="text-text-muted mt-3">{t("notifications.loadingNotifications")}</Text>
         </View>
       ) : (
         <FlatList

--- a/apps/mobile/app/article/save.tsx
+++ b/apps/mobile/app/article/save.tsx
@@ -2,6 +2,7 @@ import * as Haptics from "expo-haptics";
 import { router, useLocalSearchParams } from "expo-router";
 import { AlertCircle, ArrowLeft, ExternalLink, Loader2 } from "lucide-react-native";
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Image, Pressable, ScrollView, Text, View } from "react-native";
 
 import { Button, Card, Input, SourceBadge, Toast } from "@/components/ui";
@@ -29,14 +30,14 @@ const ERROR_ICON_SIZE = 16;
  * URL入力のクライアントバリデーション
  *
  * @param url - 検証するURL文字列
- * @returns エラーメッセージ。有効な場合はnull
+ * @returns 翻訳キー。有効な場合はnull
  */
-function validateUrl(url: string): string | null {
+function validateUrl(url: string): "article.urlRequired" | "article.urlInvalid" | null {
   if (!url.trim()) {
-    return "URLを入力してください";
+    return "article.urlRequired";
   }
   if (!URL_PATTERN.test(url.trim())) {
-    return "有効なURLを入力してください";
+    return "article.urlInvalid";
   }
   return null;
 }
@@ -48,6 +49,7 @@ function validateUrl(url: string): string | null {
  * NativeWindダークテーマ、authStore + apiFetch使用。
  */
 export default function SaveScreen() {
+  const { t } = useTranslation();
   const colors = useColors();
   const { url: sharedUrl } = useLocalSearchParams<{ url?: string }>();
   const [url, setUrl] = useState(sharedUrl ?? "");
@@ -65,9 +67,9 @@ export default function SaveScreen() {
     setErrorMessage(null);
     setPreview(null);
 
-    const validationError = validateUrl(url);
-    if (validationError) {
-      setUrlError(validationError);
+    const validationErrorKey = validateUrl(url);
+    if (validationErrorKey) {
+      setUrlError(t(validationErrorKey));
       return;
     }
 
@@ -88,11 +90,11 @@ export default function SaveScreen() {
       setPreview(data.data);
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     } catch {
-      setErrorMessage("記事の取得に失敗しました");
+      setErrorMessage(t("article.fetchFailed"));
     } finally {
       setIsFetching(false);
     }
-  }, [url]);
+  }, [url, t]);
 
   /**
    * プレビュー済みの記事をPOST /api/articlesで保存する
@@ -116,14 +118,14 @@ export default function SaveScreen() {
         return;
       }
 
-      showToast("記事を保存しました", "success");
+      showToast(t("article.savedSuccess"), "success");
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     } catch {
-      setErrorMessage("記事の保存に失敗しました");
+      setErrorMessage(t("article.saveFailed"));
     } finally {
       setIsSaving(false);
     }
-  }, [preview, url, showToast]);
+  }, [preview, url, showToast, t]);
 
   return (
     <View className="flex-1">
@@ -140,20 +142,20 @@ export default function SaveScreen() {
             <Pressable
               onPress={() => router.back()}
               accessibilityRole="button"
-              accessibilityLabel="戻る"
-              accessibilityHint="前の画面に戻ります"
+              accessibilityLabel={t("article.backA11yLabel")}
+              accessibilityHint={t("article.backA11yHint")}
               className="mr-3 p-1"
             >
               <ArrowLeft size={ICON_SIZE_LG} color={colors.text} />
             </Pressable>
-            <Text className="text-xl font-bold text-text">記事を保存</Text>
+            <Text className="text-xl font-bold text-text">{t("article.saveTitle")}</Text>
           </View>
 
           {/* URL入力 */}
           <View className="mb-4">
             <Input
-              label="URL"
-              placeholder="https://"
+              label={t("article.urlLabel")}
+              placeholder={t("article.urlPlaceholder")}
               value={url}
               onChangeText={(text) => {
                 setUrl(text);
@@ -173,7 +175,7 @@ export default function SaveScreen() {
               disabled={isFetching}
               loading={isFetching}
             >
-              取得
+              {t("article.fetchButton")}
             </Button>
           </View>
 
@@ -181,7 +183,7 @@ export default function SaveScreen() {
           {isFetching && (
             <View testID="fetch-loading" className="items-center py-8">
               <Loader2 size={ICON_SIZE_LG} color={colors.primary} />
-              <Text className="mt-2 text-text-muted text-sm">記事を取得中...</Text>
+              <Text className="mt-2 text-text-muted text-sm">{t("article.fetching")}</Text>
             </View>
           )}
 
@@ -205,7 +207,9 @@ export default function SaveScreen() {
           {/* プレビュー */}
           {preview && !isFetching && (
             <View testID="article-preview">
-              <Text className="text-text-muted text-sm font-medium mb-3">プレビュー</Text>
+              <Text className="text-text-muted text-sm font-medium mb-3">
+                {t("article.preview")}
+              </Text>
               <Card>
                 {/* サムネイル */}
                 {preview.thumbnailUrl && (
@@ -214,7 +218,7 @@ export default function SaveScreen() {
                     className="w-full rounded-lg mb-3"
                     style={{ height: THUMBNAIL_HEIGHT }}
                     resizeMode="cover"
-                    accessibilityLabel="記事のサムネイル"
+                    accessibilityLabel={t("article.thumbnailAlt")}
                   />
                 )}
 
@@ -223,7 +227,7 @@ export default function SaveScreen() {
                   <SourceBadge source={preview.source} />
                   {preview.readingTimeMinutes && (
                     <Text className="text-text-dim text-xs">
-                      {preview.readingTimeMinutes}分で読了
+                      {t("article.readingTime", { minutes: preview.readingTimeMinutes })}
                     </Text>
                   )}
                 </View>
@@ -260,7 +264,7 @@ export default function SaveScreen() {
                   disabled={isSaving}
                   loading={isSaving}
                 >
-                  保存する
+                  {t("article.saveButton")}
                 </Button>
               </View>
             </View>

--- a/apps/mobile/src/components/NotificationItem.tsx
+++ b/apps/mobile/src/components/NotificationItem.tsx
@@ -4,6 +4,7 @@ import { Pressable, Text, View } from "react-native";
 
 import { useColors } from "@/hooks/use-colors";
 import type { NotificationType } from "@/types/notification";
+import { formatRelativeTime } from "@/utils/formatters";
 
 /** NotificationItemに渡す通知データ */
 export type NotificationItemData = {
@@ -65,36 +66,6 @@ function getNotificationIcon(
         <Newspaper testID="notification-icon-article" size={NOTIFICATION_ICON_SIZE} color={color} />
       );
   }
-}
-
-/**
- * 日時文字列を相対表示にフォーマットする
- *
- * @param isoString - ISO 8601形式の日付文字列
- * @returns 相対表示文字列（例: "3分前", "2時間前", "1日前"）
- */
-function formatRelativeTime(isoString: string): string {
-  const now = Date.now();
-  const date = new Date(isoString).getTime();
-  const diffMs = now - date;
-
-  /** 1分（ミリ秒） */
-  const ONE_MINUTE_MS = 60 * 1000;
-  /** 1時間（ミリ秒） */
-  const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
-  /** 1日（ミリ秒） */
-  const ONE_DAY_MS = 24 * ONE_HOUR_MS;
-
-  if (diffMs < ONE_MINUTE_MS) {
-    return "たった今";
-  }
-  if (diffMs < ONE_HOUR_MS) {
-    return `${Math.floor(diffMs / ONE_MINUTE_MS)}分前`;
-  }
-  if (diffMs < ONE_DAY_MS) {
-    return `${Math.floor(diffMs / ONE_HOUR_MS)}時間前`;
-  }
-  return `${Math.floor(diffMs / ONE_DAY_MS)}日前`;
 }
 
 /**

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,5 +1,6 @@
 import Constants from "expo-constants";
 
+import i18n from "./i18n";
 import {
   clearAuthTokens,
   getAuthToken,
@@ -32,32 +33,20 @@ const DEFAULT_API_BASE_URL = "http://localhost:8787";
 /** Abortエラーの識別名 */
 const ABORT_ERROR_NAME = "AbortError";
 
-/** タイムアウト時のエラーメッセージ */
-const TIMEOUT_ERROR_MESSAGE = "リクエストがタイムアウトしました";
-
-/** ネットワーク接続不能時のエラーメッセージ */
-const NETWORK_ERROR_MESSAGE = "ネットワークに接続できません";
-
-/** HTTPエラー時のデフォルトメッセージ */
-const HTTP_ERROR_MESSAGE = "サーバーエラーが発生しました";
-
-/** パースエラー時のデフォルトメッセージ */
-const PARSE_ERROR_MESSAGE = "レスポンスの解析に失敗しました";
-
-/** ステータスコード別デフォルトメッセージ（非業務エラー時のフォールバック） */
-const HTTP_ERROR_MESSAGES_BY_STATUS: Readonly<Record<number, string>> = {
-  400: "リクエストが正しくありません",
-  403: "この操作を実行する権限がありません",
-  404: "リソースが見つかりません",
-  408: "リクエストがタイムアウトしました",
-  409: "競合が発生しました",
-  413: "送信データが大きすぎます",
-  422: "入力内容を確認してください",
-  429: "リクエストが多すぎます。しばらく待ってから再度お試しください",
-  500: "サーバーエラーが発生しました",
-  502: "サーバーに接続できません",
-  503: "サービスが一時的に利用できません",
-  504: "サーバー応答がタイムアウトしました",
+/** ステータスコード別翻訳キー（非業務エラー時のフォールバック） */
+const HTTP_ERROR_KEYS_BY_STATUS: Readonly<Record<number, string>> = {
+  400: "api.errors.status.400",
+  403: "api.errors.status.403",
+  404: "api.errors.status.404",
+  408: "api.errors.status.408",
+  409: "api.errors.status.409",
+  413: "api.errors.status.413",
+  422: "api.errors.status.422",
+  429: "api.errors.status.429",
+  500: "api.errors.status.500",
+  502: "api.errors.status.502",
+  503: "api.errors.status.503",
+  504: "api.errors.status.504",
 };
 
 /** bodyText のプレビュー最大長（診断用に残すが機密抑制のため制限） */
@@ -79,7 +68,7 @@ export class ApiError extends Error {
  */
 export class SessionExpiredError extends ApiError {
   constructor() {
-    super("セッションの有効期限が切れました。再度ログインしてください");
+    super(i18n.t("api.errors.sessionExpired"));
     this.name = "SessionExpiredError";
   }
 }
@@ -228,9 +217,9 @@ export async function fetchWithTimeout(url: string, options: RequestInit): Promi
     return await fetch(url, { ...options, signal: controller.signal });
   } catch (error) {
     if (error instanceof Error && error.name === ABORT_ERROR_NAME) {
-      throw new ApiNetworkError(TIMEOUT_ERROR_MESSAGE, error);
+      throw new ApiNetworkError(i18n.t("api.errors.timeout"), error);
     }
-    throw new ApiNetworkError(NETWORK_ERROR_MESSAGE, error);
+    throw new ApiNetworkError(i18n.t("api.errors.network"), error);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -284,11 +273,11 @@ async function tryParseJson(response: Response): Promise<unknown> {
  */
 async function parseSuccessBody<T>(response: Response): Promise<T> {
   if (!shouldParseAsJson(response)) {
-    throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
+    throw new ApiParseError(response.status, i18n.t("api.errors.parse"));
   }
   const parsed = await tryParseJson(response);
   if (parsed === PARSE_FAILED) {
-    throw new ApiParseError(response.status, PARSE_ERROR_MESSAGE);
+    throw new ApiParseError(response.status, i18n.t("api.errors.parse"));
   }
   return parsed as T;
 }
@@ -325,13 +314,13 @@ function isBusinessErrorPayload(value: unknown): value is BusinessErrorShape {
 }
 
 /**
- * ステータスコードに対応する日本語メッセージを返す
+ * ステータスコードに対応するエラーメッセージを返す
  *
  * @param status - HTTPステータスコード
- * @returns 対応する日本語メッセージ
+ * @returns 対応するエラーメッセージ
  */
 function defaultHttpErrorMessage(status: number): string {
-  return HTTP_ERROR_MESSAGES_BY_STATUS[status] ?? HTTP_ERROR_MESSAGE;
+  return i18n.t(HTTP_ERROR_KEYS_BY_STATUS[status] ?? "api.errors.httpGeneric");
 }
 
 /**

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -370,7 +370,7 @@
   },
   "time": {
     "justNow": "Just now",
-    "minutesAgo": "{{count}} min ago",
+    "minutesAgo": "{{count}} minutes ago",
     "hoursAgo": "{{count}} hours ago",
     "daysAgo": "{{count}} days ago",
     "weeksAgo": "{{count}} weeks ago",

--- a/apps/mobile/src/locales/en.json
+++ b/apps/mobile/src/locales/en.json
@@ -134,6 +134,7 @@
     "noArticles": "No articles",
     "readingTime": "{{minutes}} min read",
     "backA11yLabel": "Back",
+    "backA11yHint": "Go back to the previous screen",
     "summary": "Summary",
     "summarized": "Summarized",
     "summarize": "Summarize",
@@ -177,7 +178,10 @@
     "empty": "No notifications",
     "emptyDescription": "New notifications will appear here",
     "fetchError": "Failed to fetch notifications",
-    "loadingNotifications": "Loading..."
+    "loadingNotifications": "Loading...",
+    "retryHint": "Retry fetching notifications",
+    "unreadBadgeLabel": "{{count}} unread notifications",
+    "unreadBadgeLabelOver": "{{max}}+ unread notifications"
   },
   "profile": {
     "followersLabel": "Followers",
@@ -362,6 +366,38 @@
       "nextPageHint": "Go to page {{next}}",
       "skipHint": "Skip onboarding and go to login",
       "startHint": "Go to account creation"
+    }
+  },
+  "time": {
+    "justNow": "Just now",
+    "minutesAgo": "{{count}} min ago",
+    "hoursAgo": "{{count}} hours ago",
+    "daysAgo": "{{count}} days ago",
+    "weeksAgo": "{{count}} weeks ago",
+    "monthsAgo": "{{count}} months ago",
+    "yearsAgo": "{{count}} years ago"
+  },
+  "api": {
+    "errors": {
+      "timeout": "Request timed out",
+      "network": "No network connection",
+      "httpGeneric": "A server error occurred",
+      "parse": "Failed to parse response",
+      "sessionExpired": "Your session has expired. Please log in again.",
+      "status": {
+        "400": "Invalid request",
+        "403": "You do not have permission to perform this action",
+        "404": "Resource not found",
+        "408": "Request timed out",
+        "409": "A conflict occurred",
+        "413": "The submitted data is too large",
+        "422": "Please check your input",
+        "429": "Too many requests. Please wait a moment and try again.",
+        "500": "A server error occurred",
+        "502": "Unable to connect to the server",
+        "503": "The service is temporarily unavailable",
+        "504": "Server response timed out"
+      }
     }
   },
   "shareIntent": {

--- a/apps/mobile/src/locales/ja.json
+++ b/apps/mobile/src/locales/ja.json
@@ -134,6 +134,7 @@
     "noArticles": "記事がありません",
     "readingTime": "{{minutes}}分で読めます",
     "backA11yLabel": "戻る",
+    "backA11yHint": "前の画面に戻ります",
     "summary": "要約",
     "summarized": "要約済み",
     "summarize": "要約",
@@ -177,7 +178,10 @@
     "empty": "通知はありません",
     "emptyDescription": "新しい通知が届くとここに表示されます",
     "fetchError": "通知の取得に失敗しました",
-    "loadingNotifications": "読み込み中..."
+    "loadingNotifications": "読み込み中...",
+    "retryHint": "通知の取得を再試行します",
+    "unreadBadgeLabel": "未読通知{{count}}件",
+    "unreadBadgeLabelOver": "未読通知{{max}}件以上"
   },
   "profile": {
     "followersLabel": "フォロワー",
@@ -362,6 +366,38 @@
       "nextPageHint": "次のページ（{{next}}ページ目）に進みます",
       "skipHint": "オンボーディングをスキップしてログイン画面に進みます",
       "startHint": "アカウント作成画面に進みます"
+    }
+  },
+  "time": {
+    "justNow": "たった今",
+    "minutesAgo": "{{count}}分前",
+    "hoursAgo": "{{count}}時間前",
+    "daysAgo": "{{count}}日前",
+    "weeksAgo": "{{count}}週間前",
+    "monthsAgo": "{{count}}ヶ月前",
+    "yearsAgo": "{{count}}年前"
+  },
+  "api": {
+    "errors": {
+      "timeout": "リクエストがタイムアウトしました",
+      "network": "ネットワークに接続できません",
+      "httpGeneric": "サーバーエラーが発生しました",
+      "parse": "レスポンスの解析に失敗しました",
+      "sessionExpired": "セッションの有効期限が切れました。再度ログインしてください",
+      "status": {
+        "400": "リクエストが正しくありません",
+        "403": "この操作を実行する権限がありません",
+        "404": "リソースが見つかりません",
+        "408": "リクエストがタイムアウトしました",
+        "409": "競合が発生しました",
+        "413": "送信データが大きすぎます",
+        "422": "入力内容を確認してください",
+        "429": "リクエストが多すぎます。しばらく待ってから再度お試しください",
+        "500": "サーバーエラーが発生しました",
+        "502": "サーバーに接続できません",
+        "503": "サービスが一時的に利用できません",
+        "504": "サーバー応答がタイムアウトしました"
+      }
     }
   },
   "shareIntent": {

--- a/apps/mobile/src/locales/ko.json
+++ b/apps/mobile/src/locales/ko.json
@@ -161,6 +161,7 @@
     "urlInvalid": "유효한 URL을 입력해 주세요",
     "noMatch": "「{{query}}」에 일치하는 기사가 없습니다",
     "backA11yLabel": "뒤로",
+    "backA11yHint": "이전 화면으로 돌아갑니다",
     "generating": "생성 중..."
   },
   "search": {
@@ -177,7 +178,10 @@
     "empty": "알림이 없습니다",
     "emptyDescription": "새 알림이 오면 여기에 표시됩니다",
     "fetchError": "알림을 불러오는데 실패했습니다",
-    "loadingNotifications": "불러오는 중..."
+    "loadingNotifications": "불러오는 중...",
+    "retryHint": "알림 불러오기를 다시 시도합니다",
+    "unreadBadgeLabel": "읽지 않은 알림 {{count}}개",
+    "unreadBadgeLabelOver": "읽지 않은 알림 {{max}}개 이상"
   },
   "profile": {
     "followersLabel": "팔로워",
@@ -362,6 +366,38 @@
       "nextPageHint": "다음 페이지（{{next}}페이지）로 이동합니다",
       "skipHint": "온보딩을 건너뛰고 로그인 화면으로 이동합니다",
       "startHint": "계정 만들기 화면으로 이동합니다"
+    }
+  },
+  "time": {
+    "justNow": "방금 전",
+    "minutesAgo": "{{count}}분 전",
+    "hoursAgo": "{{count}}시간 전",
+    "daysAgo": "{{count}}일 전",
+    "weeksAgo": "{{count}}주 전",
+    "monthsAgo": "{{count}}개월 전",
+    "yearsAgo": "{{count}}년 전"
+  },
+  "api": {
+    "errors": {
+      "timeout": "요청이 시간 초과되었습니다",
+      "network": "네트워크에 연결할 수 없습니다",
+      "httpGeneric": "서버 오류가 발생했습니다",
+      "parse": "응답 파싱에 실패했습니다",
+      "sessionExpired": "세션이 만료되었습니다. 다시 로그인해 주세요.",
+      "status": {
+        "400": "요청이 올바르지 않습니다",
+        "403": "이 작업을 수행할 권한이 없습니다",
+        "404": "리소스를 찾을 수 없습니다",
+        "408": "요청이 시간 초과되었습니다",
+        "409": "충돌이 발생했습니다",
+        "413": "전송 데이터가 너무 큽니다",
+        "422": "입력 내용을 확인해 주세요",
+        "429": "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
+        "500": "서버 오류가 발생했습니다",
+        "502": "서버에 연결할 수 없습니다",
+        "503": "서비스를 일시적으로 사용할 수 없습니다",
+        "504": "서버 응답이 시간 초과되었습니다"
+      }
     }
   },
   "shareIntent": {

--- a/apps/mobile/src/locales/zh-CN.json
+++ b/apps/mobile/src/locales/zh-CN.json
@@ -161,6 +161,7 @@
     "urlInvalid": "请输入有效的URL",
     "noMatch": "没有匹配「{{query}}」的文章",
     "backA11yLabel": "返回",
+    "backA11yHint": "返回上一个页面",
     "generating": "生成中..."
   },
   "search": {
@@ -177,7 +178,10 @@
     "empty": "没有通知",
     "emptyDescription": "新通知到来时将显示在这里",
     "fetchError": "获取通知失败",
-    "loadingNotifications": "加载中..."
+    "loadingNotifications": "加载中...",
+    "retryHint": "重新获取通知",
+    "unreadBadgeLabel": "{{count}}条未读通知",
+    "unreadBadgeLabelOver": "{{max}}条以上未读通知"
   },
   "profile": {
     "followersLabel": "粉丝",
@@ -362,6 +366,38 @@
       "nextPageHint": "前往第{{next}}页",
       "skipHint": "跳过引导并前往登录界面",
       "startHint": "前往创建账户界面"
+    }
+  },
+  "time": {
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}}分钟前",
+    "hoursAgo": "{{count}}小时前",
+    "daysAgo": "{{count}}天前",
+    "weeksAgo": "{{count}}周前",
+    "monthsAgo": "{{count}}个月前",
+    "yearsAgo": "{{count}}年前"
+  },
+  "api": {
+    "errors": {
+      "timeout": "请求超时",
+      "network": "无法连接到网络",
+      "httpGeneric": "发生服务器错误",
+      "parse": "解析响应失败",
+      "sessionExpired": "会话已过期，请重新登录。",
+      "status": {
+        "400": "请求无效",
+        "403": "您没有权限执行此操作",
+        "404": "资源未找到",
+        "408": "请求超时",
+        "409": "发生冲突",
+        "413": "提交数据过大",
+        "422": "请检查您的输入",
+        "429": "请求过多，请稍后再试。",
+        "500": "发生服务器错误",
+        "502": "无法连接到服务器",
+        "503": "服务暂时不可用",
+        "504": "服务器响应超时"
+      }
     }
   },
   "shareIntent": {

--- a/apps/mobile/src/locales/zh-TW.json
+++ b/apps/mobile/src/locales/zh-TW.json
@@ -161,6 +161,7 @@
     "urlInvalid": "請輸入有效的URL",
     "noMatch": "沒有符合「{{query}}」的文章",
     "backA11yLabel": "返回",
+    "backA11yHint": "返回上一個頁面",
     "generating": "生成中..."
   },
   "search": {
@@ -177,7 +178,10 @@
     "empty": "沒有通知",
     "emptyDescription": "有新通知時將顯示在這裡",
     "fetchError": "取得通知失敗",
-    "loadingNotifications": "載入中..."
+    "loadingNotifications": "載入中...",
+    "retryHint": "重新取得通知",
+    "unreadBadgeLabel": "{{count}}則未讀通知",
+    "unreadBadgeLabelOver": "{{max}}則以上未讀通知"
   },
   "profile": {
     "followersLabel": "追蹤者",
@@ -362,6 +366,38 @@
       "nextPageHint": "前往第{{next}}頁",
       "skipHint": "跳過引導並前往登入畫面",
       "startHint": "前往建立帳號畫面"
+    }
+  },
+  "time": {
+    "justNow": "剛剛",
+    "minutesAgo": "{{count}}分鐘前",
+    "hoursAgo": "{{count}}小時前",
+    "daysAgo": "{{count}}天前",
+    "weeksAgo": "{{count}}週前",
+    "monthsAgo": "{{count}}個月前",
+    "yearsAgo": "{{count}}年前"
+  },
+  "api": {
+    "errors": {
+      "timeout": "請求逾時",
+      "network": "無法連線至網路",
+      "httpGeneric": "發生伺服器錯誤",
+      "parse": "解析回應失敗",
+      "sessionExpired": "工作階段已過期，請重新登入。",
+      "status": {
+        "400": "請求無效",
+        "403": "您沒有權限執行此操作",
+        "404": "找不到資源",
+        "408": "請求逾時",
+        "409": "發生衝突",
+        "413": "提交資料過大",
+        "422": "請確認您的輸入",
+        "429": "請求過多，請稍後再試。",
+        "500": "發生伺服器錯誤",
+        "502": "無法連線至伺服器",
+        "503": "服務暫時無法使用",
+        "504": "伺服器回應逾時"
+      }
     }
   },
   "shareIntent": {

--- a/apps/mobile/src/utils/formatters.ts
+++ b/apps/mobile/src/utils/formatters.ts
@@ -1,3 +1,5 @@
+import i18n from "../lib/i18n";
+
 /** 1秒のミリ秒数 */
 const SECOND_MS = 1000;
 
@@ -58,36 +60,36 @@ export function formatRelativeTime(date: Date | string, now: Date = new Date()):
   const diffMs = now.getTime() - targetDate.getTime();
 
   if (diffMs < MINUTE_MS) {
-    return "たった今";
+    return i18n.t("time.justNow");
   }
 
   if (diffMs < HOUR_MS) {
     const minutes = Math.floor(diffMs / MINUTE_MS);
-    return `${minutes}分前`;
+    return i18n.t("time.minutesAgo", { count: minutes });
   }
 
   if (diffMs < DAY_MS) {
     const hours = Math.floor(diffMs / HOUR_MS);
-    return `${hours}時間前`;
+    return i18n.t("time.hoursAgo", { count: hours });
   }
 
   if (diffMs < WEEK_MS) {
     const days = Math.floor(diffMs / DAY_MS);
-    return `${days}日前`;
+    return i18n.t("time.daysAgo", { count: days });
   }
 
   if (diffMs < MONTH_MS) {
     const weeks = Math.floor(diffMs / WEEK_MS);
-    return `${weeks}週間前`;
+    return i18n.t("time.weeksAgo", { count: weeks });
   }
 
   if (diffMs < YEAR_MS) {
     const months = Math.floor(diffMs / MONTH_MS);
-    return `${months}ヶ月前`;
+    return i18n.t("time.monthsAgo", { count: months });
   }
 
   const years = Math.floor(diffMs / YEAR_MS);
-  return `${years}年前`;
+  return i18n.t("time.yearsAgo", { count: years });
 }
 
 /**

--- a/tests/mobile/components/NotificationItem.test.tsx
+++ b/tests/mobile/components/NotificationItem.test.tsx
@@ -1,4 +1,5 @@
 import { NotificationItem } from "@mobile/components/NotificationItem";
+import i18n from "@mobile/lib/i18n";
 import { fireEvent, render } from "@testing-library/react-native";
 
 /** テスト用の通知データ（未読） */
@@ -152,6 +153,48 @@ describe("NotificationItem", () => {
 
       // Assert
       expect(onPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("英語ロケールでの相対時間表示", () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage("en");
+    });
+
+    afterEach(async () => {
+      await i18n.changeLanguage("ja");
+    });
+
+    it("英語ロケールで3時間前がhours agoと表示されること", async () => {
+      // Arrange
+      const threeHoursAgoNotification = {
+        ...UNREAD_NOTIFICATION,
+        createdAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+      };
+
+      // Act
+      const { getByTestId } = await render(
+        <NotificationItem notification={threeHoursAgoNotification} onPress={() => {}} />,
+      );
+
+      // Assert
+      expect(getByTestId("notification-time").props.children).toBe("3 hours ago");
+    });
+
+    it("英語ロケールで数秒前がJust nowと表示されること", async () => {
+      // Arrange
+      const justNowNotification = {
+        ...UNREAD_NOTIFICATION,
+        createdAt: new Date(Date.now() - 5 * 1000).toISOString(),
+      };
+
+      // Act
+      const { getByTestId } = await render(
+        <NotificationItem notification={justNowNotification} onPress={() => {}} />,
+      );
+
+      // Assert
+      expect(getByTestId("notification-time").props.children).toBe("Just now");
     });
   });
 });

--- a/tests/mobile/lib/api.test.ts
+++ b/tests/mobile/lib/api.test.ts
@@ -25,6 +25,7 @@ import {
   apiFetch,
   SessionExpiredError,
 } from "@mobile/lib/api";
+import i18n from "@mobile/lib/i18n";
 import {
   clearAuthTokens,
   getAuthToken,
@@ -79,8 +80,9 @@ function createFetchResponse(body: unknown, options: CreateFetchResponseOptions 
 }
 
 describe("apiFetch", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    await i18n.changeLanguage("ja");
     mockGetAuthToken.mockResolvedValue("valid-access-token");
     mockGetRefreshToken.mockResolvedValue("valid-refresh-token");
     mockSetAuthToken.mockResolvedValue(undefined);
@@ -605,6 +607,52 @@ describe("apiFetch", () => {
 
       // Act & Assert
       await expect(apiFetch("/articles")).rejects.toBeInstanceOf(ApiHttpError);
+    });
+  });
+
+  describe("英語ロケールでのエラーメッセージ", () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage("en");
+    });
+
+    afterEach(async () => {
+      await i18n.changeLanguage("ja");
+    });
+
+    it("タイムアウト時はApiNetworkErrorのmessageが英語になること", async () => {
+      // Arrange
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      mockFetch.mockRejectedValue(abortError);
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiNetworkError);
+      expect((caughtError as ApiNetworkError).message).toBe("Request timed out");
+    });
+
+    it("ネットワークエラー時はApiNetworkErrorのmessageが英語になること", async () => {
+      // Arrange
+      mockFetch.mockRejectedValue(new TypeError("Network request failed"));
+
+      // Act
+      let caughtError: unknown;
+      try {
+        await apiFetch("/articles");
+      } catch (e) {
+        caughtError = e;
+      }
+
+      // Assert
+      expect(caughtError).toBeInstanceOf(ApiNetworkError);
+      expect((caughtError as ApiNetworkError).message).toBe("No network connection");
     });
   });
 

--- a/tests/mobile/lib/formatters.test.ts
+++ b/tests/mobile/lib/formatters.test.ts
@@ -315,7 +315,7 @@ describe("formatRelativeTime", () => {
       expect(result).toBe("Just now");
     });
 
-    it("3分前は3 min agoと表示されること", () => {
+    it("3分前は3 minutes agoと表示されること", () => {
       // Arrange
       const now = new Date();
       const threeMinutesAgo = new Date(now.getTime() - 3 * 60 * 1000);
@@ -324,7 +324,7 @@ describe("formatRelativeTime", () => {
       const result = formatRelativeTime(threeMinutesAgo, now);
 
       // Assert
-      expect(result).toBe("3 min ago");
+      expect(result).toBe("3 minutes ago");
     });
 
     it("2時間前は2 hours agoと表示されること", () => {

--- a/tests/mobile/lib/formatters.test.ts
+++ b/tests/mobile/lib/formatters.test.ts
@@ -339,7 +339,7 @@ describe("formatRelativeTime", () => {
       expect(result).toBe("2 hours ago");
     });
 
-    it("1日前は1 days agoと表示されること", () => {
+    it("1日前は1 days agoと表示されること（plural未対応, #977で対応）", () => {
       // Arrange
       const now = new Date();
       const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
@@ -351,7 +351,7 @@ describe("formatRelativeTime", () => {
       expect(result).toBe("1 days ago");
     });
 
-    it("1週間前は1 weeks agoと表示されること", () => {
+    it("1週間前は1 weeks agoと表示されること（plural未対応, #977で対応）", () => {
       // Arrange
       const now = new Date();
       const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -363,7 +363,7 @@ describe("formatRelativeTime", () => {
       expect(result).toBe("1 weeks ago");
     });
 
-    it("1ヶ月前は1 months agoと表示されること", () => {
+    it("1ヶ月前は1 months agoと表示されること（plural未対応, #977で対応）", () => {
       // Arrange
       const now = new Date();
       const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -375,7 +375,7 @@ describe("formatRelativeTime", () => {
       expect(result).toBe("1 months ago");
     });
 
-    it("1年前は1 years agoと表示されること", () => {
+    it("1年前は1 years agoと表示されること（plural未対応, #977で対応）", () => {
       // Arrange
       const now = new Date();
       const oneYearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);

--- a/tests/mobile/lib/formatters.test.ts
+++ b/tests/mobile/lib/formatters.test.ts
@@ -1,3 +1,4 @@
+import i18n from "@mobile/lib/i18n";
 import {
   formatCompactNumber,
   formatRelativeTime,
@@ -56,6 +57,10 @@ describe("getInitials", () => {
 });
 
 describe("formatRelativeTime", () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage("ja");
+  });
+
   describe("秒単位", () => {
     it("数秒前と表示されること", () => {
       // Arrange
@@ -286,6 +291,100 @@ describe("formatRelativeTime", () => {
 
       // Assert
       expect(result).toBe("5分前");
+    });
+  });
+
+  describe("英語ロケール", () => {
+    beforeEach(async () => {
+      await i18n.changeLanguage("en");
+    });
+
+    afterEach(async () => {
+      await i18n.changeLanguage("ja");
+    });
+
+    it("数秒前はJust nowと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const fiveSecondsAgo = new Date(now.getTime() - 5 * 1000);
+
+      // Act
+      const result = formatRelativeTime(fiveSecondsAgo, now);
+
+      // Assert
+      expect(result).toBe("Just now");
+    });
+
+    it("3分前は3 min agoと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const threeMinutesAgo = new Date(now.getTime() - 3 * 60 * 1000);
+
+      // Act
+      const result = formatRelativeTime(threeMinutesAgo, now);
+
+      // Assert
+      expect(result).toBe("3 min ago");
+    });
+
+    it("2時間前は2 hours agoと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+
+      // Act
+      const result = formatRelativeTime(twoHoursAgo, now);
+
+      // Assert
+      expect(result).toBe("2 hours ago");
+    });
+
+    it("1日前は1 days agoと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+      // Act
+      const result = formatRelativeTime(oneDayAgo, now);
+
+      // Assert
+      expect(result).toBe("1 days ago");
+    });
+
+    it("1週間前は1 weeks agoと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+      // Act
+      const result = formatRelativeTime(oneWeekAgo, now);
+
+      // Assert
+      expect(result).toBe("1 weeks ago");
+    });
+
+    it("1ヶ月前は1 months agoと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const oneMonthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+      // Act
+      const result = formatRelativeTime(oneMonthAgo, now);
+
+      // Assert
+      expect(result).toBe("1 months ago");
+    });
+
+    it("1年前は1 years agoと表示されること", () => {
+      // Arrange
+      const now = new Date();
+      const oneYearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000);
+
+      // Act
+      const result = formatRelativeTime(oneYearAgo, now);
+
+      // Assert
+      expect(result).toBe("1 years ago");
     });
   });
 });

--- a/tests/mobile/screens/notifications.test.tsx
+++ b/tests/mobile/screens/notifications.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * 通知画面 英語ロケールテスト
+ *
+ * en ロケール設定時に主要 UI 文言が英語で表示されることを確認する。
+ */
+import NotificationsScreen from "@mobile-app/(tabs)/notifications";
+import { render, waitFor } from "@testing-library/react-native";
+
+import { setMockLocale } from "../helpers/i18n-test-utils";
+
+jest.mock("@mobile/hooks/use-notifications", () => ({
+  useNotifications: jest.fn(),
+  useMarkAsRead: jest.fn(),
+  useMarkAllAsRead: jest.fn(),
+  useUnreadNotificationCount: jest.fn(),
+}));
+
+const { useNotifications, useMarkAsRead, useMarkAllAsRead } = jest.requireMock(
+  "@mobile/hooks/use-notifications",
+);
+
+/** useNotifications のデフォルトモック値（読み込み中） */
+const DEFAULT_NOTIFICATIONS_LOADING = {
+  data: undefined,
+  fetchNextPage: jest.fn(),
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  isLoading: true,
+  isError: false,
+  refetch: jest.fn(),
+  isRefetching: false,
+};
+
+/** useNotifications のデフォルトモック値（空） */
+const DEFAULT_NOTIFICATIONS_EMPTY = {
+  ...DEFAULT_NOTIFICATIONS_LOADING,
+  isLoading: false,
+  data: { pages: [] },
+};
+
+/** useNotifications のデフォルトモック値（エラー） */
+const DEFAULT_NOTIFICATIONS_ERROR = {
+  ...DEFAULT_NOTIFICATIONS_LOADING,
+  isLoading: false,
+  isError: true,
+  data: undefined,
+};
+
+describe("NotificationsScreen", () => {
+  beforeEach(() => {
+    setMockLocale("ja");
+    jest.clearAllMocks();
+    useMarkAsRead.mockReturnValue({ mutate: jest.fn() });
+    useMarkAllAsRead.mockReturnValue({ mutate: jest.fn() });
+  });
+
+  describe("日本語ロケール（デフォルト）", () => {
+    it("ローディング中に読み込み中が表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_LOADING);
+
+      // Act
+      const { getByTestId } = await render(<NotificationsScreen />);
+
+      // Assert
+      expect(getByTestId("loading-indicator")).toBeDefined();
+    });
+
+    it("空の状態で日本語メッセージが表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_EMPTY);
+
+      // Act
+      const { getByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("通知はありません")).toBeDefined();
+      });
+    });
+
+    it("エラー時に日本語エラーメッセージが表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_ERROR);
+
+      // Act
+      const { getByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("通知の取得に失敗しました")).toBeDefined();
+      });
+    });
+
+    it("エラー時に日本語再試行ボタンが表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_ERROR);
+
+      // Act
+      const { getByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("再試行")).toBeDefined();
+      });
+    });
+  });
+
+  describe("英語ロケール", () => {
+    beforeEach(() => {
+      setMockLocale("en");
+    });
+
+    afterEach(() => {
+      setMockLocale("ja");
+    });
+
+    it("空の状態で英語メッセージが表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_EMPTY);
+
+      // Act
+      const { getByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("No notifications")).toBeDefined();
+      });
+    });
+
+    it("エラー時に英語エラーメッセージが表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_ERROR);
+
+      // Act
+      const { getByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("Failed to fetch notifications")).toBeDefined();
+      });
+    });
+
+    it("エラー時に英語再試行ボタンが表示されること", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_ERROR);
+
+      // Act
+      const { getByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("Retry")).toBeDefined();
+      });
+    });
+
+    it("日本語「通知はありません」が表示されないこと", async () => {
+      // Arrange
+      useNotifications.mockReturnValue(DEFAULT_NOTIFICATIONS_EMPTY);
+
+      // Act
+      const { queryByText } = await render(<NotificationsScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(queryByText("通知はありません")).toBeNull();
+      });
+    });
+  });
+});

--- a/tests/mobile/screens/save.test.tsx
+++ b/tests/mobile/screens/save.test.tsx
@@ -1,6 +1,8 @@
 import SaveScreen from "@mobile-app/article/save";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
+import { setMockLocale } from "../helpers/i18n-test-utils";
+
 /** apiFetchのモック */
 const mockApiFetch = jest.fn();
 
@@ -74,6 +76,7 @@ const MOCK_SAVE_RESPONSE = {
 
 describe("SaveScreen", () => {
   beforeEach(() => {
+    setMockLocale("ja");
     jest.clearAllMocks();
     mockShowToast.mockClear();
   });
@@ -364,6 +367,79 @@ describe("SaveScreen", () => {
       // Assert
       await waitFor(() => {
         expect(getByText("この記事はすでに保存されています")).toBeDefined();
+      });
+    });
+  });
+
+  describe("英語ロケール", () => {
+    beforeEach(() => {
+      setMockLocale("en");
+    });
+
+    afterEach(() => {
+      setMockLocale("ja");
+    });
+
+    it("取得ボタンが英語で表示されること", async () => {
+      // Arrange & Act
+      const { getByText } = await render(<SaveScreen />);
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("Fetch")).toBeDefined();
+      });
+    });
+
+    it("URLバリデーションエラーが英語で表示されること", async () => {
+      // Arrange
+      const { getByTestId, getByText } = await render(<SaveScreen />);
+
+      // Act
+      await fireEvent.press(getByTestId("fetch-button"));
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("Please enter a URL")).toBeDefined();
+      });
+    });
+
+    it("不正なURLのバリデーションエラーが英語で表示されること", async () => {
+      // Arrange
+      const { getByPlaceholderText, getByTestId, getByText } = await render(<SaveScreen />);
+
+      // Act
+      await fireEvent.changeText(getByPlaceholderText("https://"), "not-a-url");
+      await fireEvent.press(getByTestId("fetch-button"));
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText("Please enter a valid URL")).toBeDefined();
+      });
+    });
+
+    it("保存成功時のトーストメッセージが英語になること", async () => {
+      // Arrange
+      mockApiFetch
+        .mockResolvedValueOnce(MOCK_PREVIEW_RESPONSE)
+        .mockResolvedValueOnce(MOCK_SAVE_RESPONSE);
+      const { getByPlaceholderText, getByTestId, getByText } = await render(<SaveScreen />);
+
+      await fireEvent.changeText(
+        getByPlaceholderText("https://"),
+        "https://zenn.dev/test/articles/test-article",
+      );
+      await fireEvent.press(getByTestId("fetch-button"));
+
+      await waitFor(() => {
+        expect(getByText("Save")).toBeDefined();
+      });
+
+      // Act
+      await fireEvent.press(getByTestId("save-button"));
+
+      // Assert
+      await waitFor(() => {
+        expect(mockShowToast).toHaveBeenCalledWith("Article saved", "success");
       });
     });
   });


### PR DESCRIPTION
## 概要

Issue #958 の解消として、mobile アプリに残存していたハードコード文言と相対時間表記の locale 非対応を i18n 化した。

## 変更内容

- `notifications.tsx`: error/empty/loading/markAllRead/retryHint を `t()` 化
- `save.tsx`: UI 全文言を `t()` 化、`validateUrl` は翻訳キーを返す形に変更
- `_layout.tsx`: unreadBadgeLabel / unreadBadgeLabelOver を `t()` 化（count / max 補間）
- `api.ts`: タイムアウト・ネットワーク・HTTP・パース・SessionExpired 各メッセージを関数実行時の `i18n.t()` で解決
- `formatters.ts`: `formatRelativeTime` を i18next 化（time.justNow / minutesAgo / hoursAgo / daysAgo / weeksAgo / monthsAgo / yearsAgo）
- `NotificationItem.tsx`: 独自 `formatRelativeTime` を削除し `@/utils/formatters` に集約
- 翻訳キー追加（ja/en/ko/zh-CN/zh-TW 5 言語）: `time.*`, `api.errors.*`, `notifications.retryHint`, `notifications.unreadBadgeLabel`, `notifications.unreadBadgeLabelOver`, `article.backA11yHint`

## テスト

- [x] `pnpm biome check apps/mobile tests/mobile` パス（199 files）
- [x] `pnpm --filter @tech-clip/mobile typecheck` パス
- [x] `pnpm test` (mobile) 77 suites / 950 tests パス
- 追加テスト: NotificationsScreen ja/en、SaveScreen en、NotificationItem en、formatters en、api.ts en

## スコープ外

- plural 対応（`time.minutesAgo_one` 等）は後続 Issue とし、`{{count}}` 単純補間
- profile/edit.tsx の `detail.message` サーバー応答ローカライズ（サーバー対応が必要）

Closes #958

🤖 Generated with Claude Code

追跡 Issue: #977