### PR TITLE
chore: PR CI で Android Maestro E2E テストを実行しスクリーンショットを PR コメントに添付

### DIFF
--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -206,7 +206,7 @@ fi
    RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
      echo "No PR E2E run found for this branch. Skipping phase 6.5."
-     # フェーズ 7 へ進む
+     exit 0
    fi
    RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
    RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')

--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -182,13 +182,63 @@ else
 fi
 ```
 
-- **`AI Review: PASS` ラベルが存在する**: **フェーズ 7 へ進む**
+- **`AI Review: PASS` ラベルが存在する**: **フェーズ 6.5 へ進む**
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
   gh pr view {pr_number} --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
   ```
   `SendMessage(to: "issue-{issue_number}-infra-engineer", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）
+
+### フェーズ 6.5: PR E2E (Android) 出力の視覚レビュー
+
+フェーズ 6 で `AI Review: PASS` ラベルを確認した後、さらに PR E2E workflow の出力を取得して視覚レビューを行う。**このフェーズは省略してはならない。**
+
+1. PR E2E workflow の最新 run を特定する:
+
+   ```bash
+   BRANCH=$(gh pr view {pr_number} --json headRefName --jq '.headRefName')
+   RUN_JSON=$(gh run list \
+     --workflow=pr-e2e-android.yml \
+     --branch="$BRANCH" \
+     --limit 1 \
+     --json status,conclusion,databaseId)
+   RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
+   RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
+   RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
+   ```
+
+2. workflow が in_progress ならポーリング待機（30 秒間隔、最大 45 分）。
+
+3. conclusion が `failure` の場合:
+   - 原因特定のため JUnit XML を DL する（下記 step 4 と同じ）
+   - 失敗した flow 名と step を抽出して SendMessage:
+     `CHANGES_REQUESTED: PR E2E (Android) が失敗しました: <失敗詳細>`
+   - フェーズ 0 に戻る
+
+4. conclusion が `success` の場合、artifact を DL:
+
+   ```bash
+   mkdir -p .claude/tmp/screenshots .claude/tmp/junit
+   gh run download "$RUN_ID" -n pr-e2e-screenshots -D .claude/tmp/screenshots/ || true
+   gh run download "$RUN_ID" -n pr-e2e-junit -D .claude/tmp/junit/ || true
+   ```
+
+5. `.claude/tmp/screenshots/**/*.png` を Read ツールで **1 枚ずつ読み込み**、以下を検証:
+   - 画面が意図通り表示されているか
+   - エラーメッセージや赤文字が画面に出ていないか
+   - UI が崩れていない（要素が重なっていない、はみ出していない）か
+   - 日本語文字化けが無いか
+
+6. `.claude/tmp/junit/junit.xml` を Read ツールで読み、pass/fail 件数と失敗ステップを把握する。
+
+7. 視覚レビューで問題を発見した場合:
+   - `SendMessage(to: "issue-{issue_number}-infra-engineer", "CHANGES_REQUESTED: PR E2E 視覚レビューで以下を検出: <具体的な指摘>")`
+   - フェーズ 0 に戻る
+
+8. 問題なしの場合:
+   - `.claude/tmp/` を削除（次回汚染防止）: `rm -rf .claude/tmp/`
+   - フェーズ 7 へ進む
 
 ### フェーズ 7: PR マージ完了待機
 

--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -204,6 +204,10 @@ fi
      --limit 1 \
      --json status,conclusion,databaseId)
    RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
+   if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+     echo "No PR E2E run found for this branch. Skipping phase 6.5."
+     # フェーズ 7 へ進む
+   fi
    RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
    RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
    ```

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -200,7 +200,7 @@ fi
    RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
      echo "No PR E2E run found for this branch. Skipping phase 6.5."
-     # フェーズ 7 へ進む
+     exit 0
    fi
    RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
    RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -198,6 +198,10 @@ fi
      --limit 1 \
      --json status,conclusion,databaseId)
    RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
+   if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+     echo "No PR E2E run found for this branch. Skipping phase 6.5."
+     # フェーズ 7 へ進む
+   fi
    RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
    RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
    ```

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -176,13 +176,63 @@ else
 fi
 ```
 
-- **`AI Review: PASS` ラベルが存在する**: **フェーズ 7 へ進む**
+- **`AI Review: PASS` ラベルが存在する**: **フェーズ 6.5 へ進む**
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**: レビューコメントを取得する:
   ```bash
   gh pr view {pr_number} --json comments --jq '[.comments[] | select(.body | contains("## PRレビュー結果"))] | last | .body'
   ```
   `SendMessage(to: "issue-{issue_number}-coder", "CHANGES_REQUESTED: <レビューコメント内容>")` → フェーズ 0 に戻る（次の impl-ready を待つ）
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリング（適度な間隔で待機）
+
+### フェーズ 6.5: PR E2E (Android) 出力の視覚レビュー
+
+フェーズ 6 で `AI Review: PASS` ラベルを確認した後、さらに PR E2E workflow の出力を取得して視覚レビューを行う。**このフェーズは省略してはならない。**
+
+1. PR E2E workflow の最新 run を特定する:
+
+   ```bash
+   BRANCH=$(gh pr view {pr_number} --json headRefName --jq '.headRefName')
+   RUN_JSON=$(gh run list \
+     --workflow=pr-e2e-android.yml \
+     --branch="$BRANCH" \
+     --limit 1 \
+     --json status,conclusion,databaseId)
+   RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
+   RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
+   RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
+   ```
+
+2. workflow が in_progress ならポーリング待機（30 秒間隔、最大 45 分）。
+
+3. conclusion が `failure` の場合:
+   - 原因特定のため JUnit XML を DL する（下記 step 4 と同じ）
+   - 失敗した flow 名と step を抽出して SendMessage:
+     `CHANGES_REQUESTED: PR E2E (Android) が失敗しました: <失敗詳細>`
+   - フェーズ 0 に戻る
+
+4. conclusion が `success` の場合、artifact を DL:
+
+   ```bash
+   mkdir -p .claude/tmp/screenshots .claude/tmp/junit
+   gh run download "$RUN_ID" -n pr-e2e-screenshots -D .claude/tmp/screenshots/ || true
+   gh run download "$RUN_ID" -n pr-e2e-junit -D .claude/tmp/junit/ || true
+   ```
+
+5. `.claude/tmp/screenshots/**/*.png` を Read ツールで **1 枚ずつ読み込み**、以下を検証:
+   - 画面が意図通り表示されているか
+   - エラーメッセージや赤文字が画面に出ていないか
+   - UI が崩れていない（要素が重なっていない、はみ出していない）か
+   - 日本語文字化けが無いか
+
+6. `.claude/tmp/junit/junit.xml` を Read ツールで読み、pass/fail 件数と失敗ステップを把握する。
+
+7. 視覚レビューで問題を発見した場合:
+   - `SendMessage(to: "issue-{issue_number}-coder", "CHANGES_REQUESTED: PR E2E 視覚レビューで以下を検出: <具体的な指摘>")`
+   - フェーズ 0 に戻る
+
+8. 問題なしの場合:
+   - `.claude/tmp/` を削除（次回汚染防止）: `rm -rf .claude/tmp/`
+   - フェーズ 7 へ進む
 
 ### フェーズ 7: PR マージ完了待機
 

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -209,6 +209,10 @@ fi
      --limit 1 \
      --json status,conclusion,databaseId)
    RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
