### PR TITLE
fix(api): replace prefix removal from String.replace to startsWith+slice (email-verification, users)

### DIFF
--- a/apps/api/src/routes/email-verification.ts
+++ b/apps/api/src/routes/email-verification.ts
@@ -205,10 +205,11 @@ export function createEmailVerificationRoute(options: EmailVerificationRouteOpti
       );
     }
 
-    const userId = String(verification.identifier).replace(
-      `${EMAIL_VERIFICATION_IDENTIFIER_PREFIX}:`,
-      "",
-    );
+    const rawIdentifier = String(verification.identifier);
+    const identifierPrefix = `${EMAIL_VERIFICATION_IDENTIFIER_PREFIX}:`;
+    const userId = rawIdentifier.startsWith(identifierPrefix)
+      ? rawIdentifier.slice(identifierPrefix.length)
+      : rawIdentifier;
 
     await db.update(users).set({ emailVerified: true }).where(eq(users.id, userId));
 

--- a/apps/api/src/routes/users.ts
+++ b/apps/api/src/routes/users.ts
@@ -399,7 +399,10 @@ export function createUsersRoute(options: UsersRouteOptions) {
     }
 
     if (oldAvatarUrl) {
-      const oldKey = oldAvatarUrl.replace(`${r2PublicUrl}/`, "");
+      const r2UrlPrefix = `${r2PublicUrl}/`;
+      const oldKey = oldAvatarUrl.startsWith(r2UrlPrefix)
+        ? oldAvatarUrl.slice(r2UrlPrefix.length)
+        : oldAvatarUrl;
       await r2Bucket.delete(oldKey).catch((err) => {
         logger.warn("旧アバター画像の削除に失敗しました", { oldKey, error: err });
       });

--- a/tests/api/routes/email-verification.test.ts
+++ b/tests/api/routes/email-verification.test.ts
@@ -375,3 +375,107 @@ describe("POST /api/auth/verify-email", () => {
     });
   });
 });
+
+describe("POST /api/auth/verify-email — identifier prefix extraction", () => {
+  /** eq() に渡された userId を記録するスパイ */
+  const capturedEqArgs: Array<{ column: unknown; value: unknown }> = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedEqArgs.length = 0;
+
+    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+
+    mockUpdate.mockReturnValue({ set: mockUpdateSet });
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockImplementation((arg) => {
+      capturedEqArgs.push(arg);
+      return { returning: mockUpdateReturning };
+    });
+    mockUpdateReturning.mockResolvedValue([{ ...MOCK_USER, emailVerified: true }]);
+
+    mockDelete.mockReturnValue({ where: mockDeleteWhere });
+    mockDeleteWhere.mockResolvedValue([]);
+  });
+
+  it("identifier に prefix が付いている場合、userId が正しく抽出されること", async () => {
+    // Arrange
+    const verificationWithPrefix = {
+      ...MOCK_VERIFICATION,
+      identifier: "email-verification:user_01HXYZ",
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    };
+    mockSelectWhere.mockResolvedValue([verificationWithPrefix]);
+    const app = createApp();
+    const req = new Request("http://localhost/api/auth/verify-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "test-token-abc123" }),
+    });
+
+    // Act
+    const res = await app.fetch(req);
+
+    // Assert
+    expect(res.status).toBe(HTTP_OK);
+    expect(mockUpdateWhere).toHaveBeenCalled();
+    // eq() の第二引数（userId）が prefix 除去後の値であることを確認
+    const eqArg = mockUpdateWhere.mock.calls[0][0];
+    expect(eqArg).toBeDefined();
+    // drizzle-orm の eq() の戻り値は内部オブジェクトのため、
+    // mockUpdateWhere に渡される引数が eq() の返り値であることを確認する。
+    // userId の抽出が正しいかどうかは、mockUpdateSet が emailVerified: true で
+    // 呼ばれていることと組み合わせて確認する（正常レスポンスで代替）。
+    expect(mockUpdateSet).toHaveBeenCalledWith({ emailVerified: true });
+  });
+
+  it("identifier に prefix が含まれない場合、そのまま userId として扱われること", async () => {
+    // Arrange
+    const verificationWithoutPrefix = {
+      ...MOCK_VERIFICATION,
+      identifier: "user_01HXYZ",
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    };
+    mockSelectWhere.mockResolvedValue([verificationWithoutPrefix]);
+    const app = createApp();
+    const req = new Request("http://localhost/api/auth/verify-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "test-token-abc123" }),
+    });
+
+    // Act
+    const res = await app.fetch(req);
+
+    // Assert
+    expect(res.status).toBe(HTTP_OK);
+    expect(mockUpdateWhere).toHaveBeenCalled();
+    expect(mockUpdateSet).toHaveBeenCalledWith({ emailVerified: true });
+  });
+
+  it("identifier の userId 部分に 'email-verification:' を含む文字列でもプレフィックス除去は先頭のみであること", async () => {
+    // Arrange: replaceAll を誤採用した場合に "abc-:def" になるケース（regression guard）
+    const verificationWithNestedPrefix = {
+      ...MOCK_VERIFICATION,
+      identifier: "email-verification:abc-email-verification:def",
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    };
+    mockSelectWhere.mockResolvedValue([verificationWithNestedPrefix]);
+    const app = createApp();
+    const req = new Request("http://localhost/api/auth/verify-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "test-token-abc123" }),
+    });
+
+    // Act
+    const res = await app.fetch(req);
+    const body = (await res.json()) as { success: boolean };
+
+    // Assert: startsWith+slice は先頭 prefix のみ除去するので HTTP 200 で正常完了する。
+    // replaceAll を使うと "abc-:def" が渡り、update まで到達しても誤った userId になる。
+    expect(res.status).toBe(HTTP_OK);
+    expect(body.success).toBe(true);
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/api/routes/email-verification.test.ts
+++ b/tests/api/routes/email-verification.test.ts
@@ -14,6 +14,19 @@ vi.mock("@api/services/emailService", () => ({
   sendEmailVerification: vi.fn(),
 }));
 
+/** drizzle-orm の eq() をスパイ化して第二引数（userId）を検証可能にする */
+const capturedEqValues: unknown[] = [];
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    eq: vi.fn((_col: unknown, val: unknown) => {
+      capturedEqValues.push(val);
+      return { col: _col, val };
+    }),
+  };
+});
+
 import { sendEmailVerification } from "@api/services/emailService";
 
 /** テスト用のモックユーザー */
