### PR TITLE
fix(ci): reviewer 系 agent に PR 作成後 CI 発火確認 fallback を追加

### DIFF
--- a/.claude/agents/infra-reviewer.md
+++ b/.claude/agents/infra-reviewer.md
@@ -248,6 +248,30 @@ EOF
 
 PR は再作成しない。push のみ行う。
 
+
+### フェーズ 5.5: CI 発火確認 fallback
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+BRANCH=$(git -C {worktree} rev-parse --abbrev-ref HEAD)
+PR_NUMBER=<フェーズ 5 で作成 or 既存 PR>
+
+RUNS=0
+for i in $(seq 1 12); do
+  RUNS=$(gh api "repos/${REPO}/actions/runs?branch=${BRANCH}&per_page=1" \
+         --jq '.workflow_runs | length' 2>/dev/null || echo 0)
+  [ "$RUNS" -gt 0 ] && break
+  sleep 5
+done
+
+if [ "$RUNS" = "0" ]; then
+  cd {worktree}
+  git commit --allow-empty -m "chore: trigger CI for PR #${PR_NUMBER}"
+  bash scripts/push-verified.sh
+  SendMessage(to: "orchestrator", "CI_TRIGGER_FALLBACK: issue-{issue_number} PR #${PR_NUMBER} で空コミット push を実施しました")
+fi
+```
+
 ### フェーズ 6: 統合ポーリング
 
 > **絶対に `gh pr view --json statusCheckRollup` の `claude-review: SUCCESS` を APPROVED の根拠にしないこと。**

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -242,6 +242,30 @@ EOF
 
 PR は再作成しない。push のみ行う。
 
+
+### フェーズ 5.5: CI 発火確認 fallback
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+BRANCH=$(git -C {worktree} rev-parse --abbrev-ref HEAD)
+PR_NUMBER=<フェーズ 5 で作成 or 既存 PR>
+
+RUNS=0
+for i in $(seq 1 12); do
+  RUNS=$(gh api "repos/${REPO}/actions/runs?branch=${BRANCH}&per_page=1" \
+         --jq '.workflow_runs | length' 2>/dev/null || echo 0)
+  [ "$RUNS" -gt 0 ] && break
+  sleep 5
+done
+
+if [ "$RUNS" = "0" ]; then
+  cd {worktree}
+  git commit --allow-empty -m "chore: trigger CI for PR #${PR_NUMBER}"
+  bash scripts/push-verified.sh
+  SendMessage(to: "orchestrator", "CI_TRIGGER_FALLBACK: issue-{issue_number} PR #${PR_NUMBER} で空コミット push を実施しました")
+fi
+```
+
 ### フェーズ 6: 統合ポーリング
 
 > **絶対に `gh pr view --json statusCheckRollup` の `claude-review: SUCCESS` を APPROVED の根拠にしないこと。**

--- a/.claude/agents/ui-reviewer.md
+++ b/.claude/agents/ui-reviewer.md
@@ -245,6 +245,30 @@ EOF
 )"
 ```
 
+
+### フェーズ 5.5: CI 発火確認 fallback
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+BRANCH=$(git -C {worktree} rev-parse --abbrev-ref HEAD)
+PR_NUMBER=<フェーズ 5 で作成 or 既存 PR>
+
+RUNS=0
+for i in $(seq 1 12); do
+  RUNS=$(gh api "repos/${REPO}/actions/runs?branch=${BRANCH}&per_page=1" \
+         --jq '.workflow_runs | length' 2>/dev/null || echo 0)
+  [ "$RUNS" -gt 0 ] && break
+  sleep 5
+done
+
+if [ "$RUNS" = "0" ]; then
+  cd {worktree}
+  git commit --allow-empty -m "chore: trigger CI for PR #${PR_NUMBER}"
+  bash scripts/push-verified.sh
+  SendMessage(to: "orchestrator", "CI_TRIGGER_FALLBACK: issue-{issue_number} PR #${PR_NUMBER} で空コミット push を実施しました")
+fi
+```
+
 ### フェーズ 6: 統合ポーリング
 
 > **絶対に `gh pr view --json statusCheckRollup` の `claude-review: SUCCESS` を APPROVED の根拠にしないこと。**


### PR DESCRIPTION
## 概要

PR #1036 / PR #1038 で観測された「PR 作成直後に `pull_request.opened` イベントが GitHub で発火せず、CI が走らない」edge case への fallback を reviewer 系 agent に追加する。

## 変更ファイル

- `.claude/agents/reviewer.md` — フェーズ 5.5 を追加
- `.claude/agents/infra-reviewer.md` — フェーズ 5.5 を追加
- `.claude/agents/ui-reviewer.md` — フェーズ 5.5 を追加

## 追加内容

PR 作成後、`gh api .../actions/runs?branch=...` を最大 60 秒 (5 秒 × 12 回) polling し、0 件のままなら空コミットを push して `pull_request.synchronize` イベントで CI を強制発火する。fallback 実行時は orchestrator に `CI_TRIGGER_FALLBACK` を SendMessage で通知する。

## テスト

- [x] pnpm lint パス
- [x] pnpm typecheck パス
- [x] pnpm test パス (1486 tests)

Closes #1039

🤖 Reviewed by reviewer agent