### PR TITLE
fix(tests): hooks-bats を stdin + tool_input.file_path ネスト方式に更新 (#1013)

### DIFF
--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -24,11 +24,14 @@ teardown() {
 }
 
 # stdin に tool_input.file_path 形式の JSON を渡してスクリプトを実行するヘルパー
+# 注意: このヘルパーは内部で `run bash -c ...` を呼ぶため、
+#       テストケースから呼ぶときは `run run_script_with_file ...` ではなく
+#       `run_script_with_file ...` と直接呼ぶこと（run の二重呼び出し禁止）。
 run_script_with_file() {
     local file_path="$1"
     local input
     input=$(jq -n --arg p "$file_path" '{"tool_input":{"file_path":$p}}')
-    run bash -c "cd '$REPO_DIR' && echo '$input' | bash '$SCRIPT'"
+    run bash -c "cd '$REPO_DIR' && printf '%s' '$input' | bash '$SCRIPT'"
 }
 
 # --- mainブランチ上では orchestration/config ファイルもブロックされる ---
@@ -262,7 +265,7 @@ run_script_with_file() {
     local run_dir="$REPO_DIR"
 
     # Act
-    run bash -c "cd '$run_dir' && echo '$tool_input' | bash '$SCRIPT'"
+    run bash -c "cd '$run_dir' && printf '%s' '$tool_input' | bash '$SCRIPT'"
 
     # Assert
     [ "$status" -eq 0 ]

--- a/tests/hooks/orchestrator-direct-edit-guard.bats
+++ b/tests/hooks/orchestrator-direct-edit-guard.bats
@@ -23,101 +23,141 @@ teardown() {
     rm -rf "$TMPDIR"
 }
 
-# CLAUDE_TOOL_INPUTを設定してスクリプトを実行するヘルパー
+# stdin に tool_input.file_path 形式の JSON を渡してスクリプトを実行するヘルパー
 run_script_with_file() {
     local file_path="$1"
-    local tool_input
-    tool_input=$(jq -n --arg p "$file_path" '{file_path: $p}')
-    (cd "$REPO_DIR" && CLAUDE_TOOL_INPUT="$tool_input" bash "$SCRIPT")
+    local input
+    input=$(jq -n --arg p "$file_path" '{"tool_input":{"file_path":$p}}')
+    run bash -c "cd '$REPO_DIR' && echo '$input' | bash '$SCRIPT'"
 }
 
-# --- orchestration/config ファイルは許可 ---
+# --- mainブランチ上では orchestration/config ファイルもブロックされる ---
+# (step 4: main ブランチ全 DENY が step 5: orchestration_file 許可より先に評価される)
 
-@test ".claude/hooks/配下のファイルは許可されること" {
+@test "mainブランチ上の.claude/hooks/配下のファイルはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.claude/hooks/some-hook.sh"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"DENY"* ]]
 }
 
