### PR TITLE
feat(reviewer): PR マージ完了検知・Issue 自動クローズを追加 #975

### DIFF
--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -182,17 +182,62 @@ else
 fi
 ```
 
-- **`AI Review: PASS` ラベルが存在する（APPROVED）**:
-  1. `SendMessage(to: "issue-{issue_number}-infra-engineer", "APPROVED")` → infra-engineer 終了
-  2. worktree を削除する: `git -C <main-worktree-path> worktree remove {worktree} --force`
-  3. `SendMessage(to: orchestrator, "APPROVED: issue-{issue_number}")` → orchestrator がカウント管理
-  4. 終了する
+- **`AI Review: PASS` ラベルが存在する**: **フェーズ 7 へ進む**
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
   gh pr view {pr_number} --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
   ```
   `SendMessage(to: "issue-{issue_number}-infra-engineer", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）
+
+### フェーズ 7: PR マージ完了待機
+
+AI Review: PASS が確認できたあと、実際のマージまで 30 秒間隔で最大 60 分ポーリングする。
+
+```bash
+MAX_ATTEMPTS=120  # 30 秒 × 120 = 60 分
+PR_STATE=""
+for i in $(seq 1 $MAX_ATTEMPTS); do
+  PR_STATE=$(gh pr view {pr_number} --json state --jq '.state')
+  case "$PR_STATE" in
+    MERGED)
+      break
+      ;;
+    CLOSED)
+      SendMessage(to: "issue-{issue_number}-infra-engineer", "CLOSED_WITHOUT_MERGE: PR がマージされずにクローズされました")
+      exit 0
+      ;;
+    OPEN)
+      sleep 30
+      ;;
+  esac
+done
+
+if [ "$PR_STATE" != "MERGED" ]; then
+  PR_URL=$(gh pr view {pr_number} --json url --jq '.url')
+  SendMessage(to: "orchestrator", "MERGE_PENDING: issue-{issue_number} は AI Review PASS 済みですが 60 分以内にマージされませんでした。手動でマージ・クローズしてください。PR: $PR_URL")
+  exit 0
+fi
+```
+
+`MERGED` を確認したら以下を実行する:
+
+```bash
+# Issue をクローズ
+gh issue close {issue_number} --comment "PR がマージされたため自動クローズしました（reviewer agent）"
+
+# worktree 削除
+git -C <main-worktree-path> worktree remove {worktree} --force
+```
+
+続けて SendMessage を送信する:
+
+```text
+SendMessage(to: "issue-{issue_number}-infra-engineer", "APPROVED")
+SendMessage(to: "orchestrator", "APPROVED: issue-{issue_number}")
+```
+
+最後に infra-reviewer 自身が終了する。
 
 ## レビュー方針（厳守）
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -176,17 +176,62 @@ else
 fi
 ```
 
