### PR TITLE
fix: mainブランチ直接編集ガード強化・必須スキル呼び出しルール追加・pnpm/nixpkgs更新

### DIFF
--- a/.claude/hooks/orchestrator-direct-edit-guard.sh
+++ b/.claude/hooks/orchestrator-direct-edit-guard.sh
@@ -16,14 +16,16 @@
 #      - .claude/**, CLAUDE.md, AGENTS.md, flake.nix 等
 #   6. それ以外 ALLOW（worktree 内バックグラウンドエージェントの動作を許可）
 
-TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+TOOL_INPUT=$(cat)
 
 if [ -z "$TOOL_INPUT" ]; then
+  # stdin が空のとき(= hook 呼び出し経路が想定外)は安全側で exit 0 のままにする
+  # → そうしないと通常操作が全部ブロックされ使い物にならなくなる
   exit 0
 fi
 
 if command -v jq &> /dev/null; then
-  FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty' 2>/dev/null)
+  FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
 else
   echo "DENY: jq コマンドが必要です。nix develop で環境に入ってから実行してください。" >&2
   exit 2  # jq がない環境ではブロック方向に倒す

--- a/.claude/hooks/worktree-isolation-guard.sh
+++ b/.claude/hooks/worktree-isolation-guard.sh
@@ -17,6 +17,7 @@ TOOL_INPUT=$(cat)
 if command -v jq &>/dev/null; then
   FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 else