@@ -377,21 +390,15 @@ describe("POST /api/auth/verify-email", () => {
 });
 
 describe("POST /api/auth/verify-email — identifier prefix extraction", () => {
-  /** eq() に渡された userId を記録するスパイ */
-  const capturedEqArgs: Array<{ column: unknown; value: unknown }> = [];
-
   beforeEach(() => {
     vi.clearAllMocks();
-    capturedEqArgs.length = 0;
+    capturedEqValues.length = 0;
 
     mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
 
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-    mockUpdateWhere.mockImplementation((arg) => {
-      capturedEqArgs.push(arg);
-      return { returning: mockUpdateReturning };
-    });
+    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
     mockUpdateReturning.mockResolvedValue([{ ...MOCK_USER, emailVerified: true }]);
 
     mockDelete.mockReturnValue({ where: mockDeleteWhere });
@@ -419,14 +426,10 @@ describe("POST /api/auth/verify-email — identifier prefix extraction", () => {
     // Assert
     expect(res.status).toBe(HTTP_OK);
     expect(mockUpdateWhere).toHaveBeenCalled();
-    // eq() の第二引数（userId）が prefix 除去後の値であることを確認
-    const eqArg = mockUpdateWhere.mock.calls[0][0];
-    expect(eqArg).toBeDefined();
-    // drizzle-orm の eq() の戻り値は内部オブジェクトのため、
-    // mockUpdateWhere に渡される引数が eq() の返り値であることを確認する。
-    // userId の抽出が正しいかどうかは、mockUpdateSet が emailVerified: true で
-    // 呼ばれていることと組み合わせて確認する（正常レスポンスで代替）。
     expect(mockUpdateSet).toHaveBeenCalledWith({ emailVerified: true });
+    // eq() の第二引数として渡された userId が prefix 除去後の値であること
+    const updateEqValue = capturedEqValues.find((v) => v === "user_01HXYZ");
+    expect(updateEqValue).toBe("user_01HXYZ");
   });
 
   it("identifier に prefix が含まれない場合、そのまま userId として扱われること", async () => {
@@ -451,6 +454,9 @@ describe("POST /api/auth/verify-email — identifier prefix extraction", () => {
     expect(res.status).toBe(HTTP_OK);
     expect(mockUpdateWhere).toHaveBeenCalled();
     expect(mockUpdateSet).toHaveBeenCalledWith({ emailVerified: true });
+    // prefix なしの場合、identifier そのまま userId として eq() に渡されること
+    const updateEqValue = capturedEqValues.find((v) => v === "user_01HXYZ");
+    expect(updateEqValue).toBe("user_01HXYZ");
   });
 
   it("identifier の userId 部分に 'email-verification:' を含む文字列でもプレフィックス除去は先頭のみであること", async () => {
@@ -472,10 +478,13 @@ describe("POST /api/auth/verify-email — identifier prefix extraction", () => {
     const res = await app.fetch(req);
     const body = (await res.json()) as { success: boolean };
 
-    // Assert: startsWith+slice は先頭 prefix のみ除去するので HTTP 200 で正常完了する。
-    // replaceAll を使うと "abc-:def" が渡り、update まで到達しても誤った userId になる。
+    // Assert: startsWith+slice は先頭 prefix のみ除去するので "abc-email-verification:def" が userId になる。
+    // replaceAll を誤採用した場合は "abc-:def" になり、値が異なる。
     expect(res.status).toBe(HTTP_OK);
     expect(body.success).toBe(true);
     expect(mockDelete).toHaveBeenCalledTimes(1);
+    // eq() に渡された userId が先頭 prefix のみ除去した値であること
+    const updateEqValue = capturedEqValues.find((v) => v === "abc-email-verification:def");
+    expect(updateEqValue).toBe("abc-email-verification:def");
   });
 });

--- a/tests/api/routes/users.test.ts
+++ b/tests/api/routes/users.test.ts
@@ -1196,3 +1196,106 @@ describe("POST /api/users/me/avatar", () => {
     });
   });
 });
+
+describe("POST /api/users/me/avatar — 旧アバター R2 削除キー抽出", () => {
+  const mockR2Delete = vi.fn();
+
+  function createAvatarTestAppWithSpyR2() {
+    type Variables = {
+      user: typeof MOCK_USER;
+      session: Record<string, unknown>;
+    };
+    const app = new Hono<{ Variables: Variables }>();
+
+    app.use("*", (c, next) => {
+      c.set("user", MOCK_USER);
+      c.set("session", { id: "session_01" });
+      return next();
+    });
+
+    const spyR2Bucket = { delete: mockR2Delete } as unknown as R2Bucket;
+
+    const usersRoute = createUsersRoute({
+      db: mockDb as unknown as Database,
+      r2Bucket: spyR2Bucket,
+      r2PublicUrl: "https://cdn.example.com",
+      auth: mockAuth as unknown as Auth,
+    });
+    app.route("/api/users", usersRoute);
+
+    return app;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockR2Delete.mockResolvedValue(undefined);
+
+    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+    // デフォルトは oldAvatarUrl を持つユーザー（prefix あり）
+    mockSelectWhere.mockResolvedValue([
+      { ...MOCK_USER, avatarUrl: "https://cdn.example.com/avatars/old_file.jpg" },
+    ]);
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockReturnValue({ returning: mockUpdateReturning });
+    mockUpdateReturning.mockResolvedValue([
+      { ...MOCK_USER, avatarUrl: "https://cdn.example.com/avatars/new_file.jpg" },
+    ]);
+
+    vi.mocked(validateImageFile).mockReturnValue({ isValid: true });
+    vi.mocked(processAvatarImage).mockResolvedValue({
+      isValid: true,
+      image: {
+        buffer: new Uint8Array([0xff, 0xd8, 0xff]),
+        contentType: "image/jpeg",
+        extension: "jpg",
+      },
+    });
+    vi.mocked(uploadAvatarToR2).mockResolvedValue({
+      avatarUrl: "https://cdn.example.com/avatars/new_file.jpg",
+    });
+  });
+
+  it("旧アバターURL が r2PublicUrl の prefix を持つ場合、prefix を除いたキーで R2 から削除されること", async () => {
+    // Arrange: mockSelectWhere は beforeEach で prefix ありユーザーを返す設定済み
+    const app = createAvatarTestAppWithSpyR2();
+    const file = new File([new Uint8Array([0xff, 0xd8, 0xff])], "avatar.jpg", {
+      type: "image/jpeg",
+    });
+
+    // Act
+    await postAvatar(app, file);
+
+    // Assert: "https://cdn.example.com/avatars/old_file.jpg" → "avatars/old_file.jpg"
+    expect(mockR2Delete).toHaveBeenCalledWith("avatars/old_file.jpg");
+  });
+
+  it("旧アバターURL が prefix を持たない場合、そのままのキーで R2 から削除されること", async () => {
+    // Arrange: prefix なしの URL を持つユーザーをモック
+    mockSelectWhere.mockResolvedValue([{ ...MOCK_USER, avatarUrl: "legacy-key.jpg" }]);
+    const app = createAvatarTestAppWithSpyR2();
+    const file = new File([new Uint8Array([0xff, 0xd8, 0xff])], "avatar.jpg", {
+      type: "image/jpeg",
+    });
+
+    // Act
+    await postAvatar(app, file);
+
+    // Assert: フォールバックで元のキーがそのまま使われること
+    expect(mockR2Delete).toHaveBeenCalledWith("legacy-key.jpg");
+  });
+
+  it("旧アバターURL が null の場合、R2 削除が呼ばれないこと", async () => {
+    // Arrange: avatarUrl が null のユーザーをモック
+    mockSelectWhere.mockResolvedValue([{ ...MOCK_USER, avatarUrl: null }]);
+    const app = createAvatarTestAppWithSpyR2();
+    const file = new File([new Uint8Array([0xff, 0xd8, 0xff])], "avatar.jpg", {
+      type: "image/jpeg",
+    });
+
+    // Act
+    await postAvatar(app, file);
+
+    // Assert
+    expect(mockR2Delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1126 の対応。

## テスト

- [ ] pnpm lint パス
- [ ] pnpm typecheck パス
- [ ] pnpm test パス

Closes #1126

🤖 Reviewed by reviewer agent