-- **`AI Review: PASS` ラベルが存在する（APPROVED）**:
-  1. `SendMessage(to: "issue-{issue_number}-coder", "APPROVED")` → coder 終了
-  2. worktree を削除する: `git -C <main-worktree-path> worktree remove {worktree} --force`
-  3. `SendMessage(to: orchestrator, "APPROVED: issue-{issue_number}")` → orchestrator がカウント管理
-  4. 終了する
+- **`AI Review: PASS` ラベルが存在する**: **フェーズ 7 へ進む**
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
   gh pr view {pr_number} --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
   ```
   `SendMessage(to: "issue-{issue_number}-coder", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）
+
+### フェーズ 7: PR マージ完了待機
+
+AI Review: PASS が確認できたあと、実際のマージまで 30 秒間隔で最大 60 分ポーリングする。
+
+```bash
+MAX_ATTEMPTS=120  # 30 秒 × 120 = 60 分
+PR_STATE=""
+for i in $(seq 1 $MAX_ATTEMPTS); do
+  PR_STATE=$(gh pr view {pr_number} --json state --jq '.state')
+  case "$PR_STATE" in
+    MERGED)
+      break
+      ;;
+    CLOSED)
+      SendMessage(to: "issue-{issue_number}-coder", "CLOSED_WITHOUT_MERGE: PR がマージされずにクローズされました")
+      exit 0
+      ;;
+    OPEN)
+      sleep 30
+      ;;
+  esac
+done
+
+if [ "$PR_STATE" != "MERGED" ]; then
+  PR_URL=$(gh pr view {pr_number} --json url --jq '.url')
+  SendMessage(to: "orchestrator", "MERGE_PENDING: issue-{issue_number} は AI Review PASS 済みですが 60 分以内にマージされませんでした。手動でマージ・クローズしてください。PR: $PR_URL")
+  exit 0
+fi
+```
+
+`MERGED` を確認したら以下を実行する:
+
+```bash
+# Issue をクローズ
+gh issue close {issue_number} --comment "PR がマージされたため自動クローズしました（reviewer agent）"
+
+# worktree 削除
+git -C <main-worktree-path> worktree remove {worktree} --force
+```
+
+続けて SendMessage を送信する:
+
+```text
+SendMessage(to: "issue-{issue_number}-coder", "APPROVED")
+SendMessage(to: "orchestrator", "APPROVED: issue-{issue_number}")
+```
+
+最後に reviewer 自身が終了する。
 
 ## レビュー方針（厳守）
 

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -179,26 +179,7 @@ else
 fi
 ```
 
-- **`AI Review: PASS` ラベルが存在する（APPROVED）**:
-  1. ui-designer に APPROVED を送信する
-     ```text
-     SendMessage(
-       to: "issue-{issue_number}-ui-designer",
-       message: "APPROVED"
-     )
-     ```
-  2. worktree を削除する
-     ```bash
-     git -C <main-worktree-path> worktree remove {worktree} --force
-     ```
-  3. orchestrator に完了を通知する
-     ```text
-     SendMessage(
-       to: "orchestrator",
-       message: "APPROVED: issue-{issue_number}"
-     )
-     ```
-  4. 終了する。
+- **`AI Review: PASS` ラベルが存在する**: **フェーズ 7 へ進む**
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**:
   1. レビューコメントを取得する
      ```bash
@@ -213,6 +194,55 @@ fi
      ```
   3. フェーズ 0 に戻り次の impl-ready を待機する。
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリングする（適度な間隔を空けて繰り返す）
+
+### フェーズ 7: PR マージ完了待機
+
+AI Review: PASS が確認できたあと、実際のマージまで 30 秒間隔で最大 60 分ポーリングする。
+
+```bash
+MAX_ATTEMPTS=120  # 30 秒 × 120 = 60 分
+PR_STATE=""
+for i in $(seq 1 $MAX_ATTEMPTS); do
+  PR_STATE=$(gh pr view <PR番号> --json state --jq '.state')
+  case "$PR_STATE" in
+    MERGED)
+      break
+      ;;
+    CLOSED)
+      SendMessage(to: "issue-{issue_number}-ui-designer", "CLOSED_WITHOUT_MERGE: PR がマージされずにクローズされました")
+      exit 0
+      ;;
+    OPEN)
+      sleep 30
+      ;;
+  esac
+done
+
+if [ "$PR_STATE" != "MERGED" ]; then
+  PR_URL=$(gh pr view <PR番号> --json url --jq '.url')
+  SendMessage(to: "orchestrator", "MERGE_PENDING: issue-{issue_number} は AI Review PASS 済みですが 60 分以内にマージされませんでした。手動でマージ・クローズしてください。PR: $PR_URL")
+  exit 0
+fi
+```
+
+`MERGED` を確認したら以下を実行する:
+
+```bash
+# Issue をクローズ
+gh issue close {issue_number} --comment "PR がマージされたため自動クローズしました（reviewer agent）"
+
+# worktree 削除
+git -C <main-worktree-path> worktree remove {worktree} --force
+```
+
+続けて SendMessage を送信する:
+
+```text
+SendMessage(to: "issue-{issue_number}-ui-designer", "APPROVED")
+SendMessage(to: "orchestrator", "APPROVED: issue-{issue_number}")
+```
+
+最後に ui-reviewer 自身が終了する。
 
 ## レビュー方針（厳守）
 


### PR DESCRIPTION
## 概要

reviewer / infra-reviewer / ui-reviewer の 3 エージェントに **フェーズ 7: PR マージ完了待機** を追加し、AI Review PASS 後に実際のマージを確認してから Issue クローズ・worktree 削除・APPROVED 通知を行うよう変更した。

## 変更内容

- `AI Review: PASS` 検知後は即終了せず、30 秒間隔で最大 60 分 `gh pr view --json state` をポーリング
- `MERGED` 確認後: `gh issue close` → worktree 削除 → 実装エージェントと orchestrator に `APPROVED` 通知 → 終了
- `CLOSED`（マージなし）検知時: 実装エージェントに `CLOSED_WITHOUT_MERGE` を通知して終了
- 60 分経過しても `OPEN` のまま: orchestrator に `MERGE_PENDING` を通知して終了（手動マージ誘導）

## 変更ファイル

- `.claude/agents/reviewer.md`
- `.claude/agents/infra-reviewer.md`
- `.claude/agents/ui-reviewer.md`

## テスト

- [x] pnpm lint パス
- [x] markdown のみの変更のため typecheck / test への影響なし

Closes #975

🤖 Reviewed by reviewer agent