+   if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+     echo "No PR E2E run found for this branch. Skipping phase 6.5."
+     # フェーズ 7 へ進む
+   fi
    RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
    RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
    ```

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -211,7 +211,7 @@ fi
    RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
    if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
      echo "No PR E2E run found for this branch. Skipping phase 6.5."
-     # フェーズ 7 へ進む
+     exit 0
    fi
    RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
    RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -179,7 +179,7 @@ else
 fi
 ```
 
-- **`AI Review: PASS` ラベルが存在する**: **フェーズ 7 へ進む**
+- **`AI Review: PASS` ラベルが存在する**: **フェーズ 6.5 へ進む**
 - **`AI Review: NEEDS WORK` ラベルが存在する（CHANGES_REQUESTED）**:
   1. レビューコメントを取得する
      ```bash
@@ -194,6 +194,56 @@ fi
      ```
   3. フェーズ 0 に戻り次の impl-ready を待機する。
 - **どちらのラベルも存在しない（PENDING）**: 再ポーリングする（適度な間隔を空けて繰り返す）
+
+### フェーズ 6.5: PR E2E (Android) 出力の視覚レビュー
+
+フェーズ 6 で `AI Review: PASS` ラベルを確認した後、さらに PR E2E workflow の出力を取得して視覚レビューを行う。**このフェーズは省略してはならない。**
+
+1. PR E2E workflow の最新 run を特定する:
+
+   ```bash
+   BRANCH=$(gh pr view {pr_number} --json headRefName --jq '.headRefName')
+   RUN_JSON=$(gh run list \
+     --workflow=pr-e2e-android.yml \
+     --branch="$BRANCH" \
+     --limit 1 \
+     --json status,conclusion,databaseId)
+   RUN_ID=$(echo "$RUN_JSON" | jq -r '.[0].databaseId')
+   RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.[0].status')
+   RUN_CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
+   ```
+
+2. workflow が in_progress ならポーリング待機（30 秒間隔、最大 45 分）。
+
+3. conclusion が `failure` の場合:
+   - 原因特定のため JUnit XML を DL する（下記 step 4 と同じ）
+   - 失敗した flow 名と step を抽出して SendMessage:
+     `CHANGES_REQUESTED: PR E2E (Android) が失敗しました: <失敗詳細>`
+   - フェーズ 0 に戻る
+
+4. conclusion が `success` の場合、artifact を DL:
+
+   ```bash
+   mkdir -p .claude/tmp/screenshots .claude/tmp/junit
+   gh run download "$RUN_ID" -n pr-e2e-screenshots -D .claude/tmp/screenshots/ || true
+   gh run download "$RUN_ID" -n pr-e2e-junit -D .claude/tmp/junit/ || true
+   ```
+
+5. `.claude/tmp/screenshots/**/*.png` を Read ツールで **1 枚ずつ読み込み**、以下を検証:
+   - 画面が意図通り表示されているか
+   - エラーメッセージや赤文字が画面に出ていないか
+   - UI が崩れていない（要素が重なっていない、はみ出していない）か
+   - 日本語文字化けが無いか
+
+6. `.claude/tmp/junit/junit.xml` を Read ツールで読み、pass/fail 件数と失敗ステップを把握する。
+
+7. 視覚レビューで問題を発見した場合:
+   - `SendMessage(to: "issue-{issue_number}-ui-designer", "CHANGES_REQUESTED: PR E2E 視覚レビューで以下を検出: <具体的な指摘>")`
+   - フェーズ 0 に戻る
+
+8. 問題なしの場合:
+   - `.claude/tmp/` を削除（次回汚染防止）: `rm -rf .claude/tmp/`
+   - フェーズ 7 へ進む
 
 ### フェーズ 7: PR マージ完了待機
 

