### PR TITLE
fix(mobile/api): JSDoc 修正・境界ケーステスト追加 #966

### DIFF
--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -91,23 +91,13 @@ export class SessionExpiredError extends ApiError {
 export class ApiHttpError extends ApiError {
   /** HTTPステータスコード */
   public readonly status: number;
-  /** 将来の拡張用フィールド。現行実装では常に undefined */
-  public readonly code?: string;
-  /** 将来の拡張用フィールド。現行実装では常に undefined */
-  public readonly details?: unknown;
   /** レスポンス本文の先頭（診断用、最大 BODY_TEXT_PREVIEW_MAX_LENGTH 文字） */
   public readonly bodyText?: string;
 
-  constructor(
-    status: number,
-    message: string,
-    options?: { code?: string; details?: unknown; bodyText?: string; cause?: unknown },
-  ) {
+  constructor(status: number, message: string, options?: { bodyText?: string; cause?: unknown }) {
     super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
     this.name = "ApiHttpError";
     this.status = status;
-    this.code = options?.code;
-    this.details = options?.details;
     this.bodyText = options?.bodyText;
   }
 }


### PR DESCRIPTION
## 概要

PR #963 の `claude-review` で指摘された `apps/mobile/src/lib/api.ts` の `ApiHttpError` クラスにおける JSDoc 乖離問題を解消する。

## 変更内容

- `ApiHttpError` から未使用の `code` / `details` フィールドを削除する
- コンストラクタのオプション型 `options?: { code?: string; details?: unknown; bodyText?: string; cause?: unknown }` を `options?: { bodyText?: string; cause?: unknown }` に単純化する

`handleErrorResponse` は業務エラーペイロードを `ApiHttpError` に包まず直接 `return` するため、`code` / `details` は常に `undefined` のままで実装上参照点もなく、JSDoc と実装が乖離していた。未使用コード禁止ルール（`.claude/rules/coding-standards.md`）に従い、JSDoc 更新ではなくフィールド削除を選択した。

## 改善提案への対応

Issue #966 に含まれていた以下の改善提案は既に `bec3c726` コミット（PR #963 ブランチ）で対応済みのため、本 PR の範囲外。

- 改善提案 1: `readBodyOnce` が `null` を返すパスのテスト → `tests/mobile/lib/api.test.ts` L335-349 で実装済み
- 改善提案 2: Content-Type 非 JSON だが本文が `{` で始まるケースのテスト → 同 L351-373 で実装済み

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（api.test.ts 39 件、mobile 全 927 件 PASS）

## 影響範囲

- `ApiHttpError` の呼び出し箇所（`api.ts` L392, L402 と `api.test.ts` L490）は全て `code` / `details` を渡しておらず、破壊的変更なし
- 外部から `err.code` / `err.details` を参照する箇所なし

Closes #966

🤖 Generated with Claude Code