### PR TITLE
fix(ci): claude-review step 失敗時に fail-closed で ci-gate を止める

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,32 +65,19 @@ jobs:
               gh pr edit ${{ github.event.pull_request.number }} --add-label "AI Review: NEEDS WORK" --remove-label "AI Review: PASS"
 
             重要: gh pr review --approve は絶対に実行しないでください。
-      # claude-review が fail した場合は check-label は always() で実行される。
-      # ラベル "AI Review: NEEDS WORK" が付いていれば NEEDS WORK 扱いとする。
-      # - push イベントでは claude-review ジョブ自体が skipped になるため needs_work は空文字になる。
-      #   空文字 != 'true' は true となり PASS 扱いになる（意図した動作）。
-      # - ワークフローファイル変更 PR では claude-review が GitHub セキュリティ制限で失敗するが、
-      #   その場合は ci-gate が claude-review failure を検知して "manual review required" として扱う。
-      #   （reviewer エージェントが手動モードに遷移する）
-      # NG の場合は claude-review ステップがラベル "AI Review: NEEDS WORK" を付ける。
+      # check-label は steps.review.outcome を最優先で確認する fail-closed 実装。
+      # review step が failure / cancelled / skipped の場合は needs_work=true を確定出力する。
+      # review step success でも PR ラベルが何もない場合は needs_work=true（guard 強化）。
+      # 詳細ロジックは scripts/ci/check-claude-review-needs-work.sh を参照。
       - id: check-label
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          # push イベント時（PR でない）は PASS 扱い
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "needs_work=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # gh pr view 形式で取得する（gh api より安全）
-          LABELS=$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
-          # ラベルなし = レビュー未実施または PASS → PASS 扱い（continue-on-error による失敗時も同様）
-          if echo "$LABELS" | grep -q "AI Review: NEEDS WORK"; then
-            echo "needs_work=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "needs_work=false" >> "$GITHUB_OUTPUT"
-          fi
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: bash scripts/ci/check-claude-review-needs-work.sh
 
   # ── Step 2: 変更ファイル検出（claude-review に依存しない）─────────────────
   # パス分類は .claude/gate-rules.json の ci_path_filters と同期させること。

