### PR TITLE
fix(api): レート制限の KV TTL を resetAt 由来の動的算出に変更しウィンドウ長にクランプ

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -94,8 +94,8 @@ export function createInMemoryStore(): RateLimitStore {
   };
 }
 
-/** KV エントリのTTL（秒）：最大ウィンドウ長より長く保持する */
-const KV_TTL_SECONDS = 120;
+/** KV エントリの最小TTL（秒）：ウィンドウ長（60秒）に合わせた下限 */
+const KV_MIN_TTL_SECONDS = 60;
 
 /**
  * Cloudflare Workers KV を使ったレート制限ストアを生成する
@@ -113,7 +113,9 @@ export function createKvStore(kv: KVNamespace): RateLimitStore {
       return raw as RateLimitEntry;
     },
     set: async (key: string, value: RateLimitEntry) => {
-      await kv.put(key, JSON.stringify(value), { expirationTtl: KV_TTL_SECONDS });
+      const remainingMs = value.resetAt - Date.now();
+      const ttlSeconds = Math.max(KV_MIN_TTL_SECONDS, Math.ceil(remainingMs / 1000));
+      await kv.put(key, JSON.stringify(value), { expirationTtl: ttlSeconds });
     },
     clear: async () => {
       // KV には一括削除APIがないため、このメソッドはno-op

--- a/tests/api/middleware/rateLimit.test.ts
+++ b/tests/api/middleware/rateLimit.test.ts
@@ -449,7 +449,7 @@ describe("createRateLimitMiddleware", () => {
       expect(mockKv.get).toHaveBeenCalledWith("test-key", "json");
     });
 
-    it("createKvStoreのsetがKV.putを呼ぶこと", async () => {
+    it("createKvStoreのsetがKV.putをresetAt由来の動的TTLで呼ぶこと", async () => {
       // Arrange
       const mockKv = {
         get: vi.fn().mockResolvedValue(null),
@@ -460,12 +460,32 @@ describe("createRateLimitMiddleware", () => {
       } as unknown as KVNamespace;
       const store = createKvStore(mockKv);
 
-      // Act
+      // Act: resetAt = now + 60s → TTL は 60s
       await store.set("test-key", { count: 1, resetAt: Date.now() + 60_000 });
 
-      // Assert
+      // Assert: expirationTtl が windowMs 由来の60秒になること（120秒ではない）
       expect(mockKv.put).toHaveBeenCalledWith("test-key", expect.any(String), {
-        expirationTtl: 120,
+        expirationTtl: 60,
+      });
+    });
+
+    it("createKvStoreのsetがresetAt残り時間が短い場合でもKV_MIN_TTL_SECONDS=60でクランプすること", async () => {
+      // Arrange
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+      } as unknown as KVNamespace;
+      const store = createKvStore(mockKv);
+
+      // Act: resetAt = now + 5s（残り5秒）→ クランプされて60sになること
+      await store.set("test-key", { count: 1, resetAt: Date.now() + 5_000 });
+
+      // Assert: 最小TTLである60秒にクランプされること
+      expect(mockKv.put).toHaveBeenCalledWith("test-key", expect.any(String), {
+        expirationTtl: 60,
       });
     });
 

--- a/tests/api/middleware/rateLimit.test.ts
+++ b/tests/api/middleware/rateLimit.test.ts
@@ -489,6 +489,26 @@ describe("createRateLimitMiddleware", () => {
       });
     });
 
+    it("createKvStoreのsetがresetAt残り時間が60秒超の場合に動的TTLを使うこと", async () => {
+      // Arrange
+      const mockKv = {
+        get: vi.fn().mockResolvedValue(null),
+        put: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+      } as unknown as KVNamespace;
+      const store = createKvStore(mockKv);
+
+      // Act: resetAt = now + 90s → TTL は 90s（クランプされず動的算出値が使われること）
+      await store.set("test-key", { count: 1, resetAt: Date.now() + 90_000 });
+
+      // Assert: expirationTtl が動的算出値の90秒になること（最小値60秒ではない）
+      expect(mockKv.put).toHaveBeenCalledWith("test-key", expect.any(String), {
+        expirationTtl: 90,
+      });
+    });
+
     it("createKvStoreのgetがエントリを正しく返すこと", async () => {
       // Arrange
       const entry = { count: 3, resetAt: 9999999999 };


### PR DESCRIPTION
## 概要

Issue #1087 の対応。

## テスト

- [ ] pnpm lint パス
- [ ] pnpm typecheck パス
- [ ] pnpm test パス

Closes #1087

🤖 Reviewed by reviewer agent