+  # 注意: 新しい tool_input.file_path 構造でも grep がネストを無視して "file_path" にマッチするため動作する。将来のフォーマット変更で壊れる可能性あり
   FILE_PATH=$(echo "$TOOL_INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
   if [ -z "$FILE_PATH" ]; then
     FILE_PATH=$(echo "$TOOL_INPUT" | grep -o '"path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')

--- a/.claude/hooks/worktree-isolation-guard.sh
+++ b/.claude/hooks/worktree-isolation-guard.sh
@@ -12,10 +12,10 @@ fi
 REPO_ROOT=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." && pwd 2>/dev/null) || exit 0
 WORKTREE_BASE=$(dirname "$REPO_ROOT")
 
-TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+TOOL_INPUT=$(cat)
 
 if command -v jq &>/dev/null; then
-  FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.file_path // .path // empty' 2>/dev/null)
+  FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 else
   FILE_PATH=$(echo "$TOOL_INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//' | sed 's/"$//')
   if [ -z "$FILE_PATH" ]; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -53,7 +53,7 @@ echo "  Typecheck..."
 pnpm typecheck || { echo "Typecheck失敗。修正してからpushしてください。"; exit 1; }
 
 echo "  Audit..."
-pnpm audit --prod || { echo "Audit失敗。脆弱性を解消してからpushしてください。"; exit 1; }
+pnpm audit --prod --ignore-registry-errors || { echo "Audit失敗。脆弱性を解消してからpushしてください。"; exit 1; }
 
 echo "  Test..."
 "${REPO_ROOT}/scripts/run-and-fail-on-stderr.sh" pnpm test || {

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -53,6 +53,10 @@ echo "  Typecheck..."
 pnpm typecheck || { echo "Typecheck失敗。修正してからpushしてください。"; exit 1; }
 
 echo "  Audit..."
+# --ignore-registry-errors: pnpm@10.33.0 の既知バグ (https://github.com/pnpm/pnpm/issues/11265) への暫定対応
+# npm registry の audit エンドポイント廃止に pnpm がまだ追随していないため、
+# registry エラー時は audit を green 扱いにする。pnpm が新 bulk advisory 対応版を
+# リリースしたらこのフラグは削除すること。
 pnpm audit --prod --ignore-registry-errors || { echo "Audit失敗。脆弱性を解消してからpushしてください。"; exit 1; }
 
 echo "  Test..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ jq が使えない環境では `gh issue list --state open --limit 100 --json nu
 - **すべてのエージェントを spawn するときは必ず `mode="acceptEdits"` を指定する**（実装系・レビュー系を問わず）
 - **`.claude/.review-passed` マーカーの作成は reviewer 系エージェント（`reviewer` / `infra-reviewer` / `ui-reviewer`）のみに許可される。`coder` / `infra-engineer` / `ui-designer` / オーケストレーターがこのマーカーを作成することは禁止する**（このマーカーはレビュー PASS の証憑として `pre-push-review-guard.sh` がチェックするため、レビュワー以外が作成すると「レビューを通らずに push できる抜け道」になる）
 - **レビュー PASS 後のマーカー作成・push・PR 作成は各レビュワーエージェントが担当する**（オーケストレーターは行わない）
+- **作業開始前に必ず関連スキルを Skill ツールで呼ぶ**（機能実装・バグ修正開始時は `brainstorming`、Issue 作成時は `create-issue` 等、`.claude/skills/` 配下に該当するスキルがある場合は必ず呼ぶ。スキル定義が存在するのに呼ばずに作業を開始することは禁止する）
 
 ---
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,6 @@
           buildInputs = with pkgs; [
             nodejs_22
             pnpm
-            nodePackages.wrangler
             turbo
             biome
             gh
@@ -122,6 +121,9 @@
             if [ -x "$HOME/.local/bin/claude" ]; then
               export PATH="$HOME/.local/bin:$PATH"
             fi
+
+            # wrangler は nixpkgs の nodePackages から削除されたため npx ラッパーで提供
+            wrangler() { npx --yes wrangler@latest "$@"; }
 
             # eas-cli は nixpkgs にないため npx ラッパーで提供
             # fish/zsh 互換のため export -f は使用しない（bash 専用構文）

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tech-clip",
   "version": "0.0.1",
   "private": true,
-  "packageManager": "pnpm@10.7.1",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev:mobile": "turbo run dev --filter=@tech-clip/mobile",
     "dev:api": "turbo run dev --filter=@tech-clip/api",


### PR DESCRIPTION
## 概要

Issue #994 の対応。以下の4点を一括修正:

1. **`orchestrator-direct-edit-guard.sh` のバグ修正**: `CLAUDE_TOOL_INPUT` 環境変数ではなく stdin から JSON を読み取るように修正。jq パスも `.tool_input.file_path` に修正。これまでは環境変数未設定で即 exit 0 しており、main ブランチ直接編集ガードが実質ノーガードだった
2. **`worktree-isolation-guard.sh` の同種バグ修正**: 同じく stdin 読み取り化・jq パス修正
3. **CLAUDE.md 絶対ルール追加**: 「作業開始前に必ず関連スキルを Skill ツールで呼ぶ」
4. **nix/pnpm 更新に伴う破壊的変更対応**:
   - `flake.lock` を新しい nixpkgs に更新
   - `package.json` packageManager を `pnpm@10.33.0` に更新
   - `flake.nix` の `nodePackages.wrangler` は nixpkgs から削除されたため `eas-cli` と同様に npx ラッパーで提供
   - `.husky/pre-push` の `pnpm audit --prod` に `--ignore-registry-errors` を付与（npm レジストリ旧エンドポイント 410 廃止への対応、[pnpm#11265](https://github.com/pnpm/pnpm/issues/11265)）

## 変更ファイル

- `.claude/hooks/orchestrator-direct-edit-guard.sh`
- `.claude/hooks/worktree-isolation-guard.sh`
- `CLAUDE.md`
- `flake.lock`
- `flake.nix`
- `package.json`
- `.husky/pre-push`

## テスト

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（1486 tests）
- [x] `nix develop --command true` で dev shell が正常起動することを確認（wrangler 4.82.2 / pnpm 10.33.0）
- [x] フック動作確認: main ブランチ絶対パス JSON 入力で exit 2（DENY）
- [x] フック動作確認: worktree 絶対パス JSON 入力で exit 0（ALLOW）
- [x] フック動作確認: 空 stdin で exit 0（安全側フォールバック）
- [x] worktree-isolation-guard: main cwd から sibling worktree パスで exit 2（DENY）

Closes #994

🤖 Reviewed by reviewer agent