-@test ".claude/skills/配下のファイルは許可されること" {
+@test "mainブランチ上の.claude/skills/配下のファイルはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.claude/skills/some-skill.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
-@test ".claude/agents/配下のファイルは許可されること" {
+@test "mainブランチ上の.claude/agents/配下のファイルはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.claude/agents/coder.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
-@test "CLAUDE.mdは許可されること" {
+@test "mainブランチ上のCLAUDE.mdはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/CLAUDE.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
-@test "flake.nixは許可されること" {
+@test "mainブランチ上のflake.nixはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/flake.nix"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
-@test ".gitignoreは許可されること" {
+@test "mainブランチ上の.gitignoreはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.gitignore"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
-@test "settings.jsonは許可されること" {
+@test "mainブランチ上のsettings.jsonはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.claude/settings.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+}
+
+# --- non-mainブランチでは orchestration/config ファイルは許可 ---
+
+@test "非mainブランチの.claude/hooks/配下のファイルは許可されること" {
+    # Arrange
+    git -C "$REPO_DIR" checkout -b feature/test-branch
+    local file_path="$REPO_DIR/.claude/hooks/some-hook.sh"
+
+    # Act
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 0 ]
 }
 
-# --- ソースファイルはブロック ---
+@test "非mainブランチのCLAUDE.mdは許可されること" {
+    # Arrange
+    git -C "$REPO_DIR" checkout -b feature/test-branch
+    local file_path="$REPO_DIR/CLAUDE.md"
+
+    # Act
+    run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
+}
+
+@test "非mainブランチのflake.nixは許可されること" {
+    # Arrange
+    git -C "$REPO_DIR" checkout -b feature/test-branch
+    local file_path="$REPO_DIR/flake.nix"
+
+    # Act
+    run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
+}
+
+# --- ソースファイルはmainブランチではブロック ---
 
 @test "apps/配下の.tsファイルはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/apps/api/src/index.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -129,7 +169,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/mobile/src/components/App.tsx"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -140,7 +180,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/packages/shared/src/index.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -151,7 +191,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/tests/api/routes/articles.test.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -162,7 +202,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/tests/hooks/some.sh"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -173,44 +213,44 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/src/util.js"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
 }
 
-# --- どちらにもマッチしないファイルは許可 ---
+# --- mainブランチ上でもdocs系はブロックされる ---
 
-@test "docs/ROADMAP.mdは許可されること" {
+@test "mainブランチ上のdocs/ROADMAP.mdはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/docs/ROADMAP.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
-@test "README.mdは許可されること" {
+@test "mainブランチ上のREADME.mdはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/README.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
 # --- file_pathが空の場合 ---
 
-@test "CLAUDE_TOOL_INPUTが空の場合はスキップされること" {
+@test "stdinが空の場合はスキップされること" {
     # Arrange
     local run_dir="$REPO_DIR"
 
     # Act
-    run bash -c "cd '$run_dir' && CLAUDE_TOOL_INPUT='' bash '$SCRIPT'"
+    run bash -c "cd '$run_dir' && echo '' | bash '$SCRIPT'"
 
     # Assert
     [ "$status" -eq 0 ]
@@ -218,11 +258,11 @@ run_script_with_file() {
 
 @test "file_pathが空文字の場合はスキップされること" {
     # Arrange
-    local tool_input='{"file_path": ""}'
+    local tool_input='{"tool_input":{"file_path":""}}'
     local run_dir="$REPO_DIR"
 
     # Act
-    run bash -c "cd '$run_dir' && CLAUDE_TOOL_INPUT='$tool_input' bash '$SCRIPT'"
+    run bash -c "cd '$run_dir' && echo '$tool_input' | bash '$SCRIPT'"
 
     # Assert
     [ "$status" -eq 0 ]
@@ -230,15 +270,15 @@ run_script_with_file() {
 
 # --- package.json の許可・ブロック判定 ---
 
-@test "ルートのpackage.jsonは許可されること" {
+@test "mainブランチ上のルートpackage.jsonはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/package.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
 
 @test "./package.jsonは相対パスのためブロックされること" {
@@ -247,7 +287,7 @@ run_script_with_file() {
     local file_path="./package.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -259,7 +299,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/package.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -270,7 +310,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/packages/shared/package.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -283,7 +323,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/src/index.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -292,36 +332,12 @@ run_script_with_file() {
 
 # --- 明示的ブロック対象（is_blocked_file）---
 
-@test ".claude/.review-passedはブロックされること" {
-    # Arrange
-    local file_path="$REPO_DIR/.claude/.review-passed"
-
-    # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 2 ]
-    [[ "${output}" == *"DENY"* ]]
-}
-
 @test ".omc/state/配下のファイルはブロックされること" {
     # Arrange
     local file_path="$REPO_DIR/.omc/state/autopilot-state.json"
 
     # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 2 ]
-    [[ "${output}" == *"DENY"* ]]
-}
-
-@test "大文字パスの.CLAUDE/.review-passedはブロックされること" {
-    # Arrange
-    local file_path="$REPO_DIR/.CLAUDE/.review-passed"
-
-    # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -333,19 +349,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/.OMC/STATE/autopilot-state.json"
 
     # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 2 ]
-    [[ "${output}" == *"DENY"* ]]
-}
-
-@test "パストラバーサル経由の.review-passedはブロックされること" {
-    # Arrange
-    local file_path="$REPO_DIR/.claude/hooks/../.review-passed"
-
-    # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -357,32 +361,45 @@ run_script_with_file() {
     local file_path="$REPO_DIR/.omc/logs/../state/autopilot-state.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
     [[ "${output}" == *"DENY"* ]]
 }
 
-# --- .claude/ 全体と .omc/ 全体の許可 ---
-
-@test ".claude/配下の任意ファイルは許可されること" {
+@test ".omc/stateディレクトリ自体はブロックされること" {
     # Arrange
-    local file_path="$REPO_DIR/.claude/some-config.yaml"
+    local file_path="$REPO_DIR/.omc/state"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 2 ]
 }
+
+@test "大文字パスの.OMC/STATEで正しい理由メッセージが出ること" {
+    # Arrange
+    local file_path="$REPO_DIR/.OMC/STATE/x.json"
+
+    # Act
+    run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 2 ]
+    [[ "${output}" == *"実行フロー状態ファイル"* ]]
+}
+
+
+# --- .omc/ 全体の許可（.omc/state/ 除く）---
 
 @test ".omc/notepad.mdは許可されること" {
     # Arrange
     local file_path="$REPO_DIR/.omc/notepad.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 0 ]
@@ -393,18 +410,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/.omc/project-memory.json"
 
     # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 0 ]
-}
-
-@test "大文字パスの.CLAUDE/hooks/配下のファイルは許可されること" {
-    # Arrange
-    local file_path="$REPO_DIR/.CLAUDE/hooks/new-hook.sh"
-
-    # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 0 ]
@@ -417,7 +423,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/flake.nix"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -428,7 +434,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/CLAUDE.md"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -439,7 +445,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/turbo.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
@@ -450,45 +456,10 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/src/.claude/foo.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
-}
-
-@test ".omc/stateディレクトリ自体はブロックされること" {
-    # Arrange
-    local file_path="$REPO_DIR/.omc/state"
-
-    # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 2 ]
-}
-
-@test "大文字パスの.claude/.REVIEW-PASSEDで正しい理由メッセージが出ること" {
-    # Arrange
-    local file_path="$REPO_DIR/.claude/.REVIEW-PASSED"
-
-    # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 2 ]
-    [[ "${output}" == *"Edit/Write 経由では作成できません"* ]]
-}
-
-@test "大文字パスの.OMC/STATEで正しい理由メッセージが出ること" {
-    # Arrange
-    local file_path="$REPO_DIR/.OMC/STATE/x.json"
-
-    # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 2 ]
-    [[ "${output}" == *"実行フロー状態ファイル"* ]]
 }
 
 # --- ブランチ判定ロジック ---
@@ -499,7 +470,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/src/index.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 0 ]
@@ -511,7 +482,7 @@ run_script_with_file() {
     local file_path="$REPO_DIR/packages/shared/src/index.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 0 ]
@@ -525,34 +496,25 @@ run_script_with_file() {
     local file_path="$REPO_DIR/apps/api/src/index.ts"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
     [[ "${output}" == *"DENY"* ]]
 }
 
-@test "detached HEAD状態でも.claude/.review-passedはブロックされること" {
-    # Arrange
-    local commit_hash
-    commit_hash=$(git -C "$REPO_DIR" rev-parse HEAD)
-    git -C "$REPO_DIR" checkout --detach "$commit_hash"
-    run run_script_with_file "$REPO_DIR/.claude/.review-passed"
-    [ "$status" -eq 2 ]
-    [[ "${output}" == *"Edit/Write 経由では作成できません"* ]]
-}
 
 @test "detached HEAD状態でも.omc/state/配下はブロックされること" {
     # Arrange
     local commit_hash
     commit_hash=$(git -C "$REPO_DIR" rev-parse HEAD)
     git -C "$REPO_DIR" checkout --detach "$commit_hash"
-    run run_script_with_file "$REPO_DIR/.omc/state/autopilot-state.json"
+    run_script_with_file "$REPO_DIR/.omc/state/autopilot-state.json"
     [ "$status" -eq 2 ]
     [[ "${output}" == *"実行フロー状態ファイル"* ]]
 }
 
-@test "detached HEAD状態でもorchestrationファイルは許可されること" {
+@test "detached HEAD状態でもorchestrationファイルはブロックされること" {
     # Arrange
     local commit_hash
     commit_hash=$(git -C "$REPO_DIR" rev-parse HEAD)
@@ -560,23 +522,10 @@ run_script_with_file() {
     local file_path="$REPO_DIR/.claude/hooks/some-hook.sh"
 
     # Act
-    run run_script_with_file "$file_path"
-
-    # Assert
-    [ "$status" -eq 0 ]
-}
-
-@test "worktreeの非mainブランチでも.claude/.review-passedのEdit/Writeはブロックされること" {
-    # Arrange
-    git -C "$REPO_DIR" checkout -b feature/review-branch
-    local file_path="$REPO_DIR/.claude/.review-passed"
-
-    # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
-    [[ "${output}" == *"DENY"* ]]
 }
 
 @test "worktreeの非mainブランチでも.omc/state/配下のEdit/Writeはブロックされること" {
@@ -585,9 +534,23 @@ run_script_with_file() {
     local file_path="$REPO_DIR/.omc/state/autopilot-state.json"
 
     # Act
-    run run_script_with_file "$file_path"
+    run_script_with_file "$file_path"
 
     # Assert
     [ "$status" -eq 2 ]
     [[ "${output}" == *"DENY"* ]]
+}
+
+@test "worktreeの非mainブランチでも.claude/.review-passedの書き込みは許可されること" {
+    # Arrange
+    # 新スクリプトでは .review-passed の明示ブロックを除去。
+    # non-main ブランチでは step 5 の orchestration_file として許可（reviewer が Write ツールで作成可能）
+    git -C "$REPO_DIR" checkout -b feature/review-branch
+    local file_path="$REPO_DIR/.claude/.review-passed"
+
+    # Act
+    run_script_with_file "$file_path"
+
+    # Assert
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## 概要

hook 本体 `.claude/hooks/orchestrator-direct-edit-guard.sh` は既に stdin + `.tool_input.file_path` ネスト JSON 形式を受け取る仕様に変更済み (#994) だが、bats テストは古い `CLAUDE_TOOL_INPUT` env var + フラット `{file_path}` 形式のまま残っており仕様乖離していた。テストを現状の hook 仕様に揃える。

## 変更ファイル

- `tests/hooks/orchestrator-direct-edit-guard.bats`

## 変更内容

1. `run_script_with_file` ヘルパーを `CLAUDE_TOOL_INPUT` env var → `echo JSON | bash SCRIPT` の stdin 方式に変更
2. JSON 構造を `{file_path}` → `{"tool_input":{"file_path":...}}` ネスト形式に変更
3. hook 本体で既に除去されている `.review-passed` 明示ブロックに関する仕様乖離テスト 4 件を削除
4. main ブランチ全 DENY 仕様（step 4 が step 5 より先に評価される）に合わせて期待値を更新
5. 非 main ブランチでの許可ケースを追加

## テスト

- [x] `pnpm lint` パス
- [x] `pnpm typecheck` パス
- [x] `bats tests/hooks/` 全 77 件 PASS（対象 bats は 43 件全 PASS）

Closes #1013

🤖 Reviewed by reviewer agent