### PR TITLE
fix(ci): clear stale AI review labels before claude-review step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,15 @@ jobs:
       needs_work: ${{ steps.check-label.outputs.needs_work }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4.2.2
+      - name: Clear stale review labels
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "AI Review: NEEDS WORK" \
+            --remove-label "AI Review: PASS" 2>/dev/null || true
       - id: review
         continue-on-error: true  # ワークフローファイル変更PRではGitHubセキュリティ制限で失敗するため
         uses: anthropics/claude-code-action@38ec876110f9fbf8b950c79f534430740c3ac009  # v1


### PR DESCRIPTION
## Summary
- claude-review ジョブの先頭に `Clear stale review labels` ステップを追加し、checkout 直後で `AI Review: NEEDS WORK` / `AI Review: PASS` ラベルを削除する
- claude-review Action がラベル付け命令に到達する前に exit したケースで、stale な NEEDS WORK ラベルが残り ci-gate をブロックする問題を解消する
- 各 PR push が常にクリーンなラベル状態から始まるようになる

Closes #1155

## Test plan
- [x] actionlint pass
- [x] lint / typecheck / test (create-review-marker.sh で確認済み)
- [x] 既存 ci-gate 設計との整合性確認 (claude-review failure → manual review 扱いの動作を維持)
- [ ] CI で `Clear stale review labels` step が成功することを確認 (本 PR で実地テスト)

🤖 Generated with [Claude Code](https://claude.ai/code)