--- a/scripts/ci/check-claude-review-needs-work.sh
+++ b/scripts/ci/check-claude-review-needs-work.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# scripts/ci/check-claude-review-needs-work.sh
+# claude-review step の outcome と PR ラベルから needs_work を判定する fail-closed 実装。
+#
+# 入力 (env):
+#   EVENT_NAME      GitHub event 名（pull_request 以外なら needs_work=false）
+#   REVIEW_OUTCOME  steps.review.outcome（success / failure / cancelled / skipped）
+#   PR_NUMBER       PR 番号
+#   REPO            owner/repo
+#   GH_TOKEN        gh CLI 用トークン
+#   GITHUB_OUTPUT   GitHub Actions 出力ファイル（任意。なければ stdout のみ）
+#
+# 出力:
+#   needs_work=true|false を $GITHUB_OUTPUT へ append。stdout にも echo。
+set -euo pipefail
+
+emit() {
+  echo "needs_work=$1"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "needs_work=$1" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# push イベント時は既存挙動維持（PR でない）
+if [ "${EVENT_NAME:-}" != "pull_request" ]; then
+  emit false
+  exit 0
+fi
+
+# fail-closed 1: review step が success 以外なら needs_work=true
+if [ "${REVIEW_OUTCOME:-}" != "success" ]; then
+  echo "claude-review step outcome=${REVIEW_OUTCOME:-unset} → fail-closed (needs_work=true)" >&2
+  emit true
+  exit 0
+fi
+
+# review step は success。ラベルで合否判定。
+LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' 2>/dev/null || echo "__GH_FAILED__")
+
+# fail-closed 2: gh pr view 自体が失敗した場合は needs_work=true
+if [ "$LABELS" = "__GH_FAILED__" ]; then
+  echo "gh pr view failed → fail-closed (needs_work=true)" >&2
+  emit true
+  exit 0
+fi
+
+# NEEDS WORK 優先（PASS と同時に付いていても NEEDS WORK 採用）
+if echo "$LABELS" | grep -q "AI Review: NEEDS WORK"; then
+  emit true
+  exit 0
+fi
+
+# PASS ラベルが付いていれば PASS
+if echo "$LABELS" | grep -q "AI Review: PASS"; then
+  emit false
+  exit 0
+fi
+
+# fail-closed 3: review step success だがラベルが何も付いていない（異常ケース）
+echo "review step success but no AI Review label found → fail-closed" >&2
+emit true

--- a/tests/scripts/ci/claude-review-fail-closed.bats
+++ b/tests/scripts/ci/claude-review-fail-closed.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+# Tests for scripts/ci/check-claude-review-needs-work.sh
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)/scripts/ci/check-claude-review-needs-work.sh"
+
+setup() {
+  export GH_CALLS_LOG="$BATS_TEST_TMPDIR/gh-calls.log"
+  : > "$GH_CALLS_LOG"
+
+  STUB_DIR="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_DIR"
+
+  # Write gh stub that reads labels from a file (avoids word-splitting on spaces)
+  cat > "$STUB_DIR/gh" << 'GHSTUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "${GH_CALLS_LOG:-/dev/null}"
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  exit_code="${GH_STUB_EXIT_CODE:-0}"
+  if [ "$exit_code" != "0" ]; then
+    exit "$exit_code"
+  fi
+  # Read labels from file (one per line) to preserve spaces
+  labels_file="${GH_STUB_LABELS_FILE:-}"
+  if [ -n "$labels_file" ] && [ -f "$labels_file" ]; then
+    cat "$labels_file"
+  fi
+  exit 0
+fi
+echo "stub: unknown: gh $*" >&2
+exit 1
+GHSTUB
+  chmod +x "$STUB_DIR/gh"
+  export PATH="$STUB_DIR:$PATH"
+
+  export GH_TOKEN=dummy
+  export PR_NUMBER=42
+  export REPO=owner/repo
+  export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
+  : > "$GITHUB_OUTPUT"
+  export GH_STUB_LABELS_FILE="$BATS_TEST_TMPDIR/labels.txt"
+  : > "$GH_STUB_LABELS_FILE"
+
+  # defaults: pull_request event, review success
+  export EVENT_NAME=pull_request
+  export REVIEW_OUTCOME=success
+  unset GH_STUB_EXIT_CODE
+}
+
+# ── T1: push イベントは needs_work=false ──────────────────────────────────────
+@test "push イベントは needs_work=false (既存挙動)" {
+  # Arrange
+  export EVENT_NAME=push
+  export REVIEW_OUTCOME=skipped
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=false"
+  grep -q "needs_work=false" "$GITHUB_OUTPUT"
+}
+
+# ── T2: PR + review success + PASS ラベル → needs_work=false ─────────────────
+@test "PR + review success + AI Review: PASS ラベル → needs_work=false" {
+  # Arrange
+  echo "AI Review: PASS" > "$GH_STUB_LABELS_FILE"
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=false"
+  grep -q "needs_work=false" "$GITHUB_OUTPUT"
+}
+
+# ── T3: PR + review success + NEEDS WORK ラベル → needs_work=true ────────────
+@test "PR + review success + AI Review: NEEDS WORK ラベル → needs_work=true" {
+  # Arrange
+  echo "AI Review: NEEDS WORK" > "$GH_STUB_LABELS_FILE"
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T4: PR + review failure → needs_work=true (fail-closed) ──────────────────
+@test "PR + review failure → needs_work=true (fail-closed)" {
+  # Arrange
+  export REVIEW_OUTCOME=failure
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T5: PR + review cancelled → needs_work=true (fail-closed) ────────────────
+@test "PR + review cancelled → needs_work=true (fail-closed)" {
+  # Arrange
+  export REVIEW_OUTCOME=cancelled
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T6: PR + review skipped → needs_work=true (fail-closed) ──────────────────
+@test "PR + review skipped → needs_work=true (fail-closed)" {
+  # Arrange
+  export REVIEW_OUTCOME=skipped
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T7: PR + review success + ラベルなし → needs_work=true (guard 強化) ───────
+@test "PR + review success + ラベルなし → needs_work=true (fail-closed, guard 強化)" {
+  # Arrange: labels file is empty (no labels)
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T8: PR + review success + 両方のラベル → needs_work=true (NEEDS WORK 優先) ─
+@test "PR + review success + 両方のラベルが付いている → needs_work=true (NEEDS WORK 優先)" {
+  # Arrange: both labels present
+  printf 'AI Review: PASS\nAI Review: NEEDS WORK\n' > "$GH_STUB_LABELS_FILE"
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T9: PR + review success + gh pr view 失敗 → needs_work=true (fail-closed) ─
+@test "PR + review success + gh pr view が失敗 → needs_work=true (fail-closed)" {
+  # Arrange
+  export GH_STUB_EXIT_CODE=1
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}
+
+# ── T10: GITHUB_OUTPUT 未設定でも stdout に出力する ──────────────────────────
+@test "GITHUB_OUTPUT 未設定でも stdout に出力する" {
+  # Arrange
+  unset GITHUB_OUTPUT
+  echo "AI Review: PASS" > "$GH_STUB_LABELS_FILE"
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=false"
+}
+
+# ── T11: GITHUB_OUTPUT 指定時、ファイルに append される ──────────────────────
+@test "GITHUB_OUTPUT 指定時、ファイルに append される" {
+  # Arrange: pre-existing content in GITHUB_OUTPUT
+  echo "other_var=existing" >> "$GITHUB_OUTPUT"
+  echo "AI Review: PASS" > "$GH_STUB_LABELS_FILE"
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  grep -q "other_var=existing" "$GITHUB_OUTPUT"
+  grep -q "needs_work=false" "$GITHUB_OUTPUT"
+}
+
+# ── T12: REVIEW_OUTCOME が未設定の場合も fail-closed になること ───────────────
+@test "REVIEW_OUTCOME が未設定の場合も fail-closed になること" {
+  # Arrange
+  unset REVIEW_OUTCOME
+
+  # Act
+  run bash "$SCRIPT"
+
+  # Assert
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "needs_work=true"
+  grep -q "needs_work=true" "$GITHUB_OUTPUT"
+}


### PR DESCRIPTION
## 概要

Issue #1153 の対応。

## テスト

- [ ] pnpm lint パス
- [ ] pnpm typecheck パス
- [ ] pnpm test パス

Closes #1153

🤖 Reviewed by reviewer agent