### PR TITLE
docs(claude.md): .review-passedマーカーは reviewer のみ作成許可するルールを明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ jq が使えない環境では `gh issue list --state open --limit 100 --json nu
 - **TeamDelete は自動で行わない。ユーザーが明示的に指示したときのみ実行する**
 - **active-issues チームが既に存在する場合は TeamDelete / 再作成は不要**（`Agent(team_name="active-issues", ...)` で新メンバーをそのまま追加できる。`TeamCreate` は存在しない場合のみ実行する）
 - **すべてのエージェントを spawn するときは必ず `mode="acceptEdits"` を指定する**（実装系・レビュー系を問わず）
+- **`.claude/.review-passed` マーカーの作成は reviewer 系エージェント（`reviewer` / `infra-reviewer` / `ui-reviewer`）のみに許可される。`coder` / `infra-engineer` / `ui-designer` / オーケストレーターがこのマーカーを作成することは禁止する**（このマーカーはレビュー PASS の証憑として `pre-push-review-guard.sh` がチェックするため、レビュワー以外が作成すると「レビューを通らずに push できる抜け道」になる）
 - **レビュー PASS 後のマーカー作成・push・PR 作成は各レビュワーエージェントが担当する**（オーケストレーターは行わない）
 
 ---
@@ -343,7 +344,7 @@ coder がコンフリクト解消を担当:
 reviewer → 再レビューループへ（フェーズ 2 に戻る）
 ```
 
-> **注意**: `pre-push-review-guard.sh` により、`.claude/.review-passed` マーカーがない状態での push はブロックされる。各レビュワーエージェントがマーカー作成・push・PR 作成を担当する。
+> **注意**: `pre-push-review-guard.sh` により、`.claude/.review-passed` マーカーがない状態での push はブロックされる。このマーカーの作成は reviewer 系エージェント（`reviewer` / `infra-reviewer` / `ui-reviewer`）のみに許可され、coder 系エージェント（`coder` / `infra-engineer` / `ui-designer`）およびオーケストレーターは作成してはならない。各レビュワーエージェントがマーカー作成・push・PR 作成を担当する。
 
 ---
 
@@ -398,7 +399,7 @@ worktree-isolation-guard.sh により以下の制限がある（mainブランチ
 `.claude/**` や `scripts/` であっても必ず worktree 経由で変更すること。
 
 なお `.omc/state/**` は worktree 上でも Edit/Write がブロックされる（is_blocked_file による）。
-`.claude/.review-passed` は Write ツールで作成すること（例: Write ツールで `{worktree}/.claude/.review-passed` を作成、内容は空でよい）。
+`.claude/.review-passed` は **reviewer 系エージェントのみが** Write ツールで作成すること（例: Write ツールで `{worktree}/.claude/.review-passed` を作成、内容は空でよい）。coder 系エージェントおよびオーケストレーターはこのマーカーを作成してはならない。
 
 | 項目 | 詳細 |
 |---|---|


### PR DESCRIPTION
## 概要

`.claude/.review-passed` マーカーは `pre-push-review-guard.sh` がレビュー PASS の証憑としてチェックする重要なファイルだが、これまで「reviewer 以外（coder / infra-engineer / ui-designer / オーケストレーター）が作成してはならない」というルールが明文化されていなかった。

このマーカーをレビュワー以外が作成すると「レビューを通らずに push できる抜け道」になるため、CLAUDE.md に作成許可エージェントを明記する。

## 変更内容

CLAUDE.md の以下 3 箇所にルールを追記:

1. **絶対ルール セクション**: マーカー作成は reviewer 系のみ許可する旨を新規追加
2. **コンフリクト解消フロー直後の注意書き**: 既存の説明にマーカー作成権限を補足
3. **バックグラウンドエージェントの制約セクション**: Write ツールでマーカーを作成できるのは reviewer 系のみと明記

## テスト

- [x] docs-only の変更のため、lint / typecheck / test の対象外
- [x] origin/main とのコンフリクトなし
- [x] 既存ルールとの整合性を確認

Closes #980

🤖 Reviewed by reviewer agent