### PR TITLE
fix(infra): upgrade pnpm to bulk advisory endpoint version (#991)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
         devShells.ci = pkgs.mkShell {
           buildInputs = with pkgs; [
             nodejs_22
-            pnpm
+            pnpm_10
             turbo
             biome
             gh
@@ -91,7 +91,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             nodejs_22
-            pnpm
+            pnpm_10
             turbo
             biome
             gh


### PR DESCRIPTION
Closes #991

## 変更内容

- flake.nix の pnpm パッケージを `pkgs.pnpm_10` に明示化
- nixpkgs-unstable 経由で pnpm 10.33.0 が提供され、npm 旧 audit endpoint (410 Gone) 問題を根本解消
- package.json の `packageManager` フィールドも `pnpm@10.33.0` で確認済み
- `pnpm audit --prod` が正常に動作することを確認（No known vulnerabilities found）