### PR TITLE
fix(api): eliminate code duplication and fix security gaps

### DIFF
--- a/apps/api/src/app/auth-subapp.ts
+++ b/apps/api/src/app/auth-subapp.ts
@@ -96,5 +96,15 @@ export async function handleAuthCatchAll(
     return subApp.fetch(request);
   }
 
+  // NOTE (SSRF/漏洩対策):
+  // Better Auth の OAuth ハンドラが将来 Deep Link リダイレクトを返す場合、
+  // アクセストークンやセッショントークンをクエリパラメータに含めることは避ける。
+  //   - クエリパラメータはブラウザ履歴・プロキシログ・Referer ヘッダに残り、漏洩リスクが高い
+  //   - 代替案:
+  //     (a) 短命な一度限りの exchange code をクエリに載せ、アプリ側で POST で token と交換する
+  //     (b) URL fragment (#access_token=...) を使う（Referer に乗らない）
+  //     (c) 可能であればバックエンド → ネイティブブリッジを介して token を渡す
+  // 現状 Better Auth の標準ハンドラに委譲しているためコード側のリスクは無いが、
+  // Deep Link 向けのカスタムコールバックを実装する際はこのコメントを必ず確認すること。
   return auth.handler(request);
 }

--- a/apps/api/src/lib/token-utils.ts
+++ b/apps/api/src/lib/token-utils.ts
@@ -1,0 +1,42 @@
+/**
+ * トークン生成・ハッシュ化のユーティリティ
+ *
+ * SHA-256 ハッシュとランダムトークン生成を共通化する。
+ * Web Crypto API を使用するため Cloudflare Workers 環境でも動作する。
+ */
+
+/** リフレッシュトークンの文字数 */
+const REFRESH_TOKEN_LENGTH = 48;
+
+/**
+ * トークン文字列を SHA-256 でハッシュ化する
+ *
+ * @param token - ハッシュ化するトークン文字列
+ * @returns SHA-256 の16進数文字列（64文字）
+ */
+export async function hashTokenSha256(token: string): Promise<string> {
+  const encoded = new TextEncoder().encode(token);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * ランダムな16進数文字列を生成する
+ *
+ * @param lengthInChars - 生成する文字数（偶数）
+ * @returns ランダムな16進数文字列
+ */
+export function generateRandomHexToken(lengthInChars: number): string {
+  const bytes = new Uint8Array(lengthInChars / 2);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * ランダムなリフレッシュトークン文字列を生成する
+ *
+ * @returns 48文字の16進数リフレッシュトークン
+ */
+export function generateRefreshToken(): string {
+  return generateRandomHexToken(REFRESH_TOKEN_LENGTH);
+}

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,13 +1,7 @@
 import type { MiddlewareHandler } from "hono";
 
-/** 未認証エラーレスポンスのエラーコード */
-const AUTH_ERROR_CODE = "AUTH_REQUIRED";
-
-/** 未認証エラーレスポンスのメッセージ */
-const AUTH_ERROR_MESSAGE = "ログインが必要です";
-
-/** HTTP 401 Unauthorized ステータスコード */
-const HTTP_UNAUTHORIZED = 401;
+import { AUTH_ERROR_CODE, AUTH_ERROR_MESSAGE } from "../lib/error-codes";
+import { HTTP_UNAUTHORIZED } from "../lib/http-status";
 
 /**
  * Better Auth セッション検証用の型定義

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -18,6 +18,7 @@ import {
   HTTP_UNPROCESSABLE_ENTITY,
 } from "../lib/http-status";
 import { createLogger } from "../lib/logger";
+import { generateRefreshToken, hashTokenSha256 } from "../lib/token-utils";
 
 /**
  * Better Auth インスタンスの型定義
@@ -46,39 +47,11 @@ type AuthRouteOptions = {
   getAuth: () => AuthInstance;
 };
 
-/** リフレッシュトークンの文字数 */
-const REFRESH_TOKEN_LENGTH = 48;
-
 /** セッション期限切れエラーメッセージ */
 const REFRESH_TOKEN_EXPIRED_MESSAGE = "セッションの有効期限が切れました。再度ログインしてください";
 
 /** 認証ルート用ロガー */
 const logger = createLogger();
-
-/**
- * リフレッシュトークンを SHA-256 でハッシュ化する
- *
- * @param token - 平文のリフレッシュトークン
- * @returns 16進文字列のハッシュ値
- */
-async function hashRefreshToken(token: string): Promise<string> {
-  const encoded = new TextEncoder().encode(token);
-  const digest = await crypto.subtle.digest("SHA-256", encoded);
-  return Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, "0")).join(
-    "",
-  );
-}
-
-/**
- * ランダムなリフレッシュトークン文字列を生成する
- *
- * @returns 平文のリフレッシュトークン
- */
-function generateRefreshToken(): string {
-  const bytes = new Uint8Array(REFRESH_TOKEN_LENGTH / 2);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
-}
 
 /**
  * セッションに紐づくリフレッシュトークンを発行して保存する
@@ -92,7 +65,7 @@ async function createRefreshTokenRecord(
   session: { id: string; userId: string; expiresAt: string },
 ): Promise<string> {
   const refreshToken = generateRefreshToken();
-  const tokenHash = await hashRefreshToken(refreshToken);
+  const tokenHash = await hashTokenSha256(refreshToken);
 
   await db.insert(refreshTokens).values({
     id: crypto.randomUUID(),
@@ -400,7 +373,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
     }
 
     try {
-      const refreshTokenHash = await hashRefreshToken(parsed.data.refreshToken);
+      const refreshTokenHash = await hashTokenSha256(parsed.data.refreshToken);
 
       const result = await db.transaction(async (tx) => {
         const [refreshTokenRow] = await tx
@@ -483,7 +456,7 @@ export function createAuthRoute({ db, getAuth }: AuthRouteOptions) {
         }
 
         const nextRefreshToken = generateRefreshToken();
-        const nextRefreshTokenHash = await hashRefreshToken(nextRefreshToken);
+        const nextRefreshTokenHash = await hashTokenSha256(nextRefreshToken);
 
         await tx
           .update(refreshTokens)

--- a/apps/api/src/routes/email-verification.ts
+++ b/apps/api/src/routes/email-verification.ts
@@ -19,6 +19,7 @@ import {
   HTTP_UNPROCESSABLE_ENTITY,
 } from "../lib/http-status";
 import { createLogger } from "../lib/logger";
+import { hashTokenSha256 } from "../lib/token-utils";
 import type { EmailEnv } from "../services/emailService";
 import { sendEmailVerification } from "../services/emailService";
 
@@ -41,23 +42,6 @@ type EmailVerificationRouteOptions = {
   appUrl: string;
   emailEnv: EmailEnv;
 };
-
-/**
- * メール認証用トークンをSHA-256でハッシュ化する
- *
- * Web Crypto API (SubtleCrypto) を使用してハッシュ化する。
- * Cloudflare Workers 環境でも動作する。
- *
- * @param token - ハッシュ化するトークン文字列
- * @returns ハッシュ化された16進数文字列
- */
-async function hashToken(token: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(token);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
 
 /**
  * メール認証ルートを生成する
@@ -104,7 +88,7 @@ export function createEmailVerificationRoute(options: EmailVerificationRouteOpti
     }
 
     const rawToken = crypto.randomUUID();
-    const hashedToken = await hashToken(rawToken);
+    const hashedToken = await hashTokenSha256(rawToken);
     const identifier = `${EMAIL_VERIFICATION_IDENTIFIER_PREFIX}:${userId}`;
     const expiresAt = new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS).toISOString();
 
@@ -189,7 +173,7 @@ export function createEmailVerificationRoute(options: EmailVerificationRouteOpti
     }
 
     const { token } = validation.data;
-    const hashedToken = await hashToken(token);
+    const hashedToken = await hashTokenSha256(token);
 
     const [verification] = await db
       .select()

--- a/apps/api/src/routes/password-reset.ts
+++ b/apps/api/src/routes/password-reset.ts
@@ -13,6 +13,7 @@ import {
   HTTP_UNPROCESSABLE_ENTITY,
 } from "../lib/http-status";
 import { createLogger } from "../lib/logger";
+import { hashTokenSha256 } from "../lib/token-utils";
 import type { EmailEnv } from "../services/emailService";
 import { sendPasswordReset } from "../services/emailService";
 
@@ -70,23 +71,6 @@ type PasswordResetRouteOptions = {
 };
 
 /**
- * パスワードリセット用トークンをハッシュ化する
- *
- * Web Crypto API (SubtleCrypto) を使用してSHA-256でハッシュ化する。
- * Cloudflare Workers 環境でも動作する。
- *
- * @param token - ハッシュ化するトークン文字列
- * @returns ハッシュ化された16進数文字列
- */
-async function hashToken(token: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(token);
-  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-}
-
-/**
  * パスワードリセットフロー用のルートを生成する
  *
  * POST /forgot-password: パスワードリセットメール送信
@@ -135,7 +119,7 @@ export function createPasswordResetRoute(options: PasswordResetRouteOptions) {
     }
 
     const rawToken = crypto.randomUUID();
-    const hashedToken = await hashToken(rawToken);
+    const hashedToken = await hashTokenSha256(rawToken);
     const expiresAt = new Date(Date.now() + RESET_TOKEN_TTL_MS).toISOString();
 
     await db.insert(verifications).values({
@@ -195,7 +179,7 @@ export function createPasswordResetRoute(options: PasswordResetRouteOptions) {
 
     const { token, password } = validation.data;
 
-    const hashedToken = await hashToken(token);
+    const hashedToken = await hashTokenSha256(token);
 
     const [verification] = await db
       .select()
@@ -229,7 +213,10 @@ export function createPasswordResetRoute(options: PasswordResetRouteOptions) {
       );
     }
 
-    const email = verification.identifier.replace(RESET_TOKEN_IDENTIFIER_PREFIX, "");
+    const rawIdentifier = verification.identifier;
+    const email = rawIdentifier.startsWith(RESET_TOKEN_IDENTIFIER_PREFIX)
+      ? rawIdentifier.slice(RESET_TOKEN_IDENTIFIER_PREFIX.length)
+      : rawIdentifier;
 
     const [user] = await db.select().from(users).where(eq(users.email, email));
 

--- a/apps/api/src/services/parsers/generic.ts
+++ b/apps/api/src/services/parsers/generic.ts
@@ -8,6 +8,46 @@ import { calculateReadingTime, TECHCLIP_USER_AGENT } from "./_shared";
 /** fetchタイムアウト（ミリ秒） */
 const FETCH_TIMEOUT_MS = 10000;
 
+/**
+ * SSRF 対策: 内部ネットワーク・metadata サーバへの fetch を防ぐ
+ * ホスト名が私設 IP 帯 or 予約名に該当する URL は拒否する
+ */
+const PRIVATE_HOST_PATTERNS: ReadonlyArray<RegExp> = [
+  /^localhost$/i,
+  /^127\.\d+\.\d+\.\d+$/,
+  /^0\.0\.0\.0$/,
+  /^10\.\d+\.\d+\.\d+$/,
+  /^192\.168\.\d+\.\d+$/,
+  /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
+  /^169\.254\.\d+\.\d+$/,
+  /^metadata\.google\.internal$/i,
+  /^metadata\.azure\.com$/i,
+  /^\[::1\]$/,
+  /^\[::\]$/,
+  /^\[fc00:/i,
+  /^\[fd/i,
+  /^\[fe80:/i,
+];
+
+/**
+ * URL が内部ネットワーク or メタデータサーバを指しているか判定する
+ *
+ * @param urlString - 判定対象の URL 文字列
+ * @returns 内部ネットワークと判定した場合 true。parse 失敗や非 http(s) プロトコルも true
+ */
+function isPrivateHost(urlString: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(urlString);
+  } catch {
+    return true;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    return true;
+  }
+  return PRIVATE_HOST_PATTERNS.some((p) => p.test(u.hostname));
+}
+
 /** ペイウォール検出セレクター */
 const PAYWALL_SELECTORS = [
   "[class*='paywall']",
@@ -66,6 +106,10 @@ function getMetaContent(doc: LinkedomDocument, property: string): string | null 
  * @throws Error - HTMLの取得またはパースに失敗した場合
  */
 export async function parseGeneric(url: string): Promise<ParsedArticle> {
+  if (isPrivateHost(url)) {
+    throw new Error("内部ネットワークへの fetch は許可されていません");
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 

--- a/tests/api/lib/token-utils.test.ts
+++ b/tests/api/lib/token-utils.test.ts
@@ -1,0 +1,62 @@
+import { generateRefreshToken, hashTokenSha256 } from "@api/lib/token-utils";
+import { describe, expect, it } from "vitest";
+
+describe("hashTokenSha256", () => {
+  it("同じ入力に対して同じ16進文字列を返すこと", async () => {
+    // Arrange
+    const token = "test-token-12345";
+
+    // Act
+    const hash1 = await hashTokenSha256(token);
+    const hash2 = await hashTokenSha256(token);
+
+    // Assert
+    expect(hash1).toBe(hash2);
+  });
+
+  it("出力長が64文字（SHA-256 hex）であること", async () => {
+    // Arrange
+    const token = "any-token";
+
+    // Act
+    const hash = await hashTokenSha256(token);
+
+    // Assert
+    expect(hash).toHaveLength(64);
+  });
+
+  it("16進文字のみで構成されること", async () => {
+    // Arrange
+    const token = "some-token";
+
+    // Act
+    const hash = await hashTokenSha256(token);
+
+    // Assert
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("generateRefreshToken", () => {
+  it("48文字の16進文字列を返すこと", () => {
+    // Act
+    const token = generateRefreshToken();
+
+    // Assert
+    expect(token).toHaveLength(48);
+    expect(token).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("複数回呼んでも衝突しないこと（10回生成して全て異なること）", () => {
+    // Arrange
+    const tokens = new Set<string>();
+
+    // Act
+    for (let i = 0; i < 10; i++) {
+      tokens.add(generateRefreshToken());
+    }
+
+    // Assert
+    expect(tokens.size).toBe(10);
+  });
+});

--- a/tests/api/services/parsers/generic.test.ts
+++ b/tests/api/services/parsers/generic.test.ts
@@ -210,6 +210,101 @@ describe("parseGeneric", () => {
     });
   });
 
+  describe("SSRF ガード", () => {
+    it("0.0.0.0 への fetch は SSRF エラーになること", async () => {
+      // Act & Assert
+      await expect(parseGeneric("http://0.0.0.0/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("127.0.0.1 への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://127.0.0.1/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("localhost への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://localhost/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("10.x.x.x への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://10.1.2.3/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("192.168.x.x への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://192.168.1.1/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("172.16.x.x への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://172.16.0.1/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("169.254.x.x (link-local) への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://169.254.169.254/latest/meta-data/")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("metadata.google.internal への fetch は SSRF エラーになること", async () => {
+      await expect(
+        parseGeneric("http://metadata.google.internal/computeMetadata/v1/"),
+      ).rejects.toThrow("内部ネットワークへの fetch は許可されていません");
+    });
+
+    it("metadata.azure.com への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://metadata.azure.com/metadata/instance")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("[::1] (IPv6 loopback) への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://[::1]/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("[fe80::1] (IPv6 link-local) への fetch は SSRF エラーになること", async () => {
+      await expect(parseGeneric("http://[fe80::1]/anything")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("file:// プロトコルは SSRF エラーになること", async () => {
+      await expect(parseGeneric("file:///etc/passwd")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("ftp:// プロトコルは SSRF エラーになること", async () => {
+      await expect(parseGeneric("ftp://example.com/file")).rejects.toThrow(
+        "内部ネットワークへの fetch は許可されていません",
+      );
+    });
+
+    it("公開アドレス（example.com）は SSRF 判定されないこと", async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(SAMPLE_HTML),
+      });
+
+      // Act
+      const result = await parseGeneric("https://example.com/article");
+
+      // Assert
+      expect(result.title).toBe("テスト記事タイトル");
+    });
+  });
+
   describe("Markdown変換", () => {
     it("変換結果がMarkdown形式であること", async () => {
       // Arrange


### PR DESCRIPTION
## 概要

コードレビューで発見した重複実装とセキュリティギャップを修正した。

## 修正項目

### CRITICAL
1. **`generateRefreshToken` / `hashToken` の重複実装を解消**
   - `apps/api/src/lib/token-utils.ts` を新設し、`hashTokenSha256` / `generateRefreshToken` / `generateRandomHexToken` を共通化
   - `routes/auth.ts` / `routes/email-verification.ts` / `routes/password-reset.ts` から共通ユーティリティを import

### MEDIUM
2. **`middleware/auth.ts` のエラー定数を共通化**
   - ローカル定義の `AUTH_ERROR_CODE` / `AUTH_ERROR_MESSAGE` / `HTTP_UNAUTHORIZED` を削除
   - `lib/error-codes.ts` / `lib/http-status.ts` から import して使用

3. **SSRF ガード強化**
   - `services/parsers/generic.ts` に `PRIVATE_HOST_PATTERNS` と `isPrivateHost` を新規追加
   - `0.0.0.0` / localhost / 127.x / 10.x / 172.16-31.x / 192.168.x / 169.254.x / metadata hosts / IPv6 loopback・link-local を拒否
   - 非 http(s) プロトコル（file://, ftp:// 等）も拒否

### LOW
4. **`password-reset.ts` の `replace` を安全な `startsWith + slice` に変更**
   - identifier プレフィックスが本文に出現するエッジケースを回避

5. **OAuth コールバックのトークン URL リスクを `auth-subapp.ts` にコメント化**
   - Deep Link カスタムコールバック実装時の注意事項を明記

## 変更ファイル

- `apps/api/src/lib/token-utils.ts` (新規)
- `apps/api/src/app/auth-subapp.ts`
- `apps/api/src/middleware/auth.ts`
- `apps/api/src/routes/auth.ts`
- `apps/api/src/routes/email-verification.ts`
- `apps/api/src/routes/password-reset.ts`
- `apps/api/src/services/parsers/generic.ts`
- `tests/api/lib/token-utils.test.ts` (新規)
- `tests/api/services/parsers/generic.test.ts` (SSRF テスト追加)

## テスト

- [x] `pnpm biome check` 通過
- [x] `pnpm --filter api typecheck` 通過
- [x] `pnpm --filter api test` 全 1505 件通過
- [x] SSRF テスト: 0.0.0.0 / 127.0.0.1 / localhost / 10.x / 192.168.x / 172.16.x / 169.254.x (link-local) / metadata.google.internal / metadata.azure.com / [::1] / [fe80::1] / file:// / ftp:// を拒否すること
- [x] hashTokenSha256 / generateRefreshToken のユニットテスト

Closes #1061

🤖 Reviewed by reviewer agent