### PR TITLE
fix(scripts): create-worktree.sh で fetch 後にローカル main を FF merge

### DIFF
--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -37,6 +37,7 @@ fi
 
 echo "📥 origin/main を更新..."
 git fetch origin main
+git -C "${REPO_ROOT}" merge --ff-only origin/main --quiet 2>/dev/null || true
 
 echo "🌳 worktree を作成..."
 git worktree add "${WORKTREE_PATH}" -b "${BRANCH_NAME}" origin/main

--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -37,6 +37,8 @@ fi
 
 echo "📥 origin/main を更新..."
 git fetch origin main
+# main worktree のローカル main を origin/main に FF merge する。
+# 非 FF（未 push コミットがある等）の場合は失敗するが、worktree 作成自体は続行したいため || true で握り潰す。
 git -C "${REPO_ROOT}" merge --ff-only origin/main --quiet 2>/dev/null || true
 
 echo "🌳 worktree を作成..."


### PR DESCRIPTION
## 概要

`scripts/create-worktree.sh` の `git fetch origin main` 直後にローカル main ブランチを origin/main に fast-forward merge する処理を追加した。

これにより main worktree のローカル main が常に最新化され、`git log` / `git diff` / マージ済み worktree の自動掃除判定などが正しく動作するようになる。

## 変更ファイル

- `scripts/create-worktree.sh`（1 行追加）

## 変更内容

```bash
echo "📥 origin/main を更新..."
git fetch origin main
git -C "${REPO_ROOT}" merge --ff-only origin/main --quiet 2>/dev/null || true  # ← 追加
```

- `merge --ff-only` のため既存コミットは破壊しない
- 非 FF（ローカル未 push コミットがある等）の場合は失敗するが `|| true` で握り潰し、worktree 作成フローは阻害しない
- `--quiet` + `2>/dev/null` で出力ノイズを抑制

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス（API 1486 tests / Mobile 963 tests）
- [x] シェルスクリプト構文チェック (bash -n) パス

Closes #985

🤖 Reviewed by reviewer agent