--- a/.github/actions/upload-pr-e2e-comment/action.yml
+++ b/.github/actions/upload-pr-e2e-comment/action.yml
@@ -1,0 +1,144 @@
+name: Upload PR E2E Comment
+description: Upload Maestro screenshots to GitHub Release and post PR comment with inline images
+
+inputs:
+  github-token:
+    description: GitHub token
+    required: true
+  pr-number:
+    description: Pull request number
+    required: true
+  run-id:
+    description: GitHub Actions run ID
+    required: true
+  screenshots-dir:
+    description: Directory containing screenshots
+    required: false
+    default: screenshots
+  junit-path:
+    description: Path to JUnit XML file
+    required: false
+    default: test-results/junit.xml
+
+runs:
+  using: composite
+  steps:
+    - name: Upload screenshots to Release and post PR comment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        RUN_ID: ${{ inputs.run-id }}
+        SCREENSHOTS_DIR: ${{ inputs.screenshots-dir }}
+        JUNIT_PATH: ${{ inputs.junit-path }}
+      run: |
+        set -euo pipefail
+
+        REPO="${GITHUB_REPOSITORY}"
+        TAG="pr-${PR_NUMBER}-e2e"
+
+        # --- Release upsert ---
+        RELEASE_ID=$(gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.id' 2>/dev/null || true)
+        if [ -z "$RELEASE_ID" ]; then
+          RELEASE_ID=$(gh api "repos/${REPO}/releases" \
+            --method POST \
+            --field tag_name="${TAG}" \
+            --field name="PR #${PR_NUMBER} E2E Screenshots" \
+            --field body="Auto-generated screenshots from PR E2E tests." \
+            --field draft=false \
+            --field prerelease=true \
+            --jq '.id')
+        else
+          # Delete existing assets to avoid accumulation on re-run
+          gh api "repos/${REPO}/releases/${RELEASE_ID}/assets" --jq '.[].id' | \
+            xargs -I{} gh api "repos/${REPO}/releases/assets/{}" --method DELETE || true
+        fi
+
+        # --- Upload screenshots ---
+        declare -A URL_MAP
+        if [ -d "$SCREENSHOTS_DIR" ]; then
+          while IFS= read -r -d '' FILE; do
+            LABEL="${FILE#${SCREENSHOTS_DIR}/}"
+            LABEL="${LABEL%.*}"
+            ASSET_NAME="${LABEL//\//__}.png"
+            UPLOAD_URL=$(gh api "repos/${REPO}/releases/${RELEASE_ID}/assets?name=${ASSET_NAME}" \
+              --method POST \
+              --header "Content-Type: image/png" \
+              --input "$FILE" \
+              --jq '.browser_download_url' 2>/dev/null || echo "")
+            if [ -n "$UPLOAD_URL" ]; then
+              URL_MAP["$LABEL"]="$UPLOAD_URL"
+            fi
+          done < <(find "$SCREENSHOTS_DIR" -name "*.png" -print0 | sort -z)
+        fi
+
+        # --- Parse JUnit XML ---
+        PASS_COUNT=0
+        FAIL_COUNT=0
+        FAILED_FLOWS=""
+        if [ -f "$JUNIT_PATH" ]; then
+          PASS_COUNT=$(grep -oP 'tests="\K[0-9]+' "$JUNIT_PATH" | head -1 || echo 0)
+          FAIL_COUNT=$(grep -oP 'failures="\K[0-9]+' "$JUNIT_PATH" | head -1 || echo 0)
+          if [ "$FAIL_COUNT" -gt 0 ]; then
+            FAILED_FLOWS=$(grep -oP 'classname="\K[^"]+' "$JUNIT_PATH" | sort -u | head -5 | tr '\n' ', ' | sed 's/,$//')
+          fi
+        fi
+
+        # --- Maestro exit code ---
+        EXIT_CODE=$(cat test-results/maestro-exit-code.txt 2>/dev/null || echo "1")
+        if [ "$EXIT_CODE" -eq 0 ]; then
+          RESULT_ICON="✅"
+          RESULT_TEXT="PASS"
+        else
+          RESULT_ICON="❌"
+          RESULT_TEXT="FAIL"
+        fi
+
+        # --- Build comment body ---
+        BODY="<!-- pr-e2e-marker -->
+        ## PR E2E (Android) 結果
+
+        **Run ID**: \`${RUN_ID}\` / **結果**: ${RESULT_ICON} ${RESULT_TEXT}"
+
+        if [ -n "$FAILED_FLOWS" ]; then
+          BODY="${BODY}
+
+        ### 失敗フロー
+        ${FAILED_FLOWS}"
+        fi
+
+        # Group screenshots by flow
+        declare -A FLOW_SECTIONS
+        for LABEL in "${!URL_MAP[@]}"; do
+          FLOW=$(echo "$LABEL" | cut -d'/' -f1)
+          STEP=$(echo "$LABEL" | cut -d'/' -f2-)
+          URL="${URL_MAP[$LABEL]}"
+          FLOW_SECTIONS["$FLOW"]+="<img src=\"${URL}\" alt=\"${STEP}\" width=\"300\">
+        "
+        done
+
+        BODY="${BODY}
+
+        ### 全フロー
+        "
+        for FLOW in $(echo "${!FLOW_SECTIONS[@]}" | tr ' ' '\n' | sort); do
+          BODY="${BODY}
+
+        #### ${FLOW}
+        ${FLOW_SECTIONS[$FLOW]}"
+        done
+
+        # --- Upsert PR comment ---
+        EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- pr-e2e-marker -->")))] | first | .id // empty' \
+          2>/dev/null || true)
+
+        if [ -n "$EXISTING_COMMENT_ID" ]; then
+          gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
+            --method PATCH \
+            --field body="$BODY"
+        else
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --method POST \
+            --field body="$BODY"
+        fi

--- a/.github/actions/upload-pr-e2e-comment/action.yml
+++ b/.github/actions/upload-pr-e2e-comment/action.yml
@@ -126,12 +126,15 @@ runs:
           --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- pr-e2e-marker -->")))] | first | .id // empty' \
           2>/dev/null || true)
 
+        JSON_FILE="$(mktemp --suffix=.json)"
+        jq -n --rawfile body "$BODY_FILE" '{"body": $body}' > "$JSON_FILE"
+
         if [ -n "$EXISTING_COMMENT_ID" ]; then
           gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
             --method PATCH \
-            --raw-field "body=@${BODY_FILE}"
+            --input "$JSON_FILE"
         else
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --method POST \
-            --raw-field "body=@${BODY_FILE}"
+            --input "$JSON_FILE"
         fi

--- a/.github/actions/upload-pr-e2e-comment/action.yml
+++ b/.github/actions/upload-pr-e2e-comment/action.yml
@@ -73,11 +73,8 @@ runs:
         fi
 
         # --- Parse JUnit XML ---
-        PASS_COUNT=0
-        FAIL_COUNT=0
         FAILED_FLOWS=""
         if [ -f "$JUNIT_PATH" ]; then
-          PASS_COUNT=$(grep -oP 'tests="\K[0-9]+' "$JUNIT_PATH" | head -1 || echo 0)
           FAIL_COUNT=$(grep -oP 'failures="\K[0-9]+' "$JUNIT_PATH" | head -1 || echo 0)
           if [ "$FAIL_COUNT" -gt 0 ]; then
             FAILED_FLOWS=$(grep -oP 'classname="\K[^"]+' "$JUNIT_PATH" | sort -u | head -5 | tr '\n' ', ' | sed 's/,$//')
@@ -95,38 +92,41 @@ runs:
         fi
 
         # --- Build comment body ---
-        BODY="<!-- pr-e2e-marker -->
-        ## PR E2E (Android) 結果
-
-        **Run ID**: \`${RUN_ID}\` / **結果**: ${RESULT_ICON} ${RESULT_TEXT}"
-
-        if [ -n "$FAILED_FLOWS" ]; then
-          BODY="${BODY}
-
-        ### 失敗フロー
-        ${FAILED_FLOWS}"
-        fi
-
         # Group screenshots by flow
         declare -A FLOW_SECTIONS
         for LABEL in "${!URL_MAP[@]}"; do
           FLOW=$(echo "$LABEL" | cut -d'/' -f1)
           STEP=$(echo "$LABEL" | cut -d'/' -f2-)
           URL="${URL_MAP[$LABEL]}"
-          FLOW_SECTIONS["$FLOW"]+="<img src=\"${URL}\" alt=\"${STEP}\" width=\"300\">
-        "
+          FLOW_SECTIONS["$FLOW"]+="<img src=\"${URL}\" alt=\"${STEP}\" width=\"300\">"$'\n'
         done
 
-        BODY="${BODY}
-
-        ### 全フロー
-        "
+        FLOW_BODY=""
         for FLOW in $(echo "${!FLOW_SECTIONS[@]}" | tr ' ' '\n' | sort); do
-          BODY="${BODY}
+          FLOW_BODY="${FLOW_BODY}
 
-        #### ${FLOW}
-        ${FLOW_SECTIONS[$FLOW]}"
+#### ${FLOW}
+${FLOW_SECTIONS[$FLOW]}"
         done
+
+        FAILED_SECTION=""
+        if [ -n "$FAILED_FLOWS" ]; then
+          FAILED_SECTION="
+
+### 失敗フロー
+${FAILED_FLOWS}"
+        fi
+
+        BODY=$(cat <<EOF
+<!-- pr-e2e-marker -->
+## PR E2E (Android) 結果
+
+**Run ID**: \`${RUN_ID}\` / **結果**: ${RESULT_ICON} ${RESULT_TEXT}${FAILED_SECTION}
+
+### 全フロー
+${FLOW_BODY}
+EOF
+)
 
         # --- Upsert PR comment ---
         EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \

--- a/.github/actions/upload-pr-e2e-comment/action.yml
+++ b/.github/actions/upload-pr-e2e-comment/action.yml
@@ -126,15 +126,12 @@ runs:
           --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- pr-e2e-marker -->")))] | first | .id // empty' \
           2>/dev/null || true)
 
-        JSON_FILE="$(mktemp --suffix=.json)"
-        jq -n --rawfile body "$BODY_FILE" '{"body": $body}' > "$JSON_FILE"
-
         if [ -n "$EXISTING_COMMENT_ID" ]; then
           gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
             --method PATCH \
-            --input "$JSON_FILE"
+            --field "body=@${BODY_FILE}"
         else
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --method POST \
-            --input "$JSON_FILE"
+            --field "body=@${BODY_FILE}"
         fi

--- a/.github/actions/upload-pr-e2e-comment/action.yml
+++ b/.github/actions/upload-pr-e2e-comment/action.yml
@@ -72,27 +72,23 @@ runs:
           done < <(find "$SCREENSHOTS_DIR" -name "*.png" -print0 | sort -z)
         fi
 
-        # --- Parse JUnit XML ---
+        # --- Parse JUnit XML (only failed testcases, via external script) ---
         FAILED_FLOWS=""
         if [ -f "$JUNIT_PATH" ]; then
-          FAIL_COUNT=$(grep -oP 'failures="\K[0-9]+' "$JUNIT_PATH" | head -1 || echo 0)
-          if [ "$FAIL_COUNT" -gt 0 ]; then
-            FAILED_FLOWS=$(grep -oP 'classname="\K[^"]+' "$JUNIT_PATH" | sort -u | head -5 | tr '\n' ', ' | sed 's/,$//')
-          fi
+          FAILED_FLOWS=$(python3 "${{ github.action_path }}/parse-failed-flows.py")
         fi
 
         # --- Maestro exit code ---
         EXIT_CODE=$(cat test-results/maestro-exit-code.txt 2>/dev/null || echo "1")
         if [ "$EXIT_CODE" -eq 0 ]; then
-          RESULT_ICON="✅"
+          RESULT_ICON="SUCCESS"
           RESULT_TEXT="PASS"
         else
-          RESULT_ICON="❌"
+          RESULT_ICON="FAIL"
           RESULT_TEXT="FAIL"
         fi
 
-        # --- Build comment body ---
-        # Group screenshots by flow
+        # --- Group screenshots by flow ---
         declare -A FLOW_SECTIONS
         for LABEL in "${!URL_MAP[@]}"; do
           FLOW=$(echo "$LABEL" | cut -d'/' -f1)
@@ -101,32 +97,29 @@ runs:
           FLOW_SECTIONS["$FLOW"]+="<img src=\"${URL}\" alt=\"${STEP}\" width=\"300\">"$'\n'
         done
 
-        FLOW_BODY=""
-        for FLOW in $(echo "${!FLOW_SECTIONS[@]}" | tr ' ' '\n' | sort); do
-          FLOW_BODY="${FLOW_BODY}
+        # --- Build comment body to temp file (avoids YAML block scalar indentation issues) ---
+        BODY_FILE="$(mktemp)"
+        {
+          echo "<!-- pr-e2e-marker -->"
+          echo "## PR E2E (Android) Result"
+          echo ""
+          echo "**Run ID**: \`${RUN_ID}\` / **Result**: ${RESULT_ICON} ${RESULT_TEXT}"
 
-#### ${FLOW}
-${FLOW_SECTIONS[$FLOW]}"
-        done
+          if [ -n "$FAILED_FLOWS" ]; then
+            echo ""
+            echo "### Failed Flows"
+            echo "${FAILED_FLOWS}"
+          fi
 
-        FAILED_SECTION=""
-        if [ -n "$FAILED_FLOWS" ]; then
-          FAILED_SECTION="
+          echo ""
+          echo "### All Flows"
 
-### 失敗フロー
-${FAILED_FLOWS}"
-        fi
-
-        BODY=$(cat <<EOF
-<!-- pr-e2e-marker -->
-## PR E2E (Android) 結果
-
-**Run ID**: \`${RUN_ID}\` / **結果**: ${RESULT_ICON} ${RESULT_TEXT}${FAILED_SECTION}
-
-### 全フロー
-${FLOW_BODY}
-EOF
-)
+          for FLOW in $(printf '%s\n' "${!FLOW_SECTIONS[@]}" | sort); do
+            echo ""
+            echo "#### ${FLOW}"
+            printf '%s' "${FLOW_SECTIONS[$FLOW]}"
+          done
+        } > "$BODY_FILE"
 
         # --- Upsert PR comment ---
         EXISTING_COMMENT_ID=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
@@ -136,9 +129,9 @@ EOF
         if [ -n "$EXISTING_COMMENT_ID" ]; then
           gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
             --method PATCH \
-            --field body="$BODY"
+            --raw-field "body=@${BODY_FILE}"
         else
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
             --method POST \
-            --field body="$BODY"
+            --raw-field "body=@${BODY_FILE}"
         fi

--- a/.github/actions/upload-pr-e2e-comment/parse-failed-flows.py
+++ b/.github/actions/upload-pr-e2e-comment/parse-failed-flows.py
@@ -1,0 +1,22 @@
+"""Extract failed test flow names from JUnit XML."""
+import xml.etree.ElementTree as ET
+import os
+import sys
+
+junit_path = os.environ.get("JUNIT_PATH", "")
+if not junit_path:
+    sys.exit(0)
+
+try:
+    tree = ET.parse(junit_path)
+except Exception:
+    sys.exit(0)
+
+names = []
+for tc in tree.iter("testcase"):
+    if tc.find("failure") is not None or tc.find("error") is not None:
+        name = tc.get("classname") or tc.get("name") or ""
+        if name and name not in names:
+            names.append(name)
+
+print(", ".join(names[:5]))

--- a/.github/workflows/pr-e2e-android.yml
+++ b/.github/workflows/pr-e2e-android.yml
@@ -54,7 +54,7 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
+          disable-animations: true
           script: echo "AVD snapshot generated"
 
       - name: Android Emulator + Maestro
@@ -67,7 +67,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            set -euo pipefail
+            set -eu
             mkdir -p screenshots test-results
 
             # Build and install development build
@@ -82,6 +82,12 @@ jobs:
               fi
               sleep 5
             done
+
+            if ! adb shell pidof com.techclip.app > /dev/null 2>&1; then
+              echo "ERROR: App failed to start within 5 minutes"
+              echo "1" > test-results/maestro-exit-code.txt
+              exit 1
+            fi
 
             # Run Maestro tests (continue on failure to upload artifacts)
             set +e

--- a/.github/workflows/pr-e2e-android.yml
+++ b/.github/workflows/pr-e2e-android.yml
@@ -27,6 +27,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.2.2
 
+      - name: Generate dummy OTA code signing cert for CI
+        run: |
+          if [ ! -f apps/mobile/certs/certificate.pem ]; then
+            mkdir -p apps/mobile/certs
+            openssl req -x509 -newkey rsa:2048 -nodes \
+              -keyout /tmp/ci-key.pem -out apps/mobile/certs/certificate.pem \
+              -days 1 -subj "/CN=ci-dummy"
+            echo "Generated dummy certificate for CI"
+          fi
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
@@ -86,6 +96,7 @@ jobs:
             if ! adb shell pidof com.techclip.app > /dev/null 2>&1; then
               echo "ERROR: App failed to start within 5 minutes"
               pkill -P $EXPO_PID 2>/dev/null || true
+              kill $EXPO_PID 2>/dev/null || true
               echo "1" > test-results/maestro-exit-code.txt
               exit 1
             fi

--- a/.github/workflows/pr-e2e-android.yml
+++ b/.github/workflows/pr-e2e-android.yml
@@ -85,6 +85,7 @@ jobs:
 
             if ! adb shell pidof com.techclip.app > /dev/null 2>&1; then
               echo "ERROR: App failed to start within 5 minutes"
+              pkill -P $EXPO_PID 2>/dev/null || true
               echo "1" > test-results/maestro-exit-code.txt
               exit 1
             fi

--- a/.github/workflows/pr-e2e-android.yml
+++ b/.github/workflows/pr-e2e-android.yml
@@ -92,6 +92,7 @@ jobs:
             MAESTRO_EXIT=$?
             set -e
 
+            pkill -P $EXPO_PID 2>/dev/null || true
             kill $EXPO_PID 2>/dev/null || true
 
             echo "$MAESTRO_EXIT" > test-results/maestro-exit-code.txt
@@ -130,6 +131,7 @@ jobs:
       - name: Fail if Maestro failed
         if: always()
         run: |
+          set -eo pipefail
           EXIT_CODE=$(cat test-results/maestro-exit-code.txt 2>/dev/null || echo 1)
           if [ "$EXIT_CODE" -ne 0 ]; then
             echo "Maestro tests failed with exit code $EXIT_CODE"

--- a/.github/workflows/pr-e2e-android.yml
+++ b/.github/workflows/pr-e2e-android.yml
@@ -1,0 +1,137 @@
+name: PR E2E (Android)
+
+on:
+  pull_request:
+    paths:
+      - "apps/mobile/**"
+      - "tests/e2e/maestro/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/pr-e2e-android.yml"
+      - ".github/actions/upload-pr-e2e-comment/**"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-e2e-android-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  android-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.2.2
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - uses: ./.github/actions/nix-setup
+
+      - name: AVD cache
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf  # v4.2.2
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api34-x86_64-google_apis-v1
+
+      - name: Generate AVD snapshot (cache miss)
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c  # v2.13.0
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "AVD snapshot generated"
+
+      - name: Android Emulator + Maestro
+        uses: reactivecircus/android-emulator-runner@324029e2f414c084d8b15ba075288885e74aef9c  # v2.13.0
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            set -euo pipefail
+            mkdir -p screenshots test-results
+
+            # Build and install development build
+            nix develop --command bash -c "cd apps/mobile && pnpm expo run:android --variant debug" &
+            EXPO_PID=$!
+
+            # Wait for app to be installed and running
+            for i in $(seq 1 60); do
+              if adb shell pidof com.techclip.app > /dev/null 2>&1; then
+                echo "App is running"
+                break
+              fi
+              sleep 5
+            done
+
+            # Run Maestro tests (continue on failure to upload artifacts)
+            set +e
+            nix develop --command maestro test tests/e2e/maestro/ \
+              --format junit \
+              --output test-results/junit.xml \
+              --debug-output screenshots/debug
+            MAESTRO_EXIT=$?
+            set -e
+
+            kill $EXPO_PID 2>/dev/null || true
+
+            echo "$MAESTRO_EXIT" > test-results/maestro-exit-code.txt
+            exit 0
+
+      - name: Upload screenshots artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: pr-e2e-screenshots
+          path: screenshots/**/*.png
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Upload JUnit artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4.6.2
+        with:
+          name: pr-e2e-junit
+          path: |
+            test-results/junit.xml
+            test-results/maestro-exit-code.txt
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Upload screenshots to Release and comment on PR
+        if: always()
+        uses: ./.github/actions/upload-pr-e2e-comment
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          run-id: ${{ github.run_id }}
+          screenshots-dir: screenshots
+          junit-path: test-results/junit.xml
+
+      - name: Fail if Maestro failed
+        if: always()
+        run: |
+          EXIT_CODE=$(cat test-results/maestro-exit-code.txt 2>/dev/null || echo 1)
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo "Maestro tests failed with exit code $EXIT_CODE"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ apps/mobile/certs/*.pem
 
 # Brainstorming / design specs (not for PRs)
 docs/superpowers/
+
+# reviewer agent CI download temp
+.claude/tmp/

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   roots: ["<rootDir>/../../tests/mobile"],
   testMatch: ["**/*.test.ts", "**/*.test.tsx"],
   transformIgnorePatterns: [
-    "/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|react-native-svg|nativewind|react-native-reanimated|lucide-react-native|zustand|@tanstack|react-native-purchases|@shopify/flash-list))",
+    "/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base|react-native-svg|nativewind|react-native-reanimated|lucide-react-native|zustand|@tanstack|react-native-purchases|@revenuecat|@shopify/flash-list))",
   ],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,129 @@
+# TechClip テスト戦略
+
+## テスト種別
+
+### Unit / Integration テスト（Jest）
+
+- **対象**: API ロジック・モバイルコンポーネント・フック・ユーティリティ
+- **場所**: `tests/api/` / `tests/mobile/`
+- **実行**:
+  ```bash
+  # 全テスト
+  pnpm test
+
+  # API のみ
+  pnpm --filter @tech-clip/api test
+
+  # Mobile のみ
+  pnpm --filter @tech-clip/mobile test
+  ```
+
+### Smoke テスト（Jest render）
+
+- **対象**: `<App />` のレンダリング（module loading エラーの早期検知）
+- **場所**: `tests/mobile/smoke.test.tsx`
+- **目的**: `getDevServer is not a function` のような module loading エラーを unit test 層で検知する
+- **実行**: `pnpm --filter @tech-clip/mobile test` に含まれる
+
+### E2E テスト（Maestro）
+
+- **対象**: Android アプリの実機動作
+- **場所**: `tests/e2e/maestro/`
+- **flow 一覧**:
+  - `01-onboarding.yaml` — オンボーディング画面
+  - `02-auth-login.yaml` — ログイン
+  - `03-auth-register.yaml` — アカウント登録
+  - `04-article-save.yaml` — 記事保存
+  - `05-article-detail.yaml` — 記事詳細
+  - `06-profile-edit.yaml` — プロフィール編集
+  - `07-settings.yaml` — 設定・ログアウト
+  - `08-search.yaml` — 検索
+- **ローカル実行**:
+  ```bash
+  # Android エミュレータを起動してから
+  nix develop --command maestro test tests/e2e/maestro/
+  ```
+
+---
+
+## PR CI ワークフロー
+
+### `pr-e2e-android.yml`
+
+PR で以下のパスが変更されたとき自動実行される:
+
+- `apps/mobile/**`
+- `tests/e2e/maestro/**`
+- `package.json` / `pnpm-lock.yaml`
+- `flake.nix` / `flake.lock`
+- `.github/workflows/pr-e2e-android.yml`
+- `.github/actions/upload-pr-e2e-comment/**`
+
+**実行内容**:
+
+1. Android エミュレータ（API 34 / x86_64 / Google APIs）を起動
+2. `expo run:android` でアプリをビルド・インストール
+3. Maestro で全 flow を実行し JUnit XML を出力
+4. スクリーンショットを artifact にアップロード（retention: 7 日）
+5. GitHub Release にスクリーンショットをアップロード
+6. PR コメントに結果とスクリーンショットを投稿（既存コメントがあれば更新）
+7. Maestro が失敗していた場合、workflow を失敗として終了
+
+**concurrency**: 同一 PR の古い run は自動キャンセルされる。
+
+---
+
+## reviewer agent による視覚レビューフロー（フェーズ 6.5）
+
+`.claude/agents/reviewer.md` / `infra-reviewer.md` / `ui-reviewer.md` のフェーズ 6.5 に定義されている。
+
+GitHub AI Review が PASS になった後:
+
+1. `gh run list --workflow=pr-e2e-android.yml` で最新 run を特定
+2. in_progress なら 30 秒間隔で最大 45 分待機
+3. failure なら JUnit XML を DL して失敗内容を `CHANGES_REQUESTED` で返送
+4. success なら artifact を `.claude/tmp/` に DL
+5. `Read` ツールで PNG を 1 枚ずつ視覚確認（エラー表示・UI 崩れ・文字化けをチェック）
+6. JUnit XML で pass/fail 件数を確認
+7. 問題なしなら `.claude/tmp/` を削除してフェーズ 7 へ進む
+
+---
+
+## CI の動作確認方法
+
+### smoke test の動作確認
+
+`App` コンポーネントの import に意図的なエラーを混入させてテストが FAIL することを確認する:
+
+```bash
+# 一時的にエラーを注入
+echo "throw new Error('intentional error');" >> apps/mobile/app/_layout.tsx
+
+# テスト実行（失敗するはず）
+pnpm --filter @tech-clip/mobile test -- --testPathPattern="smoke"
+
+# 元に戻す
+git checkout apps/mobile/app/_layout.tsx
+```
+
+### E2E workflow の動作確認
+
+PR を作成して `pr-e2e-android.yml` が trigger されることを確認する。初回は AVD キャッシュがないため時間がかかる（30 分程度）。
+
+---
+
+## ローカルでの E2E 実行
+
+```bash
+# 1. Android エミュレータを起動（Android Studio AVD Manager から）
+
+# 2. アプリをインストール
+cd apps/mobile
+pnpm expo run:android --variant debug
+
+# 3. Maestro を実行
+nix develop --command maestro test tests/e2e/maestro/
+
+# 4. 特定の flow のみ実行
+nix develop --command maestro test tests/e2e/maestro/01-onboarding.yaml
+```

--- a/tests/e2e/maestro/01-onboarding.yaml
+++ b/tests/e2e/maestro/01-onboarding.yaml
@@ -12,11 +12,13 @@ tags:
 # アプリ起動
 - launchApp:
     clearState: true
+- takeScreenshot: screenshots/01-onboarding/01-launch
 
 # --- ページ1: 技術記事をワンタップで保存 ---
 - assertVisible: "技術記事をワンタップで保存"
 - assertVisible: "Zenn、Qiita"
 - tapOn: "次へ"
+- takeScreenshot: screenshots/01-onboarding/02-page2
 
 # --- ページ2: AIが要約・翻訳 ---
 - assertVisible: "AIが要約・翻訳"
@@ -33,6 +35,7 @@ tags:
 - assertVisible: "アカウントを作成して"
 - assertVisible: "はじめる"
 - tapOn: "はじめる"
+- takeScreenshot: screenshots/01-onboarding/03-done
 
 # ログイン画面またはホーム画面に遷移することを確認
 - assertVisible: "TechClip"

--- a/tests/e2e/maestro/02-auth-login.yaml
+++ b/tests/e2e/maestro/02-auth-login.yaml
@@ -27,6 +27,7 @@ env:
 # --- ログイン画面 ---
 - assertVisible: "ログイン"
 - assertVisible: "メールアドレス"
+- takeScreenshot: screenshots/02-auth-login/01-login-screen
 
 # メールアドレス入力
 - tapOn:
@@ -55,6 +56,7 @@ env:
 
 # ホーム画面に遷移することを確認
 - assertVisible: "すべて"
+- takeScreenshot: screenshots/02-auth-login/02-home-after-login
 
 # --- バリデーションエラーのテスト ---
 - launchApp:

--- a/tests/e2e/maestro/03-auth-register.yaml
+++ b/tests/e2e/maestro/03-auth-register.yaml
@@ -30,6 +30,7 @@ env:
 
 # --- 新規登録画面 ---
 - assertVisible: "アカウントを作成"
+- takeScreenshot: screenshots/03-auth-register/01-register-screen
 - assertVisible: "名前"
 - assertVisible: "メールアドレス"
 - assertVisible: "パスワード"
@@ -76,3 +77,4 @@ env:
 - assertVisible: "すでにアカウントをお持ちですか？"
 - tapOn: "ログイン"
 - assertVisible: "ログイン"
+- takeScreenshot: screenshots/03-auth-register/02-back-to-login

--- a/tests/e2e/maestro/04-article-save.yaml
+++ b/tests/e2e/maestro/04-article-save.yaml
@@ -27,6 +27,7 @@ env:
 # --- 記事保存画面 ---
 - assertVisible: "記事を保存"
 - assertVisible: "URL"
+- takeScreenshot: screenshots/04-article-save/01-save-screen
 
 # --- バリデーション: 空URL送信 ---
 - tapOn: "取得"
@@ -65,6 +66,7 @@ env:
 
 # 保存成功トースト確認
 - assertVisible: "記事を保存しました"
+- takeScreenshot: screenshots/04-article-save/02-saved
 
 # --- 戻るボタン ---
 - launchApp:

--- a/tests/e2e/maestro/05-article-detail.yaml
+++ b/tests/e2e/maestro/05-article-detail.yaml
@@ -19,6 +19,7 @@ env:
 
 # --- ホーム画面: 記事一覧表示 ---
 - assertVisible: "すべて"
+- takeScreenshot: screenshots/05-article-detail/01-home
 
 # ソースフィルター確認
 - assertVisible: "Zenn"
@@ -41,6 +42,7 @@ env:
 # --- 記事詳細画面 ---
 - assertVisible:
     accessibilityLabel: "戻る"
+- takeScreenshot: screenshots/05-article-detail/02-detail
 
 # お気に入り追加
 - tapOn:

--- a/tests/e2e/maestro/06-profile-edit.yaml
+++ b/tests/e2e/maestro/06-profile-edit.yaml
@@ -23,6 +23,7 @@ env:
 
 # --- プロフィール画面 ---
 - assertVisible: "プロフィール"
+- takeScreenshot: screenshots/06-profile-edit/01-profile-screen
 
 # プロフィール編集画面へ遷移（設定ボタン or 編集ボタン）
 - tapOn:
@@ -84,6 +85,7 @@ env:
 
 # 保存成功トーストまたは前画面への遷移を確認
 - assertVisible: "プロフィールを更新しました"
+- takeScreenshot: screenshots/06-profile-edit/02-saved
 
 # 戻るボタン
 - tapOn:

--- a/tests/e2e/maestro/07-settings.yaml
+++ b/tests/e2e/maestro/07-settings.yaml
@@ -23,6 +23,7 @@ env:
 
 # --- 設定画面 ---
 - assertVisible: "アカウント"
+- takeScreenshot: screenshots/07-settings/01-settings-screen
 - assertVisible: "サブスクリプション"
 - assertVisible: "一般"
 - assertVisible: "アカウント管理"
@@ -86,3 +87,4 @@ env:
 - waitForAnimationToEnd
 # ログイン画面に遷移することを確認
 - assertVisible: "ログイン"
+- takeScreenshot: screenshots/07-settings/02-after-logout

--- a/tests/e2e/maestro/08-search.yaml
+++ b/tests/e2e/maestro/08-search.yaml
@@ -23,6 +23,7 @@ env:
 
 # --- 検索画面 ---
 - assertVisible: "検索"
+- takeScreenshot: screenshots/08-search/01-search-screen
 
 # 検索フィールドをタップ
 - tapOn:
@@ -56,3 +57,4 @@ env:
 - tapOn:
     accessibilityLabel: "戻る"
 - assertVisible: "検索"
+- takeScreenshot: screenshots/08-search/02-results

--- a/tests/mobile/smoke.test.tsx
+++ b/tests/mobile/smoke.test.tsx
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "@jest/globals";
 import { render } from "@testing-library/react-native";
 
+jest.mock("@react-native-community/netinfo", () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn().mockReturnValue(() => {}),
+    fetch: jest.fn().mockResolvedValue({ isConnected: true, isInternetReachable: true }),
+    configure: jest.fn(),
+  },
+  addEventListener: jest.fn().mockReturnValue(() => {}),
+  fetch: jest.fn().mockResolvedValue({ isConnected: true, isInternetReachable: true }),
+  useNetInfo: () => ({ isConnected: true, isInternetReachable: true }),
+}));
+
 jest.mock("expo-secure-store", () => ({
   getItemAsync: jest.fn().mockResolvedValue(null),
   setItemAsync: jest.fn().mockResolvedValue(undefined),

--- a/tests/mobile/smoke.test.tsx
+++ b/tests/mobile/smoke.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "@jest/globals";
+import { render } from "@testing-library/react-native";
+
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../apps/mobile/src/lib/notifications", () => ({
+  registerPushTokenOnly: jest.fn(),
+  requestNotificationPermission: jest.fn().mockResolvedValue("granted"),
+  setupNotificationHandlers: jest.fn().mockReturnValue(() => {}),
+}));
+
+jest.mock("../../apps/mobile/src/lib/backgroundSync", () => ({
+  DEFAULT_BACKGROUND_SYNC_CONFIG: {},
+  registerNativeBackgroundFetch: jest.fn().mockResolvedValue(undefined),
+  startBackgroundSync: jest.fn().mockReturnValue(() => {}),
+}));
+
+jest.mock("../../apps/mobile/src/lib/revenueCat", () => ({
+  configureRevenueCat: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../apps/mobile/src/lib/tracking", () => ({
+  requestTrackingPermission: jest.fn().mockResolvedValue("authorized"),
+}));
+
+jest.mock("../../apps/mobile/src/lib/sentry", () => ({
+  initSentry: jest.fn(),
+}));
+
+import App from "../../apps/mobile/app/_layout";
+
+describe("App smoke test", () => {
+  it("module が読み込めてレンダリングできること", () => {
+    const tree = render(<App />);
+    expect(tree).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 概要

PR ごとに Android エミュレータ上で Maestro E2E テストを自動実行し、スクリーンショットを GitHub Release にアップロードして PR コメントに埋め込む仕組みを追加する。reviewer agent が PR コメントから直接スクリーンショットを視覚レビューできるようになる。

## 変更ファイル

### ワークフロー・アクション
- `.github/workflows/pr-e2e-android.yml` — PR E2E (Android) ワークフロー新規追加
  - `reactivecircus/android-emulator-runner@v2.13.0` で API 34 / x86_64 / Google APIs エミュレータ起動
  - KVM 有効化、AVD キャッシュ、タイムアウト 45 分、concurrency でキャンセル
  - `nix develop --command` で expo run:android と maestro 実行
  - JUnit XML とスクリーンショットを artifact にアップロード
- `.github/actions/upload-pr-e2e-comment/action.yml` — GitHub Release にスクリーンショットをアップロードし PR コメントに埋め込む composite action
  - PR 番号ごとの Release をタグ `pr-{PR}-e2e` で upsert
  - 再実行時は古い assets を削除
  - PR コメントは heredoc で組み立て、`<!-- pr-e2e-marker -->` で upsert
  - JUnit XML をパースして失敗フローを抽出

### テスト
- `tests/mobile/smoke.test.tsx` — `<App />` の Jest レンダリング smoke test（module loading エラーの早期検知）
- `tests/e2e/maestro/*.yaml` — 全フローに `takeScreenshot` ステップ追加
- `apps/mobile/jest.config.js` — `transformIgnorePatterns` に `@revenuecat` を追加

### reviewer agent 定義
- `.claude/agents/reviewer.md` / `infra-reviewer.md` / `ui-reviewer.md` — フェーズ 6.5（PR E2E 視覚レビュー）追加
  - `AI Review: PASS` ラベル確認後に PR E2E workflow をポーリングし、スクリーンショットを `.claude/tmp/` に DL して Read ツールで 1 枚ずつ視覚確認する手順を定義

### ドキュメント
- `docs/TESTING.md` — テスト戦略（unit / smoke / E2E）・PR CI ワークフロー・reviewer 視覚レビューフローを記載

### その他
- `.gitignore` に `.claude/tmp/` 追加（reviewer agent の一時 DL 先）

## テスト

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `pnpm test` パス（964/964、smoke test 含む）
- [ ] PR E2E (Android) workflow の実動確認（本 PR で走る）

## レビュー履歴

infra-reviewer で以下を修正済み:
- **HIGH #1**: `upload-pr-e2e-comment/action.yml` の PR コメント body を heredoc に置き換えてインデントを除去（旧実装では 8 スペース行頭インデントで Markdown が code block 化していた）
- **HIGH #2**: `PASS_COUNT` 誤命名・未使用デッドコードを削除
- **MEDIUM #3**: `Fail if Maestro failed` step に `set -eo pipefail` 追加
- **MEDIUM #4**: `nix develop --command bash -c ...` の子プロセス kill に `pkill -P $EXPO_PID` を追加
- **smoke test**: NetInfo モック不足で初回失敗 → mock 追加で解消

Closes #996

🤖 Reviewed by infra-reviewer agent